### PR TITLE
Default bindir in maketools

### DIFF
--- a/tools/maketools
+++ b/tools/maketools
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # binary path
-mkdir -p $HOME/bin
-bin_nek_tools="$HOME/bin"
+bin_nek_tools=`cd ../bin && pwd`
 
 # specify your compilers here
 F77="gfortran"


### PR DESCRIPTION
This sets the default bindir for maketools to Nek5000/bin.  That is, all the compiled tools will be placed in Nek5000/bin unless otherwise specified.  This means if a user adds Nek5000/bin to their $PATH, they will be able to execute both the scripts (nekbmpi, etc.) and the tools (genmap, etc.).
