### PR TITLE
Revert "Revert "Cray patch""

### DIFF
--- a/core/comm_mpi.f
+++ b/core/comm_mpi.f
@@ -25,7 +25,10 @@ c      endif
 
       ! check upper tag size limit
       call mpi_attr_get(MPI_COMM_WORLD,MPI_TAG_UB,nval,flag,ierr)
-      if (nval.lt.(10000+max(lp,lelg))) then
+c     to avoid problems with MPI_TAG_UB on Cray we change
+c     tags from global (eg) to local (e) element number
+c      if (nval.lt.(10000+max(lp,lelg))) then
+      if (nval.lt.(10000+lp)) then
          if(nid.eq.0) write(6,*) 'ABORT: MPI_TAG_UB too small!'
          call exitt
       endif
@@ -224,6 +227,25 @@ C
       real*4 buf(1)
       len = lenm
       jnid = mpi_any_source
+
+      call mpi_recv (buf,len,mpi_byte
+     $              ,jnid,mtype,nekcomm,status,ierr)
+c
+      if (len.gt.lenm) then 
+          write(6,*) nid,'long message in mpi_crecv:',len,lenm
+          call exitt
+      endif
+c
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine crecv2(mtype,buf,lenm,jnid)
+      include 'mpif.h'
+      common /nekmpi/ nid,np,nekcomm,nekgroup,nekreal
+      integer status(mpi_status_size)
+C
+      real*4 buf(1)
+      len = lenm
 
       call mpi_recv (buf,len,mpi_byte
      $              ,jnid,mtype,nekcomm,status,ierr)

--- a/core/ic.f
+++ b/core/ic.f
@@ -1259,19 +1259,21 @@ C
 C     Parallel code - send data to appropriate processor and map.
 C
          JNID=GLLNID(IEG)
-         MTYPE=3333+IEG
+c     tag for sending and receiving changed from global (eg) to 
+c     local (e) element number to avoid problems with MPI_TAG_UB on Cray
+         MTYPE=3333+GLLEL(IEG)
          LEN=4*NXYR
          LE1=4
          IF (NID.EQ.0.AND.JNID.NE.0) THEN
 c           hand-shake
             CALL CSEND(MTYPE,TDUMP,LE1,JNID,NULLPID)
-            CALL CRECV(MTYPE,dummy,LE1)
+            CALL CRECV2(MTYPE,dummy,LE1,JNID)
             CALL CSEND(MTYPE,TDUMP,LEN,JNID,NULLPID)
          ELSEIF (NID.NE.0.AND.JNID.EQ.NID) THEN
 C           Receive data from node 0
-            CALL CRECV(MTYPE,dummy,LE1)
+            CALL CRECV2(MTYPE,dummy,LE1,0)
             CALL CSEND(MTYPE,TDUMP,LE1,0,NULLPID)
-            CALL CRECV(MTYPE,TDUMP,LEN)
+            CALL CRECV2(MTYPE,TDUMP,LEN,0)
          ENDIF
 C
 C        If the data is targeted for this processor, then map 
@@ -2101,8 +2103,9 @@ c-----------------------------------------------------------------------
       if (np.gt.1) then
          l = 1
          do e=1,nelt
-            eg = lglel(e)
-            msg_id(e) = irecv(eg,wk(l),len)
+c     Tag for sending and receiving changed from global (eg) to 
+c     local (e) element number to avoid problems with MPI_TAG_UB on Cray
+            msg_id(e) = irecv(e,wk(l),len)
             l = l+nxyzr
          enddo
       endif
@@ -2129,8 +2132,11 @@ c-----------------------------------------------------------------------
             l = 1
             do e = k+1,k+nelrr
                jnid = gllnid(er(e))                ! where is er(e) now?
+c     Tag for sending and receiving changed from global (eg) to 
+c     local (e) element number to avoid problems with MPI_TAG_UB on Cray
+               jeln = gllel(er(e))
                if(ierr.ne.0) call rzero(w2(l),len)
-               call csend(er(e),w2(l),len,jnid,0)  ! blocking send
+               call csend(jeln,w2(l),len,jnid,0)  ! blocking send
                l = l+nxyzr
             enddo
             k  = k + nelrr
@@ -2242,8 +2248,9 @@ c-----------------------------------------------------------------------
       if (np.gt.1) then
          l = 1
          do e=1,nelt
-            eg = lglel(e)
-            msg_id(e) = irecv(eg,wk(l),len)
+c     tag for sending and receiving changed from global (eg) to 
+c     local (e) element number to avoid problems with MPI_TAG_UB on Cray
+            msg_id(e) = irecv(e,wk(l),len)
             l = l+nxyzr
          enddo
       endif
@@ -2269,8 +2276,11 @@ c-----------------------------------------------------------------------
             l = 1
             do e = k+1,k+nelrr
                jnid = gllnid(er(e))                ! where is er(e) now?
+c     tag for sending and receiving changed from global (eg) to 
+c     local (e) element number to avoid problems with MPI_TAG_UB on Cray
+               jeln = gllel(er(e))
                if(ierr.ne.0) call rzero(w2(l),len)
-               call csend(er(e),w2(l),len,jnid,0)  ! blocking send
+               call csend(jeln,w2(l),len,jnid,0)  ! blocking send
                l = l+nxyzr
             enddo
             k  = k + nelrr

--- a/core/navier0.f
+++ b/core/navier0.f
@@ -149,7 +149,9 @@ c-----------------------------------------------------------------------
 
          mid   = gllnid(eg)
          e     = gllel (eg)
-         mtype = 2000+eg
+c     tag for sending and receiving changed from global (eg) to 
+c     local (e) element number to avoid problems with MPI_TAG_UB on Cray
+         mtype = 2000+e
 
          if (nid.eq.0) then
             if (mid.eq.0) then
@@ -157,14 +159,14 @@ c-----------------------------------------------------------------------
                call  copy(buf(2),a(1,e),lda)
             else
                call csend (mtype,dum,wdsize,mid,nullpid)
-               call crecv (mtype,buf,len)
+               call crecv2 (mtype,buf,len,mid)
             endif
             write(49,49) mid,ibuf(1),(buf(k+1),k=1,lda)
    49       format(2i12,1p3e16.7)
          elseif (nid.eq.mid) then
             call icopy(buf(1),ia(e),1)
             call  copy(buf(2),a(1,e),lda)
-            call crecv (mtype,dum,wdsize)
+            call crecv2 (mtype,dum,wdsize,0)
             call csend (mtype,buf,len,node0,nullpid)
          endif
       enddo

--- a/core/navier5.f
+++ b/core/navier5.f
@@ -2994,15 +2994,17 @@ c-----------------------------------------------------------------------
       if (nid.eq.0) open(unit=29,file='rea.new')
 
       do eg=1,nelgt
-         mtype = eg
          call nekgsync()          !  belt
          jnid = gllnid(eg)
          e    = gllel (eg)
+c     tag for sending and receiving changed from global (eg) to 
+c     local (e) element number to avoid problems with MPI_TAG_UB on Cray
+         mtype = e
          if (jnid.eq.0 .and. nid.eq.0) then
             call get_el(xt,xm1(1,1,1,e),ym1(1,1,1,e),zm1(1,1,1,e))
             call out_el(xt,eg)
          elseif (nid.eq.0) then
-            call crecv(mtype,xt,len)
+            call crecv2(mtype,xt,len,jnid)
             call out_el(xt,eg)
          elseif (jnid.eq.nid) then
             call get_el(xt,xm1(1,1,1,e),ym1(1,1,1,e),zm1(1,1,1,e))

--- a/core/prepost.f
+++ b/core/prepost.f
@@ -439,20 +439,23 @@ C     Dump header
             if (jnid.eq.0) then
                call fill_tmp(tdump,id,ie)
             else
-               mtype=2000+ieg
+c	tag for sending and receiving changed from global (eg) to local (e) element number
+c	to avoid problems with MPI_TAG_UB on Cray
+               mtype=2000+ie
                len=4*id*nxyz
                dum1=0.
                call csend (mtype,dum1,wdsize,jnid,nullpid)
-               call crecv (mtype,tdump,len)
+               call crecv2 (mtype,tdump,len,jnid)
             endif
             if(ierr.eq.0) call out_tmp(id,p66,ierr)
          elseif (nid.eq.jnid) then
             call fill_tmp(tdump,id,ie)
             dum1=0.
-
-            mtype=2000+ieg
+c       tag for sending and receiving changed from global (eg) to local (e) element number
+c       to avoid problems with MPI_TAG_UB on Cray
+            mtype=2000+ie
             len=4*id*nxyz
-            call crecv (mtype,dum1,wdsize)
+            call crecv2 (mtype,dum1,wdsize,node0)
             call csend (mtype,tdump,len,node0,nullpid)
          endif
       enddo


### PR DESCRIPTION
Reverts Nek5000/Nek5000#31

@nicooff had submitted PR#19 for his Cray patch, and we merged it.  
After noticing some failed buildbot tests, we reverted the merge in #31.  However, these tests have failed in the master branch for a number of months and are not the result of PR #19

This double-revert should restore Nicolas' original merge.  
