### PR TITLE
Redirecting move warnings to /dev/null.  Closes #25

### DIFF
--- a/bin/nek
+++ b/bin/nek
@@ -1,8 +1,8 @@
 echo $1        >  SESSION.NAME
 echo `pwd`'/' >>  SESSION.NAME
 rm -f ioinfo
-mv -f $1.log $1.log1
-mv -f $1.sch $1.sch1
+mv -f $1.log $1.log1 2>/dev/null
+mv -f $1.sch $1.sch1 2>/dev/null
 touch $1.rea
 time ./nek5000
 rm -f SESSION.NAME

--- a/bin/nek1000s
+++ b/bin/nek1000s
@@ -3,8 +3,8 @@ echo `pwd`'/' >>  SESSION.NAME
 rm -f ioinfo
 echo -1000 >ioinfo
 rm -f logfile
-mv -f $1.log.1 $1.log1.1
-mv -f $1.sch $1.sch1
+mv -f $1.log.1 $1.log1.1 2>/dev/null
+mv -f $1.sch $1.sch1 2>/dev/null
 touch $1.rea
 time ./nek5000 > $1.log.1 
 ln $1.log.1 logfile

--- a/bin/nek1000steps
+++ b/bin/nek1000steps
@@ -3,8 +3,8 @@ echo `pwd`'/' >>  SESSION.NAME
 touch $1.rea
 rm -f ioinfo logfile
 echo -1000 > ioinfo
-mv -f $1.log.$2 $1.log1.$2
-mv -f $1.sch $1.sch1
+mv -f $1.log.$2 $1.log1.$2 2>/dev/null
+mv -f $1.sch $1.sch1 2>/dev/null
 mpiexec -np $2 ./nek5000 > $1.log.$2
 ln $1.log.$2 logfile
 rm -f SESSION.NAME

--- a/bin/nek10s
+++ b/bin/nek10s
@@ -3,8 +3,8 @@ echo `pwd`'/' >>  SESSION.NAME
 rm -f ioinfo
 echo -10 >ioinfo
 rm -f logfile
-mv -f $1.log.1 $1.log1.1
-mv -f $1.sch $1.sch1
+mv -f $1.log.1 $1.log1.1 2>/dev/null
+mv -f $1.sch $1.sch1 2>/dev/null
 touch $1.rea
 time ./nek5000 > $1.log.1 
 ln $1.log.1 logfile

--- a/bin/nek10steps
+++ b/bin/nek10steps
@@ -3,8 +3,8 @@ echo `pwd`'/' >>  SESSION.NAME
 touch $1.rea
 rm -f ioinfo logfile
 echo -10 > ioinfo
-mv -f $1.log.$2 $1.log1.$2
-mv -f $1.sch $1.sch1
+mv -f $1.log.$2 $1.log1.$2 2>/dev/null
+mv -f $1.sch $1.sch1 2>/dev/null
 mpiexec -np $2 ./nek5000 > $1.log.$2
 ln $1.log.$2 logfile
 rm -f SESSION.NAME

--- a/bin/nekb
+++ b/bin/nekb
@@ -2,8 +2,8 @@ echo $1        >  SESSION.NAME
 echo `pwd`'/' >>  SESSION.NAME
 rm -f ioinfo
 rm -f logfile
-mv -f $1.log $1.log1
-mv -f $1.sch $1.sch1
+mv -f $1.log $1.log1 2>/dev/null
+mv -f $1.sch $1.sch1 2>/dev/null
 touch $1.rea
 nohup time ./nek5000 > $1.log &
 sleep 2

--- a/bin/nekbmpi
+++ b/bin/nekbmpi
@@ -3,8 +3,8 @@ echo `pwd`'/' >>  SESSION.NAME
 touch $1.rea
 rm -f logfile
 rm -f ioinfo
-mv $1.log.$2 $1.log1.$2
-mv $1.sch $1.sch1
+mv $1.log.$2 $1.log1.$2 2>/dev/null
+mv $1.sch $1.sch1       2>/dev/null
 mpiexec -np $2 ./nek5000 > $1.log.$2 &
 sleep 2
 ln $1.log.$2 logfile

--- a/bin/nekd
+++ b/bin/nekd
@@ -1,7 +1,7 @@
 echo $1        >  SESSION.NAME
 echo `pwd`'/' >>  SESSION.NAME
 rm -f ioinfo
-mv -f $1.log $1.log1
-mv -f $1.sch $1.sch1
+mv -f $1.log $1.log1 2>/dev/null
+mv -f $1.sch $1.sch1 2>/dev/null
 touch $1.rea
 gdb ./nek5000

--- a/bin/nekl
+++ b/bin/nekl
@@ -2,13 +2,13 @@ echo $1        >  SESSION.NAME
 echo `pwd`'/' >>  SESSION.NAME
 touch $1.rea
 rm ioinfo
-mv $1.log $1.log1
-mv $1.fld $1.fld1
-mv $1.his $1.his1
-mv $1.sch $1.sch1
-mv $1.out $1.out1
-mv $1.ore $1.ore1
-mv $1.nre $1.nre1
+mv $1.log $1.log1 2>/dev/null
+mv $1.fld $1.fld1 2>/dev/null
+mv $1.his $1.his1 2>/dev/null
+mv $1.sch $1.sch1 2>/dev/null
+mv $1.out $1.out1 2>/dev/null
+mv $1.ore $1.ore1 2>/dev/null
+mv $1.nre $1.nre1 2>/dev/null
 time nek5000 > $1.log
 sleep 1
 rm logfile

--- a/bin/neklmpi
+++ b/bin/neklmpi
@@ -2,8 +2,8 @@ echo $1        >  SESSION.NAME
 echo `pwd`'/' >>  SESSION.NAME
 touch $1.rea
 rm -f ioinfo logfile
-mv -f $1.log.$2 $1.log1.$2
-mv -f $1.sch $1.sch1
+mv -f $1.log.$2 $1.log1.$2 2>/dev/null
+mv -f $1.sch $1.sch1 2>/dev/null
 mpiexec -np $2 ./nek5000 > $1.log.$2
 ln $1.log.$2 logfile
 rm -f SESSION.NAME

--- a/bin/nekmpi
+++ b/bin/nekmpi
@@ -3,7 +3,7 @@ echo `pwd`'/' >>  SESSION.NAME
 touch $1.rea
 rm -f logfile
 rm -f ioinfo
-mv $1.log.$2 $1.log1.$2
-mv $1.sch $1.sch1
+mv $1.log.$2 $1.log1.$2 2>/dev/null
+mv $1.sch $1.sch1       2>/dev/null
 mpiexec -np $2 ./nek5000
 rm -f SESSION.NAME

--- a/bin/neknek
+++ b/bin/neknek
@@ -1,4 +1,4 @@
-mv SESSION.NAME  SESSION.NAME.1
+mv SESSION.NAME  SESSION.NAME.1 2>/dev/null
 echo   2      >>   SESSION.NAME                        
 echo  $1      >>   SESSION.NAME                     
 echo `pwd`'/' >>   SESSION.NAME                         
@@ -8,12 +8,12 @@ echo `pwd`'/' >>   SESSION.NAME
 echo  $4      >>   SESSION.NAME                       
 touch $1.rea
 rm ioinfo
-mv $1.log $1.log1
-mv $1.his $1.his1
-mv $1.sch $1.sch1
-mv $2.log $2.log1
-mv $2.his $2.his1
-mv $2.sch $2.sch1
+mv $1.log $1.log1 2>/dev/null
+mv $1.his $1.his1 2>/dev/null
+mv $1.sch $1.sch1 2>/dev/null
+mv $2.log $2.log1 2>/dev/null
+mv $2.his $2.his1 2>/dev/null
+mv $2.sch $2.sch1 2>/dev/null
 NP1=$3
 NP2=$4
 NP=$(($NP1+$NP2))

--- a/bin/neknekb
+++ b/bin/neknekb
@@ -1,19 +1,19 @@
-mv SESSION.NAME  SESSION.NAME.1
-echo   2      >>   SESSION.NAME                        
-echo  $1      >>   SESSION.NAME                     
-echo `pwd`'/' >>   SESSION.NAME                         
-echo  $3      >>   SESSION.NAME                      
-echo  $2      >>   SESSION.NAME                      
-echo `pwd`'/' >>   SESSION.NAME                        
-echo  $4      >>   SESSION.NAME                       
+mv SESSION.NAME  SESSION.NAME.1 2>/dev/null
+echo   2      >>   SESSION.NAME 2>/dev/null                        
+echo  $1      >>   SESSION.NAME 2>/dev/null
+echo `pwd`'/' >>   SESSION.NAME 2>/dev/null 
+echo  $3      >>   SESSION.NAME 2>/dev/null 
+echo  $2      >>   SESSION.NAME 2>/dev/null 
+echo `pwd`'/' >>   SESSION.NAME 2>/dev/null 
+echo  $4      >>   SESSION.NAME 2>/dev/null 
 touch $1.rea
 rm ioinfo
-mv $1.log $1.log1
-mv $1.his $1.his1
-mv $1.sch $1.sch1
-mv $2.log $2.log1
-mv $2.his $2.his1
-mv $2.sch $2.sch1
+mv $1.log $1.log1 2>/dev/null
+mv $1.his $1.his1 2>/dev/null
+mv $1.sch $1.sch1 2>/dev/null
+mv $2.log $2.log1 2>/dev/null
+mv $2.his $2.his1 2>/dev/null
+mv $2.sch $2.sch1 2>/dev/null
 NP1=$3
 NP2=$4
 NP=$(($NP1+$NP2))

--- a/bin/nekpbs
+++ b/bin/nekpbs
@@ -8,9 +8,9 @@ echo  "echo \`pwd\`'/' >> SESSION.NAME"                         >> $1.batch
 echo  rm -f  $1.his1                                            >> $1.batch
 echo  rm -f  $1.sch1                                            >> $1.batch
 echo  rm -f  $1.log1                                            >> $1.batch
-echo  mv $1.log $1.log1                                         >> $1.batch
-echo  mv $1.his $1.his1                                         >> $1.batch
-echo  mv $1.sch $1.sch1                                         >> $1.batch
+echo  mv $1.log $1.log1 2>/dev/null                             >> $1.batch
+echo  mv $1.his $1.his1 2>/dev/null                             >> $1.batch
+echo  mv $1.sch $1.sch1 2>/dev/null                             >> $1.batch
 echo  rm -f logfile                                             >> $1.batch
 echo  rm -f ioinfo                                              >> $1.batch
 echo  sleep 5                                                   >> $1.batch

--- a/bin/nekqsub
+++ b/bin/nekqsub
@@ -2,9 +2,9 @@ echo $1        >  SESSION.NAME
 echo `pwd`'/' >>  SESSION.NAME
 touch $1.rea
 rm -f ioinfo
-mv -f $1.log.$2 $1.log1.$2
-mv -f $1.his $1.his1
-mv -f $1.sch $1.sch1
+mv -f $1.log.$2 $1.log1.$2 2>/dev/null
+mv -f $1.his $1.his1 2>/dev/null
+mv -f $1.sch $1.sch1 2>/dev/null
 rm -f $1.output
 rm -f *.output
 rm -f *.error


### PR DESCRIPTION
I didn't do the arguably more proper:

```
if [ -e <file> ]; then
  mv <file> <file1>
fi
```

because it wouldn't work in all shells, e.g. csh.
