### PR TITLE
Updated Travis badge after renaming Nek5000 repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Nek5000 
-![https://travis-ci.org/Nek5000/nek5000](https://travis-ci.org/Nek5000/nek5000.svg?branch=develop)
+![https://travis-ci.org/Nek5000/Nek5000](https://travis-ci.org/Nek5000/Nek5000.svg?branch=develop)
 [![GPLv3 licensed](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://raw.githubusercontent.com/Nek5000/nek5000/develop/LICENSE)
 
 ## Wait, where did everything go?


### PR DESCRIPTION
The image for the Travis badge isn't loading.  I think it's because we changed the name of the repo (nek5000 -> Nek5000) and Travis doesn't redirect.  This fixed it in my fork.  
