### PR TITLE
Fixed paths in makefile, #includes to match new repo layout

### DIFF
--- a/core/chelpers.c
+++ b/core/chelpers.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include "jl/name.h"
+#include "name.h"
 
 #define print_stack FORTRAN_UNPREFIXED(print_stack, PRINT_STACK)
 #define sizeOfLongInt FORTRAN_UNPREFIXED(sizeoflongint, SIZEOFLONGINT)

--- a/core/makefile.template
+++ b/core/makefile.template
@@ -4,7 +4,7 @@ CASENAME=
 CASEDIR=
 S=
 S2=
-J:=$S/jl
+J=
 OPT_INCDIR:=./
 OBJDIR=obj
 IFMPI= 
@@ -133,10 +133,10 @@ FL2   = $(L2) $(P) $(PPS_F) -I$(CASEDIR) -I$S -I$(S2) -I$(OPT_INCDIR)
 FL3   = $(L3) $(P) $(PPS_F) -I$(CASEDIR) -I$S -I$(OPT_INCDIR)
 FL4   = $(L4) $(P) $(PPS_F) -I$(CASEDIR) -I$S -I$(OPT_INCDIR)
 
-cFL0   = $(L0) $(PPS_C) 
-cFL2   = $(L2) $(PPS_C) 
-cFL3   = $(L3) $(PPS_C) 
-cFL4   = $(L4) $(PPS_C) 
+cFL0   = $(L0) $(PPS_C) -I$J
+cFL2   = $(L2) $(PPS_C) -I$J
+cFL3   = $(L3) $(PPS_C) -I$J
+cFL4   = $(L4) $(PPS_C) -I$J
 
 ################################################################################
 all : nek5000

--- a/core/makenek
+++ b/core/makenek
@@ -3,8 +3,10 @@
 # (c) 2008,2009,2010 UCHICAGO ARGONNE, LLC
 
 # source path 
-SOURCE_ROOT="$HOME/nek5_svn/trunk/nek" 
-SOURCE_ROOT2="$SOURCE_ROOT/cmt" 
+SOURCE_ROOT="$HOME/nek5000" 
+SOURCE_ROOT_CORE="$SOURCE_ROOT/core"
+SOURCE_ROOT_JL="$SOURCE_ROOT/jl"
+SOURCE_ROOT_CMT="$SOURCE_ROOT/core/cmt"
 
 # Fortran compiler
 F77="mpif77"
@@ -82,9 +84,12 @@ mver=1
 if [ -d $2 ] && [ $# -eq 2 ]; then
   SOURCE_ROOT="$2"
   echo "change source code directory to: ", $SOURCE_ROOT
+  SOURCE_ROOT_CORE="$SOURCE_ROOT/core"
+  SOURCE_ROOT_JL="$SOURCE_ROOT/jl"
+  SOURCE_ROOT_CMT="$SOURCE_ROOT/core/cmt"
 fi
 # do some checks and create makefile
-source $SOURCE_ROOT/makenek.inc
+source $SOURCE_ROOT_CORE/makenek.inc
 # compile
 make -j4 -f makefile 2>&1 | tee compiler.out
 exit 0

--- a/core/makenek.inc
+++ b/core/makenek.inc
@@ -53,9 +53,12 @@ fi
 
 CASENAME=$1
 CASEDIR=`pwd`
-APATH_SRC=`cd $SOURCE_ROOT; pwd`
-SOURCE_ROOT=$APATH_SRC
-APATH_SRC=`cd $SOURCE_ROOT2; pwd`
+APATH_SRC=`cd $SOURCE_ROOT_CORE; pwd`
+SOURCE_ROOT_CORE=$APATH_SRC
+APATH_SRC=`cd $SOURCE_ROOT_JL; pwd`
+SOURCE_ROOT_JL=$APATH_SRC
+echo "JL root" $SOURCE_ROOT_JL
+APATH_SRC=`cd $SOURCE_ROOT_CMT; pwd`
 SOURCE_ROOT_CMT=$APATH_SRC
 echo "CMT root" $SOURCE_ROOT_CMT
 
@@ -63,7 +66,7 @@ IFMOAB=false
 IFNEKNEK=false
 
 # do some basic checks
-if [ "$CASEDIR" == "$SOURCE_ROOT" ]; then
+if [ "$CASEDIR" == "$SOURCE_ROOT_CORE" ]; then
    echo "FATAL ERROR: Working directory has to be different from the source!"
    exit 1
 fi
@@ -88,8 +91,8 @@ if [ ! -f SIZE ]; then
    exit 1
 fi
 
-if [ ! -f $SOURCE_ROOT/makefile.template ]; then
-  echo "FATAL ERROR: Cannot find $SOURCE_ROOT/makefile.template!"
+if [ ! -f $SOURCE_ROOT_CORE/makefile.template ]; then
+  echo "FATAL ERROR: Cannot find $SOURCE_ROOT_CORE/makefile.template!"
   exit 1
 fi
 
@@ -354,7 +357,7 @@ fi
 echo $PPLIST | grep 'K10_MXM' >/dev/null 
 if [ $? -eq 0 ]; then
    MXM_USER="mxm_std.o k10_mxm.o blas.o" 
-   USR_LFLAGS="${USR_LFLAGS} ${SOURCE_ROOT}/libk10_mxm.a"
+   USR_LFLAGS="${USR_LFLAGS} ${SOURCE_ROOT_CORE}/libk10_mxm.a"
 fi
 echo $PPLIST | grep 'BLAS_MXM' >/dev/null 
 if [ $? -eq 0 ]; then
@@ -418,8 +421,9 @@ sed -e "s:^F77[ ]*=.*:F77\:=$F77:" \
 -e "s/^IFNEKNEK[ ]*=.*/IFNEKNEK:=$IFNEKNEK/" \
 -e "s:^USR[ ]*=.*:USR\:=$USR:" \
 -e "s:^USR_LFLAGS[ ]*=.*:USR_LFLAGS\:=$USR_LFLAGS:" \
--e "s:^S[ ]*=.*:S\:=${SOURCE_ROOT}:" \
--e "s:^S2[ ]*=.*:S2\:=${SOURCE_ROOT_CMT}:" $SOURCE_ROOT/makefile.template >.makefile
+-e "s:^S[ ]*=.*:S\:=${SOURCE_ROOT_CORE}:" \
+-e "s:^S2[ ]*=.*:S2\:=${SOURCE_ROOT_CMT}:" \
+-e "s:^J[ ]*=.*:J\:=${SOURCE_ROOT_JL}:" $SOURCE_ROOT_CORE/makefile.template >.makefile
 
 echo $G | grep '\-g' 1>/dev/null
 if [ $? -eq 0 ]; then

--- a/tools/genmap/makefile
+++ b/tools/genmap/makefile
@@ -15,4 +15,4 @@ clean:
 	'rm' *.o
 
 genmap.o          : genmap.f		 		;  $(F77) -c $(FLAGS) genmap.f
-byte.o				: ../../nek/byte.c	;  $(CC)  -c $(CFLAGS) ../../nek/byte.c
+byte.o				: ../../core/byte.c	;  $(CC)  -c $(CFLAGS) ../../core/byte.c

--- a/tools/int_tp/makefile
+++ b/tools/int_tp/makefile
@@ -16,6 +16,6 @@ clean:
 
 int_tp.o  	: int_tp.f	        ; $(F77) -c $(FLAGS)  int_tp.f 
 byte.o          : byte.c                ; $(CC)  -c $(CFLAGS) byte.c
-speclib.o  	: ../../nek/speclib.f	; $(F77) -c $(FLAGS)  ../../nek/speclib.f 
+speclib.o  	: ../../core/speclib.f	; $(F77) -c $(FLAGS)  ../../core/speclib.f 
 mxm44f2.o  	: mxm44f2.f	        ; $(F77) -c $(FLAGS)  mxm44f2.f 
 int_tp_gbox.o   : int_tp_gbox.f	        ; $(F77) -c $(FLAGS)  int_tp_gbox.f 

--- a/tools/postnek/makefile
+++ b/tools/postnek/makefile
@@ -77,7 +77,7 @@ userf.o    : userf.f	basics.inc basicsp.inc	; $(F77) -c $(FLAGS)  userf.f
 trap.o     : trap.f	basics.inc basicsp.inc	; $(F77) -c $(FLAGS)  trap.f
 xinterface.o	: xinterface.f 	basics.inc	; $(F77) -c $(FLAGS)  xinterface.f
 reverc.o	: revert.f			; $(F77) -c $(FLAGS)  revert.f
-blas.o	   : ../../nek/3rd_party/blas.f	; $(F77) -c $(FLAGS)  ../../nek/3rd_party/blas.f
+blas.o	   : ../../core/3rd_party/blas.f	; $(F77) -c $(FLAGS)  ../../nek/3rd_party/blas.f
 
 revert.o	: revert.c				; $(CC)  -c $(CFLAGS)  revert.c
 byte.o   : byte.c   					; $(CC)  -c $(CFLAGS)  byte.c


### PR DESCRIPTION
These changes allow you to build nek5000 and its tools with the new repo's directory layout.  
