### PR TITLE
Synching short_tests with NekExamples.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
     # - TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
 
     - TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
-    # - TEST_CASE=Eddy_EddyUv::test_PnPn_Parallel  # Exceeds time limit for Travis jobs
+    - TEST_CASE=Eddy_EddyUv::test_PnPn_Parallel
     - TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
-    # - TEST_CASE=Eddy_EddyUv::test_PnPn2_Parallel # Exceeds time limit for Travis jobs
+    - TEST_CASE=Eddy_EddyUv::test_PnPn2_Parallel
 
     - TEST_CASE=KovStState::test_PnPn2_Serial
     - TEST_CASE=KovStState::test_PnPn2_Parallel
@@ -46,6 +46,7 @@ before_install:
   - export CC=mpicc
   - export IFMPI=true
   - export VERBOSE_TESTS=true
+  - export PARALLEL_PROCS=2
 
   - sudo apt-get update -qq
   - sudo apt-get install -y libmpich-dev mpich

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -1786,13 +1786,13 @@ class LowMachTest(NekTestCase):
         self.assertAlmostEqualDelayed(gmres, target_val=0, delta=100, label='gmres')
 
         vx = self.get_value_from_log(label='ERROR VX', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(vx, target_val=2.4635E-09, delta=1e-10, label='VX')
+        self.assertAlmostEqualDelayed(vx, target_val=2.4635E-09, delta=1e-06, label='VX')
 
         t = self.get_value_from_log(label='ERROR T', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(t, target_val=4.5408E-12, delta=1e-13, label='T')
+        self.assertAlmostEqualDelayed(t, target_val=4.5408E-12, delta=1e-06, label='T')
 
         qtl = self.get_value_from_log(label='ERROR QTL', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(qtl, target_val=2.6557E-06, delta=1e-07, label='QTL')
+        self.assertAlmostEqualDelayed(qtl, target_val=2.6557E-06, delta=1e-06, label='QTL')
 
         self.assertDelayedFailures()
 


### PR DESCRIPTION
This PR updates the short_tests:
- omitting ':' in labels for 'gmres' and 'PRES' labels.  Required since @stgeke formatted stdout.
- Adding option for number of MPI ranks in parallel tests
- Runs parallel tests with 2 MPI ranks. Fixes #44.  Allows parallel tests to complete in ~2 minutes
