### PR TITLE
Ensure NOTIMER disables all operation counting

### DIFF
--- a/core/mxm_std.f
+++ b/core/mxm_std.f
@@ -4136,6 +4136,7 @@ c
       include 'OPCTR'
       include 'TOTAL'
 c
+#ifndef NOTIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -4146,6 +4147,7 @@ c
       dct(myrout) = dct(myrout) + (isbcnt)
       ncall(myrout) = ncall(myrout) + 1
       dcount      =      dcount + (isbcnt)
+#endif
 c
 c
       call mxma2(a,n1,b,n2,c,n3)  ! In some cases, this is faster.

--- a/core/mxm_std.f
+++ b/core/mxm_std.f
@@ -4136,7 +4136,7 @@ c
       include 'OPCTR'
       include 'TOTAL'
 c
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1

--- a/core/navier1.f
+++ b/core/navier1.f
@@ -370,7 +370,7 @@ c
 
       integer e
 C
-#ifndef NOTIMER
+#ifdef TIMER
       if (icalld.eq.0) tcdtp=0.0
       icalld=icalld+1
       ncdtp=icalld
@@ -538,7 +538,7 @@ C
 
       enddo
 C
-#ifndef NOTIMER
+#ifdef TIMER
       tcdtp=tcdtp+(dnekclock()-etime1)
 #endif
       return
@@ -584,7 +584,7 @@ C---------------------------------------------------------------------
 
       integer e
 C
-#ifndef NOTIMER
+#ifdef TIMER
       if (icalld.eq.0) tmltd=0.0
       icalld=icalld+1
       nmltd=icalld
@@ -742,7 +742,7 @@ c        NOTE: NZ1=NZ2=1
 C
       enddo
 C
-#ifndef NOTIMER
+#ifdef TIMER
       tmltd=tmltd+(dnekclock()-etime1)
 #endif
       return
@@ -869,7 +869,7 @@ C
 
       include 'OPCTR'
 C
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -883,7 +883,7 @@ C
 C
       NTOT=NX1*NY1*NZ1*NELV
 C
-#ifndef NOTIMER
+#ifdef TIMER
       isbcnt = ntot*(1+ndim)
       dct(myrout) = dct(myrout) + (isbcnt)
       ncall(myrout) = ncall(myrout) + 1
@@ -931,7 +931,7 @@ C
 
       include 'OPCTR'
 C
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -945,7 +945,7 @@ C
 C
       NTOT=NX1*NY1*NZ1*NELV
 C
-#ifndef NOTIMER
+#ifdef TIMER
       isbcnt = ntot*(1+ndim)
       dct(myrout) = dct(myrout) + (isbcnt)
       ncall(myrout) = ncall(myrout) + 1
@@ -2405,7 +2405,7 @@ C-------------------------------------------------------------------
       REAL  Y(1),X(1),XMASK(1)
       include 'OPCTR'
 C
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -2538,7 +2538,7 @@ C
 C
       NTOT1=NX1*NY1*NZ1*NELV
 
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -2574,7 +2574,7 @@ C
 C
       NTOT1=NX1*NY1*NZ1*NELV
 
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -2821,7 +2821,7 @@ c-----------------------------------------------------------------------
 C
       NTOT1=NX1*NY1*NZ1*NELV
 
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -2860,7 +2860,7 @@ c-----------------------------------------------------------------------
 C
       NTOT1=NX1*NY1*NZ1*NELV
 
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -2899,7 +2899,7 @@ c-----------------------------------------------------------------------
 C
       NTOT1=NX1*NY1*NZ1*NELV
 
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -2937,7 +2937,7 @@ c-----------------------------------------------------------------------
 C
       NTOT1=NX1*NY1*NZ1*NELV
 
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -3116,7 +3116,7 @@ C
       include 'CTIMER'
       include 'OPCTR'
 C
-#ifndef NOTIMER
+#ifdef TIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -3465,7 +3465,7 @@ C
       REAL    CONV (LX1,LY1,LZ1,1) 
       REAL    FI   (LX1,LY1,LZ1,1)
 
-#ifndef NOTIMER
+#ifdef TIMER
       if (icalld.eq.0) tadvc=0.0
       icalld=icalld+1
       nadvc=icalld
@@ -3505,7 +3505,7 @@ c     if (istep.gt.5) call exitti(' CONVOP dbg: $',ip99)
 
  100  continue
 
-#ifndef NOTIMER
+#ifdef TIMER
       tadvc=tadvc+(dnekclock()-etime1)
 #endif
 
@@ -3824,7 +3824,7 @@ c
       include 'OPCTR'
 
 c     Operation count
-#ifndef NOTIMER
+#ifdef TIMER
       integer opct
       if (isclld.eq.0) then
           isclld=1
@@ -3872,7 +3872,7 @@ c
          enddo
       endif
 c
-#ifndef NOTIMER
+#ifdef TIMER
       if (ndim.eq.3) then
          opct = ntot*21
       else
@@ -3904,7 +3904,7 @@ c
 c
 c     Operation count
 c
-#ifndef NOTIMER
+#ifdef TIMER
       integer opct
       if (isclld.eq.0) then
           isclld=1
@@ -3952,7 +3952,7 @@ c
          enddo
       endif
 c
-#ifndef NOTIMER
+#ifdef TIMER
       opct = ndim*ntot
       dct(myrout) = dct(myrout) + opct
       dcount      =      dcount + opct
@@ -3983,7 +3983,7 @@ C
 c
 c     Operation count
 c
-#ifndef NOTIMER
+#ifdef TIMER
       integer opct
       if (isclld.eq.0) then
           isclld=1
@@ -4069,7 +4069,7 @@ c
 c
       enddo
 c
-#ifndef NOTIMER
+#ifdef TIMER
       if (if3d) then
          opct = 21*ntot
       else
@@ -4103,7 +4103,7 @@ c
 c
 c     Operation count
 c
-#ifndef NOTIMER
+#ifdef TIMER
       integer opct
       if (isclld.eq.0) then
           isclld=1
@@ -4152,7 +4152,7 @@ c
          enddo
       endif
 c
-#ifndef NOTIMER
+#ifdef TIMER
       opct = ndim*ntot
       dct(myrout) = dct(myrout) + opct
       dcount      =      dcount + opct

--- a/core/navier1.f
+++ b/core/navier1.f
@@ -869,22 +869,26 @@ C
 
       include 'OPCTR'
 C
+#ifndef NOTIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
           myrout=nrout
           rname(myrout) = 'opbinv'
       endif
+#endif
 C
       call opmask  (inp1,inp2,inp3)
       call opdssum (inp1,inp2,inp3)
 C
       NTOT=NX1*NY1*NZ1*NELV
 C
+#ifndef NOTIMER
       isbcnt = ntot*(1+ndim)
       dct(myrout) = dct(myrout) + (isbcnt)
       ncall(myrout) = ncall(myrout) + 1
       dcount      =      dcount + (isbcnt)
+#endif
 
       call invcol3 (out1,bm1,h2inv,ntot)  ! this is expensive and should
       call dssum   (out1,nx1,ny1,nz1)     ! be changed (pff, 3/18/09)
@@ -927,22 +931,26 @@ C
 
       include 'OPCTR'
 C
+#ifndef NOTIMER
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
           myrout=nrout
           rname(myrout) = 'opbnv1'
       endif
+#endif
 C
       CALL OPMASK  (INP1,INP2,INP3)
       CALL OPDSSUM (INP1,INP2,INP3)
 C
       NTOT=NX1*NY1*NZ1*NELV
 C
+#ifndef NOTIMER
       isbcnt = ntot*(1+ndim)
       dct(myrout) = dct(myrout) + (isbcnt)
       ncall(myrout) = ncall(myrout) + 1
       dcount      =      dcount + (isbcnt)
+#endif
 C
       IF (IF3D) THEN
          DO 100 I=1,NTOT
@@ -3814,9 +3822,10 @@ c
       real vxn(1),vyn(1),vzn(1)
 c
       include 'OPCTR'
-      integer opct
 
 c     Operation count
+#ifndef NOTIMER
+      integer opct
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -3825,6 +3834,7 @@ c     Operation count
       endif
       ncall(myrout) = ncall(myrout) + 1
       opct = 0
+#endif
 
       call velchar (vx,vxn,vxlag,nbd,tau,dtlag)
       call velchar (vy,vyn,vylag,nbd,tau,dtlag)
@@ -3849,7 +3859,6 @@ c
      $                  + ty*tym1(i,1,1,1)
      $                  + tz*tzm1(i,1,1,1)
          enddo
-         opct = ntot*21
       else
          do i=1,ntot
 c
@@ -3861,11 +3870,17 @@ c
             vy(i,1,1,1) = tx*sxm1(i,1,1,1)
      $                  + ty*sym1(i,1,1,1)
          enddo
-         opct = ntot*10
       endif
 c
+#ifndef NOTIMER
+      if (ndim.eq.3) then
+         opct = ntot*21
+      else
+         opct = ntot*10
+         endif
       dct(myrout) = dct(myrout) + opct
       dcount      =      dcount + opct
+#endif
 C
 c
       return
@@ -3886,10 +3901,11 @@ c
       integer mu(0:1)
 c
       include 'OPCTR'
-      integer opct
 c
 c     Operation count
 c
+#ifndef NOTIMER
+      integer opct
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -3897,6 +3913,7 @@ c
           rname(myrout) = 'frkcvv'
       endif
       ncall(myrout) = ncall(myrout) + 1
+#endif
 c
 c
 c     Evaluate right-hand-side for Runge-Kutta scheme in the case of
@@ -3935,9 +3952,11 @@ c
          enddo
       endif
 c
+#ifndef NOTIMER
       opct = ndim*ntot
       dct(myrout) = dct(myrout) + opct
       dcount      =      dcount + opct
+#endif
 c
       return
       end
@@ -3961,10 +3980,11 @@ c
      $             , dwds(lx1,ly1,lz1)
 C
       include 'OPCTR'
-      integer opct
 c
 c     Operation count
 c
+#ifndef NOTIMER
+      integer opct
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -3973,6 +3993,7 @@ c
       endif
       ncall(myrout) = ncall(myrout) + 1
       opct = 0
+#endif
 c
       nel = nelv
       if (imesh.eq.2) nel = nelt
@@ -4048,6 +4069,7 @@ c
 c
       enddo
 c
+#ifndef NOTIMER
       if (if3d) then
          opct = 21*ntot
       else
@@ -4056,6 +4078,7 @@ c
 c
       dct(myrout) = dct(myrout) + opct
       dcount      =      dcount + opct
+#endif
 c
       return
       end
@@ -4077,10 +4100,11 @@ c
       integer mu(0:1)
 c
       include 'OPCTR'
-      integer opct
 c
 c     Operation count
 c
+#ifndef NOTIMER
+      integer opct
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -4088,6 +4112,7 @@ c
           rname(myrout) = 'frkcv2'
       endif
       ncall(myrout) = ncall(myrout) + 1
+#endif
 c
 c
 c     Evaluate right-hand-side for Runge-Kutta scheme in the case of
@@ -4127,9 +4152,11 @@ c
          enddo
       endif
 c
+#ifndef NOTIMER
       opct = ndim*ntot
       dct(myrout) = dct(myrout) + opct
       dcount      =      dcount + opct
+#endif
 C
       return
       end

--- a/core/navier4.f
+++ b/core/navier4.f
@@ -327,7 +327,7 @@ C
 C
       include 'OPCTR'
 C
-#ifndef NOTIMER
+#ifdef TIMER
 C
       if (isclld.eq.0) then
           isclld=1

--- a/core/navier4.f
+++ b/core/navier4.f
@@ -327,6 +327,8 @@ C
 C
       include 'OPCTR'
 C
+#ifndef NOTIMER
+C
       if (isclld.eq.0) then
           isclld=1
           nrout=nrout+1
@@ -337,6 +339,7 @@ C
       dct(myrout) = dct(myrout) + dfloat(isbcnt)
       ncall(myrout) = ncall(myrout) + 1
       dcount      =      dcount + dfloat(isbcnt)
+#endif
 C
       DT = 0.0
       DO 10 I=1,N


### PR DESCRIPTION
This request ensures all operation counting code is disabled by the
preprocessor NOTIMER flag. Previously only some counters were disabled.

Note: The NOTIMER flags will need to be changed to TIMER if pull
requested #75 is accepted (a trivial change).
