### PR TITLE
Synching up short_tests/lib with NekExamples/lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - TEST_CASE=Benard_Ray9::test_PnPn_Serial
     - TEST_CASE=Benard_Ray9::test_PnPn2_Serial
     # - TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    - TEST_CASE=Benard_RayDD::test_PnPn2_Serial
+    # - TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
     # - TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
     - TEST_CASE=Benard_RayDN::test_PnPn2_Serial
     # - TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs

--- a/short_tests/lib/nekBinRun.py
+++ b/short_tests/lib/nekBinRun.py
@@ -2,7 +2,7 @@ import os
 import sys
 from subprocess import call, check_call, PIPE, STDOUT, Popen, CalledProcessError
 
-def run_meshgen(command, stdin, cwd):
+def run_meshgen(command, stdin, cwd, verbose=False):
 
     logfile = os.path.join(cwd, '{0}.out'.format(os.path.basename(command)))
     stdin_bytes   = bytes("\n".join(stdin))
@@ -13,8 +13,14 @@ def run_meshgen(command, stdin, cwd):
     print('    Using working directory "{0}"'.format(cwd))
 
     try:
+        (stdoutdata, stderrdata) = Popen([command], stdin=PIPE, stderr=STDOUT, stdout=PIPE, cwd=cwd).communicate(stdin_bytes)
+
         with open(logfile, 'w') as f:
-            Popen([command], stdin=PIPE, stderr=STDOUT, stdout=f, cwd=cwd).communicate(stdin_bytes)
+            f.writelines(stdoutdata)
+
+        if verbose:
+            sys.stdout.write(stdoutdata)
+
     except (OSError, CalledProcessError) as E:
         # TODO: Change to warnings.warn()
         print('Could not complete {0}!  Caught error: "{1}".  Check "{2}" for details.'.format(command, E, logfile))

--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -21,7 +21,7 @@ def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=N
     lines = [re.sub(r'(^source\s+\$SOURCE_ROOT/makenek.inc)', r'\g<1> >compiler.out', l)
              for l in lines]
 
-    lines = [re.sub(r'(.+)2>&1\s+\|\s*tee\s+compiler.out', r'\g<1> >>compiler.out 2>&1', l)
+    lines = [re.sub(r'(.+)2>&1\s+\|\s*tee\s+compiler.out', r'\g<1>', l)
              for l in lines]
 
     with open(outfile, 'w') as f:

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -238,7 +238,7 @@ class NekTestCase(unittest.TestCase):
 
         print("Finished getting setup options!")
 
-    def build_tools(self, targets=None, tools_root=None, tools_bin=None, f77=None, cc=None, bigmem=None):
+    def build_tools(self, targets=None, tools_root=None, tools_bin=None, f77=None, cc=None, bigmem=None, verbose=None):
         from lib.nekBinBuild import build_tools
         build_tools(
             targets    = targets    if targets    else ('clean', 'genmap'),
@@ -246,7 +246,8 @@ class NekTestCase(unittest.TestCase):
             tools_bin  = tools_bin  if tools_bin  else self.tools_bin,
             f77        = f77        if f77        else 'gfortran',
             cc         = cc         if cc         else 'gcc',
-            bigmem     = bigmem     if bigmem     else 'false'
+            bigmem     = bigmem     if bigmem     else 'false',
+            verbose    = verbose    if verbose    else self.verbose
         )
 
     def config_size(self, infile=None, outfile=None, lx2=None, ly2=None, lz2=None):
@@ -278,6 +279,7 @@ class NekTestCase(unittest.TestCase):
             command = os.path.join(self.tools_bin, 'genmap'),
             stdin   = [rea_file, tol],
             cwd     = os.path.join(self.examples_root, cls.example_subdir),
+            verbose = self.verbose
         )
 
     def run_genbox(self, box_file=None):
@@ -294,6 +296,7 @@ class NekTestCase(unittest.TestCase):
             command = os.path.join(self.tools_bin, 'genbox'),
             stdin   = [box_file],
             cwd     = os.path.join(self.examples_root, self.__class__.example_subdir),
+            verbose = self.verbose
         )
 
     def run_n2to3(self, stdin):
@@ -317,7 +320,8 @@ class NekTestCase(unittest.TestCase):
             cwd         = os.path.join(self.examples_root, cls.example_subdir),
             f77         = self.f77,
             cc          = self.cc,
-            ifmpi       = str(self.ifmpi).lower()
+            ifmpi       = str(self.ifmpi).lower(),
+            verbose     = self.verbose
         )
 
     def run_nek(self, rea_file=None, step_limit=None):


### PR DESCRIPTION
The library for short_tests/NekTests.py is being synched up with the library from NekExamples.  It features verbose output for makenek, maketools, genmap, and genbox.  
