### PR TITLE
bugfixes in local_grad2_t, navier1.f

### DIFF
--- a/core/convect.f
+++ b/core/convect.f
@@ -1269,7 +1269,7 @@ c     Global-to-local mapping for gs
       parameter(lf=lx1*lz1*2*ldim*lelt)
       common /c_is1/ glo_num_face(lf)
      $             , glo_num_vol((lx1+2)*(ly1+2)*(lz1+2)*lelt)
-      integer*8 glo_num_face,glo_num_vol,ngv,nf
+      integer*8 glo_num_face,glo_num_vol,ngv
 
       common /nekmpi/ mid,mp,nekcomm,nekgroup,nekreal
 

--- a/core/navier1.f
+++ b/core/navier1.f
@@ -4963,7 +4963,7 @@ c-----------------------------------------------------------------------
       subroutine local_grad2_t(u,ur,us,N,e,D,Dt,w)
 c     Output: ur,us         Input:u,N,e,D,Dt
       real u (0:N,0:N,1)
-      real ur(0:N,0:N),us(0:N,0:N),ut(0:N,0:N)
+      real ur(0:N,0:N),us(0:N,0:N)
       real D (0:N,0:N),Dt(0:N,0:N)
       real w (0:N,0:N)
       integer e


### PR DESCRIPTION
gs_setup should not have an integer*8 for that particular argument. Even though ut isn't used, it's never good to have arrays dimensioned with variables unless they're dummy args. This fix prevented NaNs in gfortran+openmpi SMP runs.
