### PR TITLE
Fixed inclusion of MPI in PPLIST definition when IFCMT==false

### DIFF
--- a/core/makenek.inc
+++ b/core/makenek.inc
@@ -253,7 +253,6 @@ if [ "$IFCMT" == "true" -o "$IFCMT" == "yes" ]; then
 else
   # default
   IFCMT=false
-  PPLIST="${PPLIST} MPI"
 fi
 export IFCMT
 


### PR DESCRIPTION
@fischer1 and his students discovered an error in makenek when compiling w/o MPI.  In particular, the MPI proprocessor symbol is always defined when IFCMT==false.  This overrides the definition of IFMPI in makenek.  

This PR fixes that issue.  
