### PR TITLE
Added Travis tests w/o MPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,64 +4,62 @@ sudo: required
 
 env:
   matrix:
-    env:
+    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Axi::test_PnPn_Serial
+    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Axi::test_PnPn2_Serial
 
-      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Axi::test_PnPn_Serial
-      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Axi::test_PnPn2_Serial
+    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_Ray9::test_PnPn_Serial
+    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_Ray9::test_PnPn2_Serial
+    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
+    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDN::test_PnPn2_Serial
+    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
 
-      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_Ray9::test_PnPn_Serial
-      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_Ray9::test_PnPn2_Serial
-      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
-      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDN::test_PnPn2_Serial
-      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
+    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
+    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
 
-      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
-      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
+    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=KovStState::test_PnPn2_Serial
 
-      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=KovStState::test_PnPn2_Serial
+    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=LowMachTest::test_PnPn_Serial
+    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=LowMachTest::test_PnPn2_Serial
 
-      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=LowMachTest::test_PnPn_Serial
-      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=LowMachTest::test_PnPn2_Serial
+    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn_Serial    # Stdout exceeds Travis' max log length
+    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn_Parallel  # Stdout exceeds Travis' max log length
+    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
+    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
 
-      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn_Serial    # Stdout exceeds Travis' max log length
-      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn_Parallel  # Stdout exceeds Travis' max log length
-      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
-      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Serial
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Parallel
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Serial
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Parallel
 
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Serial
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Parallel
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Serial
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Parallel
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn_Serial
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn2_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn2_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
 
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn_Serial
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn2_Serial
-      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
-      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn2_Serial
-      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Parallel
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Parallel
 
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Parallel
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Parallel
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Serial
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Parallel
 
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Serial
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Parallel
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Serial
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Parallel
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Serial
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Parallel
 
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Serial
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Parallel
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Serial
-      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Parallel
-
-      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn_Serial    # Stdout exceeds Travis' max log length
-      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn_Parallel  # Stdout exceeds Travis' max log length
-      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
-      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn_Serial    # Stdout exceeds Travis' max log length
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn_Parallel  # Stdout exceeds Travis' max log length
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
 
 before_install: 
   - export ROOT_DIR=`pwd`

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,47 +4,70 @@ sudo: required
 
 env:
   matrix:
+    env:
 
-    - TEST_CASE=Axi::test_PnPn_Serial
-    - TEST_CASE=Axi::test_PnPn_Parallel
-    - TEST_CASE=Axi::test_PnPn2_Serial
-    - TEST_CASE=Axi::test_PnPn2_Parallel
+      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Axi::test_PnPn_Serial
+      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Axi::test_PnPn2_Serial
 
-    - TEST_CASE=Benard_Ray9::test_PnPn_Serial
-    - TEST_CASE=Benard_Ray9::test_PnPn2_Serial
-    # - TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    # - TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
-    # - TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    - TEST_CASE=Benard_RayDN::test_PnPn2_Serial
-    # - TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    # - TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
+      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_Ray9::test_PnPn_Serial
+      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_Ray9::test_PnPn2_Serial
+      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
+      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDN::test_PnPn2_Serial
+      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
 
-    - TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
-    - TEST_CASE=Eddy_EddyUv::test_PnPn_Parallel
-    - TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
-    - TEST_CASE=Eddy_EddyUv::test_PnPn2_Parallel
+      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
+      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
 
-    - TEST_CASE=KovStState::test_PnPn2_Serial
-    - TEST_CASE=KovStState::test_PnPn2_Parallel
+      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=KovStState::test_PnPn2_Serial
 
-    - TEST_CASE=LowMachTest::test_PnPn_Serial
-    - TEST_CASE=LowMachTest::test_PnPn_Parallel
-    - TEST_CASE=LowMachTest::test_PnPn2_Serial
-    - TEST_CASE=LowMachTest::test_PnPn2_Parallel
+      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=LowMachTest::test_PnPn_Serial
+      - IFMPI=false F77=gfortran CC=gcc TEST_CASE=LowMachTest::test_PnPn2_Serial
 
-    # - TEST_CASE=VarVis::test_PnPn_Serial    # Stdout exceeds Travis' max log length
-    # - TEST_CASE=VarVis::test_PnPn_Parallel  # Stdout exceeds Travis' max log length
-    # - TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
-    # - TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
+      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn_Serial    # Stdout exceeds Travis' max log length
+      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn_Parallel  # Stdout exceeds Travis' max log length
+      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
+      # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
+
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Serial
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Parallel
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Serial
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Parallel
+
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn_Serial
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn2_Serial
+      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
+      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn2_Serial
+      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
+      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
+
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Parallel
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Parallel
+
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Serial
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Parallel
+
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Serial
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Parallel
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Serial
+      - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Parallel
+
+      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn_Serial    # Stdout exceeds Travis' max log length
+      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn_Parallel  # Stdout exceeds Travis' max log length
+      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
+      # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
 
 before_install: 
   - export ROOT_DIR=`pwd`
 
   - export SOURCE_ROOT=$ROOT_DIR
   - export EXAMPLES_ROOT=$ROOT_DIR/short_tests
-  - export F77=mpif77
-  - export CC=mpicc
-  - export IFMPI=true
   - export VERBOSE_TESTS=true
   - export PARALLEL_PROCS=2
 


### PR DESCRIPTION
Fixes #55.  Travis tests are now run w/o MPI using gfortran and gcc

cc: @fischer1 @stgeke 
