### PR TITLE
Updated makefile for postnek and removed unused directory

### DIFF
--- a/3rd_party/.gitignore
+++ b/3rd_party/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory?
-*
-# Except this file
-!.gitignore

--- a/tools/postnek/makefile
+++ b/tools/postnek/makefile
@@ -77,7 +77,7 @@ userf.o    : userf.f	basics.inc basicsp.inc	; $(F77) -c $(FLAGS)  userf.f
 trap.o     : trap.f	basics.inc basicsp.inc	; $(F77) -c $(FLAGS)  trap.f
 xinterface.o	: xinterface.f 	basics.inc	; $(F77) -c $(FLAGS)  xinterface.f
 reverc.o	: revert.f			; $(F77) -c $(FLAGS)  revert.f
-blas.o	   : ../../core/3rd_party/blas.f	; $(F77) -c $(FLAGS)  ../../nek/3rd_party/blas.f
+blas.o	   : ../../core/3rd_party/blas.f	; $(F77) -c $(FLAGS)  ../../core/3rd_party/blas.f
 
 revert.o	: revert.c				; $(CC)  -c $(CFLAGS)  revert.c
 byte.o   : byte.c   					; $(CC)  -c $(CFLAGS)  byte.c


### PR DESCRIPTION
This pull request addresses issue #16 

postnek's makefile pointed to the "3rd_party" directory that existed in the SVN repo.  This directory was moved to core/3rd_party during the transition to Git.

Additionally, the top-level "3rd_party" directory was empty and unused.  Both users and developers were understandably confused.  I deleted that directory to avoid further confusion.  
