### PR TITLE
Updates to short_tests

### DIFF
--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -1003,9 +1003,47 @@ class CylRestart_Pb(NekTestCase):
 
 class Eddy_EddyUv(NekTestCase):
     example_subdir  = 'eddy'
-    case_name        = 'eddy_uv'
+    case_name       = 'eddy_uv'
 
     def setUp(self):
+
+        # Default SIZE parameters. Can be overridden in test cases
+        self.size_params = dict(
+            ldim     = 2,
+            lx1      = 8,
+            lxd      = 12,
+            lx2      = None,
+            lx1m     = 1,
+            lelg     = 4100,
+            lp       = 512,
+            lelt     = 300,
+            ldimt    = 2,
+            lelx     = 20,
+            lely     = 20,
+            lelz     = 1,
+            ax1      = 'lx1',
+            ax2      = 'lx2',
+            lbx1     = 'lx1',
+            lbx2     = 'lx2',
+            lbelt    = 'lelt',
+            lpx1     = 'lx1',
+            lpx2     = 'lx2',
+            lpelt    = 'lelt',
+            lpert    = 3,
+            lelecmt  = None,
+            toteq    = None,
+            mxprev   = 20,
+            lgmres   = 30,
+            lorder   = None,
+            lhis     = 100,
+            maxobj   = 4,
+            maxmbr   = 'lelt*6',
+            nsessmax = None,
+            nmaxl    = None,
+            nfldmax  = None,
+            nmaxcom  = None
+        )
+
         self.build_tools(['genmap'])
 
         # Tweak the .rea file and run genmap
@@ -1020,7 +1058,9 @@ class Eddy_EddyUv(NekTestCase):
 
     @pn_pn_serial
     def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        # Update SIZE parameters for PnPn
+        self.size_params['lx2'] = 'lx1'
+        self.config_size(**self.size_params)
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -1040,7 +1080,8 @@ class Eddy_EddyUv(NekTestCase):
 
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2'] = 'lx1'
+        self.config_size(**self.size_params)
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -1057,7 +1098,8 @@ class Eddy_EddyUv(NekTestCase):
 
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2'] = 'lx1-2'
+        self.config_size(**self.size_params)
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -1077,7 +1119,8 @@ class Eddy_EddyUv(NekTestCase):
 
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2'] = 'lx1-2'
+        self.config_size(**self.size_params)
         self.build_nek()
         self.run_nek(step_limit=None)
 

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -64,8 +64,8 @@ class Axi(NekTestCase):
         pres = self.get_value_from_log('PRES ', column=-4)
         self.assertAlmostEqualDelayed(pres, target_val=0., delta=76., label='PRES')
 
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=2, label='total solver time')
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=2, label='total solver time')
 
         self.assertDelayedFailures()
 
@@ -91,8 +91,8 @@ class Axi(NekTestCase):
         u_press = self.get_value_from_log('U-Press ', column=-5)
         self.assertAlmostEqualDelayed(u_press, target_val=0., delta=104., label='U-Press')
 
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=4, label='total solver time')
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=4, label='total solver time')
 
         self.assertDelayedFailures()
 
@@ -166,8 +166,8 @@ class Benard_Ray9(NekTestCase):
         self.build_nek(usr_file='ray_9')
         self.run_nek(rea_file='ray_9', step_limit=1000)
 
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30., label='total solver time')
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30., label='total solver time')
 
         gmres = self.get_value_from_log('gmres ', column=-7)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=23., label='gmres')
@@ -189,8 +189,8 @@ class Benard_Ray9(NekTestCase):
         self.build_nek(usr_file='ray_9')
         self.run_nek(rea_file='ray_9', step_limit=1000)
 
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40., label='total solver time')
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40., label='total solver time')
 
         gmres = self.get_value_from_log('gmres ', column=-6)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=11., label='gmres')
@@ -286,8 +286,8 @@ class Benard_RayDD(NekTestCase):
             '{0}.log.{1}{2}'.format('ray_dd', self.mpi_procs, self.log_suffix)
         )
 
-        solver_time = self.get_value_from_log(label='total solver time', column=-2, logfile=logfile)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=24., label='total solver time')
+        # solver_time = self.get_value_from_log(label='total solver time', column=-2, logfile=logfile)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=24., label='total solver time')
 
         gmres = self.get_value_from_log('gmres ', column=-6, logfile=logfile)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=11., label='gmres')
@@ -307,8 +307,8 @@ class Benard_RayDD(NekTestCase):
         self.build_nek(usr_file='ray_cr')
         self.run_nek(step_limit=None)
 
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=20., label='total solver time')
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=20., label='total solver time')
 
         gmres = self.get_value_from_log('gmres ', column=-6)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=11., label='gmres')
@@ -403,8 +403,8 @@ class Benard_RayDN(NekTestCase):
             '{0}.log.{1}{2}'.format('ray_dn', self.mpi_procs, self.log_suffix)
         )
 
-        solver_time = self.get_value_from_log(label='total solver time', column=-2, logfile=logfile)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30., label='total solver time')
+        # solver_time = self.get_value_from_log(label='total solver time', column=-2, logfile=logfile)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30., label='total solver time')
 
         gmres = self.get_value_from_log('gmres ', column=-6, logfile=logfile)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=11., label='gmres')
@@ -423,8 +423,8 @@ class Benard_RayDN(NekTestCase):
         self.build_nek(usr_file='ray_cr')
         self.run_nek(rea_file='ray_dn', step_limit=None)
 
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=12., label='total solver time')
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=12., label='total solver time')
 
         gmres = self.get_value_from_log('gmres ', column=-6)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=11., label='gmres')
@@ -519,8 +519,8 @@ class Benard_RayNN(NekTestCase):
             '{0}.log.{1}{2}'.format('ray_nn', self.mpi_procs, self.log_suffix)
         )
 
-        solver_time = self.get_value_from_log(label='total solver time', column=-2, logfile=logfile)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30., label='total solver time')
+        # solver_time = self.get_value_from_log(label='total solver time', column=-2, logfile=logfile)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30., label='total solver time')
 
         gmres = self.get_value_from_log('gmres ', column=-6, logfile=logfile)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=14., label='gmres')
@@ -539,8 +539,8 @@ class Benard_RayNN(NekTestCase):
         self.build_nek(usr_file='ray_cr')
         self.run_nek(rea_file='ray_nn', step_limit=None)
 
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=20., label='total solver time')
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=20., label='total solver time')
 
         gmres = self.get_value_from_log('gmres ', column=-6)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=14., label='gmres')
@@ -635,8 +635,8 @@ class Eddy_EddyUv(NekTestCase):
         yerr = self.get_value_from_log('Y err', column=-6, row=-1)
         self.assertAlmostEqualDelayed(yerr, target_val=6.489061E-07, delta=1E-06, label='Y err')
 
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=80, label='total solver time')
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=80, label='total solver time')
 
         self.assertDelayedFailures()
 
@@ -674,8 +674,8 @@ class Eddy_EddyUv(NekTestCase):
         yerr = self.get_value_from_log('Y err', column=-6, row=-1)
         self.assertAlmostEqualDelayed(yerr, target_val=7.842019E-05, delta=1E-06, label='Y err')
 
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, 0.1, delta=80, label='total solver time')
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, 0.1, delta=80, label='total solver time')
 
         self.assertDelayedFailures()
 
@@ -756,8 +756,8 @@ class KovStState(NekTestCase):
         self.build_nek()
         self.run_nek(step_limit=None)
 
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=5, label='total solver time')
+        # solver_time = self.get_value_from_log(label='total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=5, label='total solver time')
 
         err = self.get_value_from_log(label='err', column=-3, row=-1)
         self.assertAlmostEqualDelayed(err, target_val=8.55641E-10, delta=1e-06, label='err')
@@ -842,8 +842,8 @@ class LowMachTest(NekTestCase):
         self.build_nek()
         self.run_nek(step_limit=200)
 
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40, label='total solver time')
+        # solver_time = self.get_value_from_log(label='total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40, label='total solver time')
 
         gmres = self.get_value_from_log(label='gmres', column=-7)
         self.assertAlmostEqualDelayed(gmres, target_val=0, delta=100, label='gmres')
@@ -986,8 +986,8 @@ class VarVis(NekTestCase):
         self.build_nek()
         self.run_nek(step_limit=None)
 
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30, label='total solver time')
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30, label='total solver time')
 
         gmres = self.get_value_from_log('gmres ', column=-6)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=19, label='gmres')

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 from lib.nekTestCase import *
 from unittest import skip
 
@@ -1007,3 +1008,30 @@ class VarVis(NekTestCase):
 
     def tearDown(self):
         self.move_logs()
+
+if __name__ == '__main__':
+    import unittest, argparse, os
+
+    # Get arguments from command line
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--f77", default='mpif77', help="The Fortran 77 compiler to use [default: mpif77]")
+    parser.add_argument("--cc", default='mpicc',  help="The C compiler to use [default: mpicc]")
+    parser.add_argument("--ifmpi", default='true', choices=['true', 'false'], help="Enable/disable parallel tests with MPI [default: true]")
+    parser.add_argument("--nprocs", default='4', help="Number of processes to use for MPI tests [default: 4]")
+    parser.add_argument("-v", "--verbose", action='store_true', help="Enable verbose output")
+    args = parser.parse_args()
+
+    # # Set environment
+    os.environ['CC'] = args.cc
+    os.environ['F77'] = args.f77
+    os.environ['IFMPI'] = args.ifmpi
+    os.environ['PARALLEL_PROCS'] = args.nprocs
+    if args.verbose:
+        os.environ['VERBOSE_TESTS'] = 'true'
+        ut_verbose = 2
+    else:
+        os.environ['VERBOSE_TESTS'] = 'false'
+        ut_verbose = 1
+
+    suite = unittest.TestSuite([unittest.TestLoader().loadTestsFromTestCase(t) for t in (Axi, Eddy_EddyUv)])
+    unittest.TextTestRunner(verbosity=ut_verbose, buffer=True).run(suite)

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -2,216 +2,52 @@ from lib.nekTestCase import *
 from unittest import skip
 
 ###############################################################################
-#  turbChannel: turbChannel.rea
-###############################################################################
-
-class TurbChannel(NekTestCase):
-    example_subdir = 'turbChannel'
-    case_name = 'turbChannel'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap(tol='0.5')
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=95., label='gmres ')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=200., label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=95., label='gmres ')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=200., label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=26., label='gmres ')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=140., label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=26., label='gmres ')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=140., label='total solver time')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-# ###############################################################################
-# #  2d_eigtest: eig1.rea
-# ###############################################################################
-#
-# TODO: implement 2d_eigtest
-
-# class TwoDEigtest(NekTestCase):
-#     example_subdir  = '2d_eigtest'
-#     rea_file        = 'eig1'
-#
-#     def setUp(self):
-#         import shutil
-#         cls = self.__class__
-#
-#         # Copy Nek5000 source and replace hmholtz.f
-#         old_source_root = self.source_root
-#         new_source_root = os.path.join(self.examples_root, cls.example_subdir, 'nek5000')
-#         shutil.copytree(old_source_root, new_source_root)
-#         shutil.copy(
-#             os.path.join(self.examples_root, cls.example_subdir, 'hmholtz_b_prec.f'),
-#             os.path.join(new_source_root, 'core', 'hmholtz.f')
-#         )
-#
-#         self.source_root = new_source_root
-#
-#         self.build_tools(['genmap'])
-#         self.run_genmap()
-#
-#     @pn_pn_serial
-#     def test_PnPn_Serial(self):
-#         cls = self.__class__
-#
-#         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-#
-#         # Run all problems
-#         for lx0 in range(1,17):
-#             size0_path = os.path.join(self.examples_root, cls.example_subdir, 'SIZE0')
-#             with open(size0_path, 'w') as f:
-#                 f.write('{0}parameter (lx0 = {1} )'.format(' '*6, lx0))
-#             for ext in ('.log', '.fld', '.his', '.sch', '.out', '.ore', '.nre'):
-#                 fpath = os.path.join(self.examples_root, cls.example_subdir, cls.rea_file+ext)
-#                 try:
-#                     os.remove(fpath)
-#                 except OSError:
-#                     pass
-#             self.build_nek()
-#             self.run_nek(log_suffix='{0}.{1}'.format(self.log_suffix, lx0), step_limit=None)
-#
-#         # Append all logs
-#         total_log = os.path.join(
-#             self.examples_root,
-#             cls.example_subdir,
-#             '{0}.log.{1}{2}.{3}'.format(self.rea_file, self.mpi_procs, self.log_suffix, 'tot'))
-#         try:
-#             os.remove(total_log)
-#         except OSError:
-#             pass
-#         with open(total_log, 'a') as f_out:
-#             for lx0 in range(1,17):
-#                 single_log = os.path.join(
-#                     self.examples_root,
-#                     cls.example_subdir,
-#                     '{0}.log.{1}{2}.{3}'.format(self.rea_file, self.mpi_procs, self.log_suffix, lx0))
-#                 with open(single_log, 'r') as f_in:
-#                     f_out.writelines(f_in)
-#
-#         for i in (2, 3, 6, 10):
-#             test_val = self.get_value_from_log(' {0}   '.format(i), column=-6, logfile=total_log)
-#             self.assertAlmostEqual()
-#
-# ###############################################################################
-# #  3dbox: b3d.rea
-# ###############################################################################
-
-class ThreeDBox(NekTestCase):
-    example_subdir  = '3dbox'
-    case_name        = 'b3d'
-
-    def setUp(self):
-        self.build_tools(['genbox', 'genmap'])
-        self.run_genbox()
-        self.mvn('box', self.__class__.case_name)
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        phrase = self.get_phrase_from_log('end of time-step loop')
-        self.assertIsNotNullDelayed(phrase, label='end of time-step loop')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        phrase = self.get_phrase_from_log('end of time-step loop')
-        self.assertIsNotNullDelayed(phrase, label='end of time-step loop')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        phrase = self.get_phrase_from_log('end of time-step loop')
-        self.assertIsNotNullDelayed(phrase, label='end of time-step loop')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        phrase = self.get_phrase_from_log('end of time-step loop')
-        self.assertIsNotNullDelayed(phrase, label='end of time-step loop')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-###############################################################################
 #  axi: axi.rea
 ###############################################################################
 
 class Axi(NekTestCase):
     example_subdir  = 'axi'
-    case_name        = 'axi'
+    case_name       = 'axi'
 
     def setUp(self):
+
+        # Default SIZE parameters. Can be overridden in test cases
+        self.size_params = dict(
+            ldim      = '2',
+            lx1       = '6',
+            lxd       = '9',
+            lx2       = 'lx1-2',
+            lx1m      = 'lx1',
+            lelg      = '300',
+            lp        = '8',
+            lelt      = '80',
+            ldimt     = '4',
+            lelx      = '20',
+            lely      = '60',
+            lelz      = '1',
+            ax1       = 'lx1',
+            ax2       = 'lx2',
+            lbx1      = '1',
+            lbx2      = '1',
+            lbelt     = '1',
+            lpx1      = '1',
+            lpx2      = '1',
+            lpelt     = '1',
+            lpert     = '1',
+            lelecmt   = '',
+            toteq     = '',
+            mxprev    = '80',
+            lgmres    = '40',
+            lorder    = '3',
+            lhis      = '100',
+            maxobj    = '4',
+            maxmbr    = 'lelt*6',
+            nsessmax  = '',
+            nmaxl     = '',
+            nfldmax   = '',
+            nmaxcom   = '',
+        )
+
         self.build_tools(['genbox', 'genmap'])
         self.run_genbox()
         self.mvn('box', self.__class__.case_name)
@@ -219,7 +55,8 @@ class Axi(NekTestCase):
 
     @pn_pn_serial
     def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2']='lx1'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -233,7 +70,8 @@ class Axi(NekTestCase):
 
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2']='lx1'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -244,7 +82,8 @@ class Axi(NekTestCase):
 
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2']='lx1-2'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -258,7 +97,8 @@ class Axi(NekTestCase):
 
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2']='lx1-2'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -279,12 +119,49 @@ class Benard_Ray9(NekTestCase):
     case_name = 'ray_9'
 
     def setUp(self):
+        self.size_params = dict (
+            ldim      = '2',
+            lx1       = '8',
+            lxd       = '12',
+            lx2       = 'lx1-2',
+            lx1m      = '1',
+            lelg      = '5000',
+            lp        = '512',
+            lelt      = '200',
+            ldimt     = '1',
+            lelx      = '1',
+            lely      = '1',
+            lelz      = '1',
+            ax1       = 'lx1',
+            ax2       = 'lx2',
+            lbx1      = '1',
+            lbx2      = '1',
+            lbelt     = '1',
+            lpx1      = '1',
+            lpx2      = '1',
+            lpelt     = '1',
+            lpert     = '1',
+            lelecmt   = '',
+            toteq     = '',
+            mxprev    = '20',
+            lgmres    = '20',
+            lorder    = '3',
+            lhis      = '100',
+            maxobj    = '4',
+            maxmbr    = 'lelt*6',
+            nsessmax  = '',
+            nmaxl     = '',
+            nfldmax   = '',
+            nmaxcom   = '',
+        )
+
         self.build_tools(['genmap'])
         self.run_genmap(rea_file='ray_9')
 
     @pn_pn_serial
     def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2']='lx1'
+        self.config_size()
         self.build_nek(usr_file='ray_9')
         self.run_nek(rea_file='ray_9', step_limit=1000)
 
@@ -296,7 +173,8 @@ class Benard_Ray9(NekTestCase):
 
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2']='lx1'
+        self.config_size()
         self.build_nek(usr_file='ray_9')
         self.run_nek(rea_file='ray_9', step_limit=1000)
 
@@ -305,7 +183,8 @@ class Benard_Ray9(NekTestCase):
 
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2']='lx1-2'
+        self.config_size()
         self.build_nek(usr_file='ray_9')
         self.run_nek(rea_file='ray_9', step_limit=1000)
 
@@ -317,7 +196,8 @@ class Benard_Ray9(NekTestCase):
 
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2']='lx1-2'
+        self.config_size()
         self.build_nek(usr_file='ray_9')
         self.run_nek(rea_file='ray_9', step_limit=1000)
 
@@ -327,18 +207,55 @@ class Benard_Ray9(NekTestCase):
     def tearDown(self):
         self.move_logs()
 
+
 class Benard_RayDD(NekTestCase):
     example_subdir = 'benard'
     case_name = 'ray_dd'
 
     def setUp(self):
+        self.size_params = dict (
+            ldim      = '2',
+            lx1       = '8',
+            lxd       = '12',
+            lx2       = 'lx1-2',
+            lx1m      = '1',
+            lelg      = '5000',
+            lp        = '512',
+            lelt      = '200',
+            ldimt     = '1',
+            lelx      = '1',
+            lely      = '1',
+            lelz      = '1',
+            ax1       = 'lx1',
+            ax2       = 'lx2',
+            lbx1      = '1',
+            lbx2      = '1',
+            lbelt     = '1',
+            lpx1      = '1',
+            lpx2      = '1',
+            lpelt     = '1',
+            lpert     = '1',
+            lelecmt   = '',
+            toteq     = '',
+            mxprev    = '20',
+            lgmres    = '20',
+            lorder    = '3',
+            lhis      = '100',
+            maxobj    = '4',
+            maxmbr    = 'lelt*6',
+            nsessmax  = '',
+            nmaxl     = '',
+            nfldmax   = '',
+            nmaxcom   = '',
+        )
         self.build_tools(['genmap'])
         self.run_genmap()
 
     @pn_pn_serial
     def test_PnPn_Serial(self):
         import lib.nekBinRun, lib.nekBinBuild, shutil
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2']='lx1'
+        self.config_size()
         shutil.copy(
             os.path.join(self.examples_root, 'benard', 'ray_dd.map'),
             os.path.join(self.examples_root, 'benard', 'benard_split', 'ray_dd.map')
@@ -384,7 +301,8 @@ class Benard_RayDD(NekTestCase):
 
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2']='lx1-2'
+        self.config_size()
         self.build_nek(usr_file='ray_cr')
         self.run_nek(step_limit=None)
 
@@ -406,18 +324,55 @@ class Benard_RayDD(NekTestCase):
     def tearDown(self):
         self.move_logs()
 
+
 class Benard_RayDN(NekTestCase):
     example_subdir = 'benard'
     case_name = 'ray_dn'
 
     def setUp(self):
+        self.size_params = dict (
+            ldim      = '2',
+            lx1       = '8',
+            lxd       = '12',
+            lx2       = 'lx1-2',
+            lx1m      = '1',
+            lelg      = '5000',
+            lp        = '512',
+            lelt      = '200',
+            ldimt     = '1',
+            lelx      = '1',
+            lely      = '1',
+            lelz      = '1',
+            ax1       = 'lx1',
+            ax2       = 'lx2',
+            lbx1      = '1',
+            lbx2      = '1',
+            lbelt     = '1',
+            lpx1      = '1',
+            lpx2      = '1',
+            lpelt     = '1',
+            lpert     = '1',
+            lelecmt   = '',
+            toteq     = '',
+            mxprev    = '20',
+            lgmres    = '20',
+            lorder    = '3',
+            lhis      = '100',
+            maxobj    = '4',
+            maxmbr    = 'lelt*6',
+            nsessmax  = '',
+            nmaxl     = '',
+            nfldmax   = '',
+            nmaxcom   = '',
+        )
         self.build_tools(['genmap'])
         self.run_genmap(rea_file='ray_dn')
 
     @pn_pn_serial
     def test_PnPn_Serial(self):
         import lib.nekBinRun, lib.nekBinBuild, shutil
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2']='lx1'
+        self.config_size()
         shutil.copy(
             os.path.join(self.examples_root, 'benard', 'ray_dn.map'),
             os.path.join(self.examples_root, 'benard', 'benard_split', 'ray_dn.map')
@@ -462,7 +417,8 @@ class Benard_RayDN(NekTestCase):
 
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2']='lx1-2'
+        self.config_size()
         self.build_nek(usr_file='ray_cr')
         self.run_nek(rea_file='ray_dn', step_limit=None)
 
@@ -484,18 +440,55 @@ class Benard_RayDN(NekTestCase):
     def tearDown(self):
         self.move_logs()
 
+
 class Benard_RayNN(NekTestCase):
     example_subdir = 'benard'
     case_name = 'ray_nn'
 
     def setUp(self):
+        self.size_params = dict (
+            ldim      = '2',
+            lx1       = '8',
+            lxd       = '12',
+            lx2       = 'lx1-2',
+            lx1m      = '1',
+            lelg      = '5000',
+            lp        = '512',
+            lelt      = '200',
+            ldimt     = '1',
+            lelx      = '1',
+            lely      = '1',
+            lelz      = '1',
+            ax1       = 'lx1',
+            ax2       = 'lx2',
+            lbx1      = '1',
+            lbx2      = '1',
+            lbelt     = '1',
+            lpx1      = '1',
+            lpx2      = '1',
+            lpelt     = '1',
+            lpert     = '1',
+            lelecmt   = '',
+            toteq     = '',
+            mxprev    = '20',
+            lgmres    = '20',
+            lorder    = '3',
+            lhis      = '100',
+            maxobj    = '4',
+            maxmbr    = 'lelt*6',
+            nsessmax  = '',
+            nmaxl     = '',
+            nfldmax   = '',
+            nmaxcom   = '',
+        )
         self.build_tools(['genmap'])
         self.run_genmap(rea_file='ray_nn')
 
     @pn_pn_serial
     def test_PnPn_Serial(self):
         import lib.nekBinRun, lib.nekBinBuild, shutil
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2']='lx1'
+        self.config_size()
         shutil.copy(
             os.path.join(self.examples_root, 'benard', 'ray_nn.map'),
             os.path.join(self.examples_root, 'benard', 'benard_split', 'ray_nn.map')
@@ -540,7 +533,8 @@ class Benard_RayNN(NekTestCase):
 
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2']='lx1-2'
+        self.config_size()
         self.build_nek(usr_file='ray_cr')
         self.run_nek(rea_file='ray_nn', step_limit=None)
 
@@ -561,439 +555,6 @@ class Benard_RayNN(NekTestCase):
 
     def tearDown(self):
         self.move_logs()
-#
-#
-# ####################################################################
-# #  blasius: blasius.rea
-# ####################################################################
-class Blasius(NekTestCase):
-    example_subdir  = 'blasius'
-    case_name        = 'blasius'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=162., label='gmres ')
-
-        delta = self.get_value_from_log('delta', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(delta, target_val=1.26104, delta=1e-05, label='delta')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30., label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=162., label='gmres ')
-
-        delta = self.get_value_from_log('delta', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(delta, target_val=1.26104, delta=1e-05, label='delta')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=125., label='gmres ')
-
-        delta = self.get_value_from_log('delta', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(delta, target_val=1.26104, delta=1e-05, label='delta')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30., label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=125., label='gmres ')
-
-        delta = self.get_value_from_log('delta', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(delta, target_val=1.26104, delta=1e-05, label='delta')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-# ####################################################################
-# #  cone: cone.rea, cone016.rea, cone064.rea, cone256.rea
-# ####################################################################
-#
-# # TODO: implement cone
-#
-# ####################################################################
-# #  conj_ht: conj_ht.rea
-# ####################################################################
-
-class ConjHt(NekTestCase):
-    example_subdir  = 'conj_ht'
-    case_name        = 'conj_ht'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=46., label='gmres')
-
-        tmax = self.get_value_from_log('tmax', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(tmax, target_val=1.31190E+01, delta=1E-06, label='tmax')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=7, label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=46., label='gmres')
-
-        tmax = self.get_value_from_log('tmax', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(tmax, target_val=1.31190E+01, delta=1E-06, label='tmax')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=26., label='gmres')
-
-        tmax = self.get_value_from_log('tmax', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(tmax, target_val=1.31190E+01, delta=1E-06, label='tmax')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=7, label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=26., label='gmres')
-
-        tmax = self.get_value_from_log('tmax', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(tmax, target_val=1.31190E+01, delta=1E-06, label='tmax')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-# ####################################################################
-# #  cyl_restart: ca.rea, cb.rea, pa.rea, pb.rea
-# ####################################################################
-
-class CylRestart_Ca(NekTestCase):
-    example_subdir  = 'cyl_restart'
-    case_name        = 'ca'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=85., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.37986119139E-03, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=85., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.37986119139E-03, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=29., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.09547531705E-02, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=29., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.09547531705E-02, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-class CylRestart_Cb(NekTestCase):
-    example_subdir  = 'cyl_restart'
-    case_name        = 'cb'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=77., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.37986119139E-03, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=77., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.37986119139E-03, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=28., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.09547531705E-02, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=28., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.09547531705E-02, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-class CylRestart_Pa(NekTestCase):
-    example_subdir  = 'cyl_restart'
-    case_name        = 'pa'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=85., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.37986119139E-03, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=85., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.37986119139E-03, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=29., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.09547531705E-02, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=29., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.09547531705E-02, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-class CylRestart_Pb(NekTestCase):
-    example_subdir  = 'cyl_restart'
-    case_name        = 'pb'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=77., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.37986119139E-03, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=77., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.37986119139E-03, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=28., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.09547531705E-02, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=28., label='gmres')
-
-        test_val = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(test_val, target_val=5.09547531705E-02, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
 
 # ####################################################################
 # #  eddy; eddy_uv.rea, amg_eddy.rea, htps_ed.rea
@@ -1009,39 +570,39 @@ class Eddy_EddyUv(NekTestCase):
 
         # Default SIZE parameters. Can be overridden in test cases
         self.size_params = dict(
-            ldim     = 2,
-            lx1      = 8,
-            lxd      = 12,
-            lx2      = None,
-            lx1m     = 1,
-            lelg     = 4100,
-            lp       = 512,
-            lelt     = 300,
-            ldimt    = 2,
-            lelx     = 20,
-            lely     = 20,
-            lelz     = 1,
-            ax1      = 'lx1',
-            ax2      = 'lx2',
-            lbx1     = 'lx1',
-            lbx2     = 'lx2',
-            lbelt    = 'lelt',
-            lpx1     = 'lx1',
-            lpx2     = 'lx2',
-            lpelt    = 'lelt',
-            lpert    = 3,
-            lelecmt  = None,
-            toteq    = None,
-            mxprev   = 20,
-            lgmres   = 30,
-            lorder   = None,
-            lhis     = 100,
-            maxobj   = 4,
-            maxmbr   = 'lelt*6',
-            nsessmax = None,
-            nmaxl    = None,
-            nfldmax  = None,
-            nmaxcom  = None
+            ldim      = '2',
+            lx1       = '8',
+            lxd       = '12',
+            lx2       = 'lx1-2',
+            lx1m      = '1',
+            lelg      = '4100',
+            lp        = '512',
+            lelt      = '300',
+            ldimt     = '2',
+            lelx      = '20',
+            lely      = '20',
+            lelz      = '1',
+            ax1       = 'lx1',
+            ax2       = 'lx2',
+            lbx1      = '1',
+            lbx2      = '1',
+            lbelt     = '1',
+            lpx1      = '1',
+            lpx2      = '1',
+            lpelt     = '1',
+            lpert     = '1',
+            lelecmt   = '',
+            toteq     = '',
+            mxprev    = '20',
+            lgmres    = '30',
+            lorder    = '3',
+            lhis      = '100',
+            maxobj    = '4',
+            maxmbr    = 'lelt*6',
+            nsessmax  = '',
+            nmaxl     = '',
+            nfldmax   = '',
+            nmaxcom   = '',
         )
 
         self.build_tools(['genmap'])
@@ -1060,7 +621,7 @@ class Eddy_EddyUv(NekTestCase):
     def test_PnPn_Serial(self):
         # Update SIZE parameters for PnPn
         self.size_params['lx2'] = 'lx1'
-        self.config_size(**self.size_params)
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -1081,7 +642,7 @@ class Eddy_EddyUv(NekTestCase):
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.size_params['lx2'] = 'lx1'
-        self.config_size(**self.size_params)
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -1099,7 +660,7 @@ class Eddy_EddyUv(NekTestCase):
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
         self.size_params['lx2'] = 'lx1-2'
-        self.config_size(**self.size_params)
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -1120,7 +681,7 @@ class Eddy_EddyUv(NekTestCase):
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
         self.size_params['lx2'] = 'lx1-2'
-        self.config_size(**self.size_params)
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -1138,602 +699,6 @@ class Eddy_EddyUv(NekTestCase):
     def tearDown(self):
         self.move_logs()
 
-# ####################################################################
-# #  eddy_neknek: eddy_neknek.rea
-# ####################################################################
-#
-# # TODO: implment eddy_neknek tests
-#
-# ####################################################################
-# #  eddy_psi_omega; psi_omega.rea
-# ####################################################################
-
-class Eddy_PsiOmega(NekTestCase):
-    example_subdir  = 'eddy_psi_omega'
-    case_name        = 'psi_omega'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        xerr = self.get_value_from_log('X err', column=-6, row=-1)
-        self.assertAlmostEqualDelayed(xerr, target_val=1.177007E-10, delta=1E-06, label='X err')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=17, label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        xerr = self.get_value_from_log('X err', column=-6, row=-1)
-        self.assertAlmostEqualDelayed(xerr, target_val=1.177007E-10, delta=1E-06, label='X err')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        xerr = self.get_value_from_log('X err', column=-6, row=-1)
-        self.assertAlmostEqualDelayed(xerr, target_val=1.177007E-10, delta=1E-06, label='X err')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, 0.1, delta=17, label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        xerr = self.get_value_from_log('X err', column=-6, row=-1)
-        self.assertAlmostEqualDelayed(xerr, target_val=1.177007E-10, delta=1E-06, label='X err')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-# ####################################################################
-# #  expansion: expansion.rea
-# ####################################################################
-#
-# # TODO: implement expansion tests
-#
-# ####################################################################
-# #  ext_cyl; ext_cyl.rea
-# ####################################################################
-
-class ExtCyl(NekTestCase):
-    example_subdir  = 'ext_cyl'
-    case_name        = 'ext_cyl'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=85., label='gmres')
-
-        dragx = self.get_value_from_log('dragx', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(dragx, target_val=1.2138790E+00, delta=1E-06, label='dragx')
-
-        dragy = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(dragy, target_val=1.3040301E-07, delta=1E-06, label='dragy')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=400, label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=85., label='gmres')
-
-        dragx = self.get_value_from_log('dragx', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(dragx, target_val=1.2138790E+00, delta=1E-06, label='dragx')
-
-        dragy = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(dragy, target_val=1.3040301E-07, delta=1E-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=26., label='gmres')
-
-        dragx = self.get_value_from_log('dragx', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(dragx, target_val=1.2138878E+00, delta=1e-05, label='dragx')
-
-        dragy = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(dragy, target_val=3.2334222E-07, delta=1e-06, label='dragy')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=380, label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=26., label='gmres')
-
-        dragx = self.get_value_from_log('dragx', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(dragx, target_val=1.2138878E+00, delta=1e-05, label='dragx')
-
-        dragy = self.get_value_from_log('dragy', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(dragy, target_val=3.2334222E-07, delta=1e-06, label='dragy')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-# ####################################################################
-# #  fs_2; st1.rea, st2.rea, std_wv.rea
-# ####################################################################
-
-class Fs2_St1(NekTestCase):
-    example_subdir  = 'fs_2'
-    case_name        = 'st1'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @unittest.expectedFailure
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        phrase = self.get_phrase_from_log("ABORT: ")
-        self.assertIsNotNullDelayed(phrase, 'ABORT: ')
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        phrase = self.get_phrase_from_log("ABORT: ")
-        self.assertIsNotNullDelayed(phrase, 'ABORT: ')
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=38., label='gmres')
-
-        amp = self.get_value_from_log('amp', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(amp, target_val=6.382414E-01, delta=1e-06, label='amp')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2,)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=18.3, label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=38., label='gmres')
-
-        amp = self.get_value_from_log('amp', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(amp, target_val=6.382414E-01, delta=1e-06, label='amp')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-
-class Fs2_St2(NekTestCase):
-    example_subdir  = 'fs_2'
-    case_name        = 'st2'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @unittest.expectedFailure
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        phrase = self.get_phrase_from_log("ABORT: ")
-        self.assertIsNotNullDelayed(phrase, 'ABORT: ')
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        phrase = self.get_phrase_from_log("ABORT: ")
-        self.assertIsNotNullDelayed(phrase, 'ABORT: ')
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=38., label='gmres')
-
-        amp = self.get_value_from_log('amp', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(amp, target_val=6.376171E-01, delta=1e-06, label='amp')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2,)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=23, label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=38., label='gmres')
-
-        amp = self.get_value_from_log('amp', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(amp, target_val=6.376171E-01, delta=1e-06, label='amp')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-class Fs2_StdWv(NekTestCase):
-    example_subdir  = 'fs_2'
-    case_name        = 'std_wv'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @unittest.expectedFailure
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        phrase = self.get_phrase_from_log("ABORT: ")
-        self.assertIsNotNullDelayed(phrase, 'ABORT: ')
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        phrase = self.get_phrase_from_log("ABORT: ")
-        self.assertIsNotNullDelayed(phrase, 'ABORT: ')
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=20., label='gmres')
-
-        amp = self.get_value_from_log('amp', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(amp, target_val=1.403287E-01, delta=1e-06, label='amp')
-
-        solver_time = self.get_value_from_log('total solver time', column=-2,)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=21., label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=20., label='gmres')
-
-        amp = self.get_value_from_log('amp', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(amp, target_val=1.403287E-01, delta=1e-06, label='amp')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-# ####################################################################
-# #  fs_hydro: fs_hydro.rea
-# ####################################################################
-
-class FsHydro(NekTestCase):
-    example_subdir = 'fs_hydro'
-    case_name       = 'fs_hydro'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @unittest.expectedFailure
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        phrase = self.get_phrase_from_log("ABORT: ")
-        self.assertIsNotNullDelayed(phrase, 'ABORT')
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        phrase = self.get_phrase_from_log("ABORT: ")
-        self.assertIsNotNullDelayed(phrase, 'ABORT')
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2,)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=200, label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=108., label='gmres')
-
-        amp = self.get_value_from_log('AMP', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(amp, target_val=-6.4616452E-05, delta=2e-03, label='AMP')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2,)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=200, label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=108., label='gmres')
-
-        amp = self.get_value_from_log('AMP', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(amp, target_val=-6.4616452E-05, delta=2e-03, label='AMP')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-# ####################################################################
-# #  hemi; hemi
-# ####################################################################
-
-class Hemi(NekTestCase):
-    example_subdir = 'hemi'
-    case_name = 'hemi'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @unittest.expectedFailure
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2,)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=100., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=39., label='gmres')
-
-        wmax = self.get_value_from_log('wmax', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(wmax, target_val=4.9173E-01, delta=1e-06, label='wmax')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-7,)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=39., label='gmres')
-
-        wmax = self.get_value_from_log('wmax', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(wmax, target_val=4.9173E-01, delta=1e-06, label='wmax')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2,)
-        self.assertAlmostEqual(solver_time, 0.1, delta=60.)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqual(gmres, 0., delta=34.)
-
-        wmax = self.get_value_from_log('wmax', column=-2, row=-1)
-        self.assertAlmostEqual(wmax, 4.7915E-01, delta=1e-06)
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-6,)
-        self.assertAlmostEqual(gmres, 0., delta=34.)
-
-        wmax = self.get_value_from_log('wmax', column=-2, row=-1)
-        self.assertAlmostEqual(wmax, 4.7915E-01, delta=1e-06)
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  kovasznay; kov.rea
-####################################################################
-
-class Kovasznay(NekTestCase):
-    example_subdir = 'kovasznay'
-    case_name = 'kov'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=12, label='total solver time')
-
-        gmres = self.get_value_from_log(label='gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=34, label='gmres')
-
-        err = self.get_value_from_log(label='err', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(err, target_val=5.14316E-13, delta=1e-06, label='err')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log(label='gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=34, label='gmres')
-
-        err = self.get_value_from_log(label='err', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(err, target_val=5.14316E-13, delta=1e-06, label='err')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=17, label='total solver time')
-
-        gmres = self.get_value_from_log(label='gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=14, label='gmres')
-
-        err = self.get_value_from_log(label='err', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(err, target_val=5.90551E-13, delta=1e-06, label='err')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log(label='gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=14, label='gmres')
-
-        err = self.get_value_from_log(label='err', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(err, target_val=5.90551E-13, delta=1e-06, label='err')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
 ####################################################################
 #  kov_st_state; kov_st_stokes.rea
 ####################################################################
@@ -1744,12 +709,49 @@ class KovStState(NekTestCase):
     case_name = 'kov_st_stokes'
 
     def setUp(self):
+        self.size_params = dict(
+            ldim      = '2',
+            lx1       = '14',
+            lxd       = '20',
+            lx2       = 'lx1-2',
+            lx1m      = '1',
+            lelg      = '500',
+            lp        = '64',
+            lelt      = '80',
+            ldimt     = '1',
+            lelx      = '1',
+            lely      = '1',
+            lelz      = '1',
+            ax1       = 'lx1',
+            ax2       = 'lx2',
+            lbx1      = '1',
+            lbx2      = '1',
+            lbelt     = '1',
+            lpx1      = '1',
+            lpx2      = '1',
+            lpelt     = '1',
+            lpert     = '1',
+            lelecmt   = '',
+            toteq     = '',
+            mxprev    = '20',
+            lgmres    = '40',
+            lorder    = '3',
+            lhis      = '100',
+            maxobj    = '4',
+            maxmbr    = 'lelt*6',
+            nsessmax  = '',
+            nmaxl     = '',
+            nfldmax   = '',
+            nmaxcom   = '',
+        )
+
         self.build_tools(['genmap'])
         self.run_genmap()
 
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2'] = 'lx1-2'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -1763,7 +765,8 @@ class KovStState(NekTestCase):
 
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2'] = 'lx1-2'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -1784,6 +787,41 @@ class LowMachTest(NekTestCase):
     case_name       = 'lowMach_test'
 
     def setUp(self):
+        self.size_params = dict (
+            ldim      = '2',
+            lx1       = '14',
+            lxd       = '20',
+            lx2       = 'lx1-0',
+            lx1m      = '1',
+            lelg      = '5000',
+            lp        = '1024',
+            lelt      = '600',
+            ldimt     = '1',
+            lelx      = '1',
+            lely      = '1',
+            lelz      = '1',
+            ax1       = '1',
+            ax2       = '1',
+            lbx1      = '1',
+            lbx2      = '1',
+            lbelt     = '1',
+            lpx1      = '1',
+            lpx2      = '1',
+            lpelt     = '1',
+            lpert     = '1',
+            lelecmt   = '',
+            toteq     = '1',
+            mxprev    = '20',
+            lgmres    = '30',
+            lorder    = '3',
+            lhis      = '100',
+            maxobj    = '4',
+            maxmbr    = 'lelt*6',
+            nsessmax  = '1',
+            nmaxl     = '1',
+            nfldmax   = '1',
+            nmaxcom   = '1',
+        )
         self.build_tools(['genmap'])
 
         # Tweak the .rea file and run genmap
@@ -1798,7 +836,8 @@ class LowMachTest(NekTestCase):
 
     @pn_pn_serial
     def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2'] = 'lx1'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=200)
 
@@ -1821,7 +860,8 @@ class LowMachTest(NekTestCase):
 
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2'] = 'lx1'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=200)
 
@@ -1841,7 +881,8 @@ class LowMachTest(NekTestCase):
 
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2'] = 'lx1-2'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=200)
 
@@ -1851,7 +892,8 @@ class LowMachTest(NekTestCase):
 
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2'] = 'lx1-2'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=200)
 
@@ -1862,1076 +904,6 @@ class LowMachTest(NekTestCase):
     def tearDown(self):
         self.move_logs()
 
-####################################################################
-#  mhd; gpf.rea, gpf_m.rea, gpf_b.rea
-####################################################################
-
-class Mhd_Gpf(NekTestCase):
-    example_subdir = 'mhd'
-    case_name = 'gpf'
-
-    def setUp(self):
-        self.build_tools(['genbox', 'genmap'])
-        self.run_genbox(box_file='gpf')
-        self.run_genmap(rea_file='box')
-        self.mvn('box', 'gpf')
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        # TODO: This is expected to fail
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        phrase = self.get_phrase_from_log("ABORT: MHD")
-        self.assertIsNotNullDelayed(phrase, label='ABORT: MHD')
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        # TODO: This is expected to fail
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        phrase = self.get_phrase_from_log("ABORT: MHD")
-        self.assertIsNotNullDelayed(phrase, label='ABORT: MHD')
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=130, label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=15, label='gmres')
-
-        rtavg = self.get_value_from_log('rtavg_gr_Em', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(rtavg, target_val=2.56712250E-01, delta=.02, label='rtavg')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=15, label='gmres')
-
-        rtavg = self.get_value_from_log('rtavg_gr_Em', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(rtavg, target_val=2.56712250E-01, delta=.02, label='rtavg')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-class Mhd_GpfM(NekTestCase):
-    example_subdir = 'mhd'
-    case_name = 'gpf_m'
-
-    def setUp(self):
-        import shutil
-        # Probably a cleaner way to do this...
-        # I'm just mimicking the
-        self.build_tools(['genbox', 'genmap'])
-        self.run_genbox(box_file='gpf')
-        self.run_genmap(rea_file='box')
-        self.mvn('box', 'gpf')
-        shutil.copy(
-            os.path.join(self.examples_root, self.__class__.example_subdir, 'gpf.map'),
-            os.path.join(self.examples_root, self.__class__.example_subdir, 'gpf_m.map')
-        )
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek(usr_file='gpf')
-        self.run_nek(rea_file='gpf_m', step_limit=None)
-
-        phrase = self.get_phrase_from_log(label="ERROR: FDM")
-        self.assertIsNotNullDelayed(phrase, label='ERROR: FDM')
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek(usr_file='gpf')
-        self.run_nek(rea_file='gpf_m', step_limit=None)
-
-        phrase = self.get_phrase_from_log(label="ERROR: FDM")
-        self.assertIsNotNullDelayed(phrase, label='ERROR: FDM')
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek(usr_file='gpf')
-        self.run_nek(rea_file='gpf_m', step_limit=None)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=130, label='total solver time')
-
-        rtavg = self.get_value_from_log('rtavg_gr_Em', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(rtavg, target_val=2.56712250E-01, delta=.02, label='rtavg')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek(usr_file='gpf')
-        self.run_nek(rea_file='gpf_m', step_limit=None)
-
-        rtavg = self.get_value_from_log('rtavg_gr_Em', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(rtavg, target_val=2.56712250E-01, delta=.02, label='rtavg')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-class Mhd_GpfB(NekTestCase):
-    example_subdir = 'mhd'
-    case_name = 'gpf_b'
-
-    def setUp(self):
-        # Probably a cleaner way to do this...
-        # I'm just mimicking the
-        self.build_tools(['genbox', 'genmap'])
-        self.run_genbox(box_file='gpf')
-        self.run_genmap(rea_file='box')
-        self.mvn('box', 'gpf')
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek(usr_file='gpf')
-        self.run_nek(rea_file='gpf_b', step_limit=None)
-
-        phrase = self.get_phrase_from_log("ABORT: MHD")
-        self.assertIsNotNullDelayed(phrase, label='ABORT: MHD')
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek(usr_file='gpf')
-        self.run_nek(rea_file='gpf_b', step_limit=None)
-
-        phrase = self.get_phrase_from_log("ABORT: MHD")
-        self.assertIsNotNullDelayed(phrase, label='ABORT: MHD')
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek(usr_file='gpf')
-        self.run_nek(rea_file='gpf_b', step_limit=None)
-
-        rtavg = self.get_value_from_log('rtavg_gr_Em', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(rtavg, target_val=2.56712250E-01, delta=.02, label='rtavg')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek(usr_file='gpf')
-        self.run_nek(rea_file='gpf_b', step_limit=None)
-
-        rtavg = self.get_value_from_log('rtavg_gr_Em', column=-4, row=-1)
-        self.assertAlmostEqualDelayed(rtavg, target_val=2.56712250E-01, delta=.02, label='rtavg')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  os7000; u3_t020_n13.rea
-####################################################################
-
-class Os7000(NekTestCase):
-    example_subdir = 'os7000'
-    case_name = 'u3_t020_n13'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @unittest.expectedFailure
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40., label='total solver time')
-
-        gmres = self.get_value_from_log(label='gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=43., label='gmres')
-
-        egn = self.get_value_from_log(label='egn', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(egn, target_val=4.74494769e-05, delta=1e-06, label='egn')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        gmres = self.get_value_from_log(label='gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=43., label='gmres')
-
-        egn = self.get_value_from_log(label='egn', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(egn, target_val=4.74494769e-05, delta=1e-06, label='egn')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40., label='total solver time')
-
-        gmres = self.get_value_from_log(label='gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=43., label='gmres')
-
-        egn = self.get_value_from_log(label='egn', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(egn, target_val=5.93471252E-05, delta=1e-06, label='egn')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=1000)
-
-        gmres = self.get_value_from_log(label='gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=43., label='gmres')
-
-        egn = self.get_value_from_log(label='egn', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(egn, target_val=5.93471252E-05, delta=1e-06, label='egn')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  peris; peris.rea
-####################################################################
-
-class Peris(NekTestCase):
-    example_subdir = 'peris'
-    case_name = 'peris'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @unittest.expectedFailure
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        phrase = self.get_phrase_from_log('ABORT: ')
-        self.assertIsNotNullDelayed(phrase, label='ABORT: ')
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        phrase = self.get_phrase_from_log('ABORT: ')
-        self.assertIsNotNullDelayed(phrase, label='ABORT: ')
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=13., label='total solver time')
-
-        gmres = self.get_value_from_log(label='gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=18., label='gmres')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log(label='gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=18., label='gmres')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  pipe; helix.rea, stenosis.rea
-####################################################################
-
-class Pipe_Helix(NekTestCase):
-    example_subdir = 'pipe'
-    case_name = 'helix'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @unittest.expectedFailure
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=22., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=61., label='gmres')
-
-        err2 = self.get_value_from_log('err2', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(err2, target_val=1.9077617E+00, delta=1e-06, label='err2')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=61., label='gmres')
-
-        err2 = self.get_value_from_log('err2', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(err2, target_val=1.9077617E+00, delta=1e-06, label='err2')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=22., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=123., label='gmres')
-
-        err2 = self.get_value_from_log('err2', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(err2, target_val=1.9072258E+00, delta=1e-06, label='err2')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=123., label='gmres')
-
-        err2 = self.get_value_from_log('err2', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(err2, target_val=1.9072258E+00, delta=1e-06, label='err2')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-class Pipe_Stenosis(NekTestCase):
-    example_subdir = 'pipe'
-    case_name = 'stenosis'
-
-    def setUp(self):
-        n2to3_input = [
-            'w2dcyl020a',
-            'stenosis',
-            '0                      ascii output',
-            '20                     input number of levels: (1, 2, 3,... etc.?):',
-            '0                      input z min:',
-            '10                     input z max:',
-            '1                      input gain (0=custom,1=uniform,other=geometric spacing):',
-            'n                      This is for CEM: yes or no:',
-            'v                      Enter Z (5) boundary condition (P,v,O):',
-            'O                      Enter Z (6) boundary condition (v,O):',
-            'y                      Formatted .rea file? (y or Y):',
-        ]
-        self.build_tools(['n2to3', 'genmap'])
-        self.run_n2to3(n2to3_input)
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=80., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=196., label='gmres')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=196., label='gmres')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=51., label='gmres')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=51., label='gmres')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  rayleigh; ray1.rea, ray2.rea
-####################################################################
-
-class Rayleigh_Ray1(NekTestCase):
-    example_subdir  = 'rayleigh'
-    case_name        = 'ray1'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap(rea_file='ray1')
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek(usr_file='ray0')
-        self.run_nek(rea_file='ray1', step_limit=200)
-
-        gmres = self.get_value_from_log(label='gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=32., label='gmres')
-
-        umax = self.get_value_from_log(label='umax', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(umax, target_val=2.792052E-03, delta=1e-03, label='umax')
-
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=3., label='total solver time')
-
-        self.assertDelayedFailures()
-
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek(usr_file='ray0')
-        self.run_nek(rea_file='ray1', step_limit=200)
-
-        gmres = self.get_value_from_log(label='gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=32., label='gmres')
-
-        umax = self.get_value_from_log(label='umax', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(umax, target_val=2.792052E-03, delta=1e-03, label='umax')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek(usr_file='ray0')
-        self.run_nek(rea_file='ray1', step_limit=200)
-
-        gmres = self.get_value_from_log(label='gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=11., label='gmres')
-
-        umax = self.get_value_from_log(label='umax', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(umax, target_val=4.831113E-03, delta=1e-05, label='umax')
-
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=3., label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek(usr_file='ray0')
-        self.run_nek(rea_file='ray1', step_limit=200)
-
-        gmres = self.get_value_from_log(label='gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=11., label='gmres')
-
-        umax = self.get_value_from_log(label='umax', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(umax, target_val=4.831113E-03, delta=1e-05, label='umax')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-class Rayleigh_Ray2(NekTestCase):
-    example_subdir  = 'rayleigh'
-    case_name        = 'ray2'
-
-    def setUp(self):
-        self.build_tools(['genmap', 'genbox'])
-        self.run_genbox(box_file='ray2')
-        self.run_genmap(rea_file='box')
-        self.mvn('box', 'ray2')
-
-    @unittest.expectedFailure
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek(usr_file='ray0')
-        self.run_nek(rea_file='ray2', step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=31, label='gmres')
-
-        umax = self.get_value_from_log('umax', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(umax, target_val=4.549071E-03, delta=1e-05, label='umax')
-
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=3., label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek(usr_file='ray0')
-        self.run_nek(rea_file='ray2', step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=31, label='gmres')
-
-        umax = self.get_value_from_log('umax', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(umax, target_val=4.549071E-03, delta=1e-05, label='umax')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek(usr_file='ray0')
-        self.run_nek(rea_file='ray2', step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=11, label='gmres')
-
-        umax = self.get_value_from_log('umax', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(umax, target_val=6.728787E-03, delta=1e-05, label='umax')
-
-        solver_time = self.get_value_from_log(label='total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=3., label='total solver time')
-
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek(usr_file='ray0')
-        self.run_nek(rea_file='ray2', step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=11, label='gmres')
-
-        umax = self.get_value_from_log('umax', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(umax, target_val=6.728787E-03, delta=1e-05, label='umax')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  strat; re10f1000p1000.rea, re10f1000p0001.rea
-####################################################################
-
-class Strat_P1000(NekTestCase):
-    example_subdir = 'strat'
-    case_name = 're10f1000p1000'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=140, label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=60, label='gmres')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=60, label='gmres')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=80, label='total solver time')
-
-        upres = self.get_value_from_log('U-PRES', column=-6)
-        self.assertAlmostEqualDelayed(upres, target_val=0, delta=27, label='U-PRES')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        upres = self.get_value_from_log('U-PRES', column=-6)
-        self.assertAlmostEqualDelayed(upres, target_val=0, delta=27, label='U-PRES')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-class Strat_P0001(NekTestCase):
-    example_subdir = 'strat'
-    case_name = 're10f1000p0001'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=140, label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=60, label='gmres')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0, delta=60, label='gmres')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=80, label='total solver time')
-
-        upres = self.get_value_from_log('U-PRES', column=-6)
-        self.assertAlmostEqualDelayed(upres, target_val=0, delta=27, label='U-PRES')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=200)
-
-        upres = self.get_value_from_log('U-PRES', column=-6)
-        self.assertAlmostEqualDelayed(upres, target_val=0, delta=27, label='U-PRES')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  solid; solid.rea
-####################################################################
-
-class Solid(NekTestCase):
-    example_subdir = 'solid'
-    case_name = 'solid'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @unittest.expectedFailure
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        phrase = self.get_phrase_from_log(label='ABORT: ')
-        self.assertIsNotNullDelayed(phrase, label='ABORT: ')
-        self.assertDelayedFailures()
-
-    @unittest.expectedFailure
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        phrase = self.get_phrase_from_log(label='ABORT: ')
-        self.assertIsNotNullDelayed(phrase, label='ABORT: ')
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        error = self.get_value_from_log('error', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(error, target_val=7.821228E-05, delta=1e-06, label='error')
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        error = self.get_value_from_log('error', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(error, target_val=7.821228E-05, delta=1e-06, label='error')
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  shear4; shear4.rea, thin.rea
-####################################################################
-
-class Shear4_Shear4(NekTestCase):
-    example_subdir = 'shear4'
-    case_name = 'shear4'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=10., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=26., label='gmres')
-
-        vort = self.get_value_from_log('peak vorticity', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(vort, target_val=3.031328E+01, delta=1e-06, label='peak vorticity')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=26., label='gmres')
-
-        vort = self.get_value_from_log('peak vorticity', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(vort, target_val=3.031328E+01, delta=1e-06, label='peak vorticity')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=10., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=17., label='gmres')
-
-        vort = self.get_value_from_log('peak vorticity', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(vort, target_val=3.031328E+01, delta=1e-06, label='peak vorticity')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=17., label='gmres')
-
-        vort = self.get_value_from_log('peak vorticity', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(vort, target_val=3.031328E+01, delta=1e-06, label='peak vorticity')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-class Shear4_Thin(NekTestCase):
-    example_subdir = 'shear4'
-    case_name = 'thin'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=10., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=26., label='gmres')
-
-        vort = self.get_value_from_log('peak vorticity', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(vort, target_val=9.991753E+01, delta=1e-06, label='peak vorticity')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=26., label='gmres')
-
-        vort = self.get_value_from_log('peak vorticity', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(vort, target_val=9.991753E+01, delta=1e-06, label='peak vorticity')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=10., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=17., label='gmres')
-
-        vort = self.get_value_from_log('peak vorticity', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(vort, target_val=9.991556E+01, delta=1e-06, label='peak vorticity')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=17., label='gmres')
-
-        vort = self.get_value_from_log('peak vorticity', column=-3, row=-1)
-        self.assertAlmostEqualDelayed(vort, target_val=9.991556E+01, delta=1e-06, label='peak vorticity')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  taylor; taylor.rea
-####################################################################
-
-class Taylor(NekTestCase):
-    example_subdir = 'taylor'
-    case_name = 'taylor'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=23., label='gmres')
-
-        tq = self.get_value_from_log('tq', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(tq, target_val=4.13037E-06, delta=1e-06, label='tq')
-
-        err = self.get_value_from_log('err', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(err, target_val=2.973648E-09, delta=1e-06, label='err')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=23., label='gmres')
-
-        tq = self.get_value_from_log('tq', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(tq, target_val=4.13037E-06, delta=1e-06, label='tq')
-
-        err = self.get_value_from_log('err', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(err, target_val=2.973648E-09, delta=1e-06, label='err')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=14, label='gmres')
-
-        tq = self.get_value_from_log('tq', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(tq, target_val=4.10783E-06, delta=1e-06, label='tq')
-
-        err = self.get_value_from_log('err', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(err, target_val=2.826284E-10, delta=1e-06, label='err')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=14, label='gmres')
-
-        tq = self.get_value_from_log('tq', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(tq, target_val=4.10783E-06, delta=1e-06, label='tq')
-
-        err = self.get_value_from_log('err', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(err, target_val=2.826284E-10, delta=1e-06, label='err')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
 
 ####################################################################
 #  var_vis; var_vis.rea
@@ -2942,13 +914,49 @@ class VarVis(NekTestCase):
     case_name = 'st2'
 
     def setUp(self):
+        self.size_params = dict(
+            ldim      = '2',
+            lx1       = '8',
+            lxd       = '12',
+            lx2       = 'lx1-2',
+            lx1m      = 'lx1',
+            lelg      = '4100',
+            lp        = '512',
+            lelt      = '300',
+            ldimt     = '2',
+            lelx      = '20',
+            lely      = '20',
+            lelz      = '1',
+            ax1       = 'lx1',
+            ax2       = 'lx2',
+            lbx1      = '1',
+            lbx2      = '1',
+            lbelt     = '1',
+            lpx1      = '1',
+            lpx2      = '1',
+            lpelt     = '1',
+            lpert     = '1',
+            lelecmt   = '',
+            toteq     = '',
+            mxprev    = '20',
+            lgmres    = '30',
+            lorder    = '3',
+            lhis      = '100',
+            maxobj    = '4',
+            maxmbr    = 'lelt*6',
+            nsessmax  = '',
+            nmaxl     = '',
+            nfldmax   = '',
+            nmaxcom   = '',
+        )
         self.build_tools(['genmap'])
         self.run_genmap()
 
     @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2'] = 'lx1'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -2960,7 +968,8 @@ class VarVis(NekTestCase):
     @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.size_params['lx2'] = 'lx1'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -2971,7 +980,8 @@ class VarVis(NekTestCase):
 
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2'] = 'lx1-2'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
@@ -2985,204 +995,13 @@ class VarVis(NekTestCase):
 
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.size_params['lx2'] = 'lx1-2'
+        self.config_size()
         self.build_nek()
         self.run_nek(step_limit=None)
 
         gmres = self.get_value_from_log('gmres ', column=-6)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=19, label='gmres')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  vortex; r1854a.rea
-####################################################################
-
-class Vortex(NekTestCase):
-    example_subdir = 'vortex'
-    case_name = 'r1854a'
-
-    def setUp(self):
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=60., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=65., label='gmres')
-
-        vmin = self.get_value_from_log('VMIN', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(vmin, target_val=-1.910312E-03, delta=1e-05, label='VMIN')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        gmres = self.get_value_from_log('gmres ', column=-7)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=65., label='gmres')
-
-        vmin = self.get_value_from_log('VMIN', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(vmin, target_val=-1.910312E-03, delta=1e-05, label='VMIN')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=50., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=18., label='gmres')
-
-        vmin = self.get_value_from_log('VMIN', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(vmin, target_val=-1.839120E-03, delta=1e-05, label='VMIN')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1-2')
-        self.build_nek()
-        self.run_nek(step_limit=10)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=50., label='total solver time')
-
-        gmres = self.get_value_from_log('gmres ', column=-6)
-        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=18., label='gmres')
-
-        vmin = self.get_value_from_log('VMIN', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(vmin, target_val=-1.839120E-03, delta=1e-05, label='VMIN')
-
-        self.assertDelayedFailures()
-
-    def tearDown(self):
-        self.move_logs()
-
-####################################################################
-#  vortex2; v2d
-####################################################################
-
-class Vortex2(NekTestCase):
-    example_subdir = 'vortex2'
-    case_name = 'v2d'
-
-    def setUp(self):
-        import re
-        self.build_tools(['genmap'])
-        self.run_genmap()
-
-        # Tweak .rea file
-        rea_file_path = os.path.join(self.examples_root, self.__class__.example_subdir, self.case_name + '.rea')
-        with open(rea_file_path, 'r') as f:
-            lines = [re.sub(r'(^\s+[\d.]+\s+p11.*$)', r' 8000\g<1>', l) for l in f]
-        with open(rea_file_path, 'w') as f:
-            f.writelines(lines)
-
-        # Extra tweaks to the SIZE file
-        size_file_path = os.path.join(self.examples_root, self.__class__.example_subdir, 'SIZE')
-        with open(size_file_path, 'r') as f:
-            lines = f.readlines()
-
-        lines = [re.sub(
-            r'( {6}parameter *)\(lx1=10,ly1=lx1,lz1=1,lelt=80,lelv=lelt\)( *)',
-            r'\g<1>(lx1=8,ly1=lx1,lz1=1,lelt=80,lelv=lelt)\g<2>', l, flags=re.I) for l in lines]
-        lines = [re.sub(
-            r'( {6}parameter *)\(lxd=15,lyd=lxd,lzd=1\)( *)',
-            r'\g<1>(lxd=12,lyd=lxd,lzd=1)\g<2>', l, flags=re.I) for l in lines]
-
-        with open(size_file_path, 'w') as f:
-            f.writelines(lines)
-
-    @pn_pn_serial
-    def test_PnPn_Serial(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=80, label='total solver time')
-
-        pres = self.get_value_from_log('PRES ', column=-4)
-        self.assertAlmostEqualDelayed(pres, target_val=0., delta=100., label='PRES')
-
-        umin = self.get_value_from_log('umin', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(umin, target_val=-1.453402E-03, delta=1e-03, label='umin')
-
-        torqx = self.get_value_from_log('torqx', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(torqx, target_val=-1.7399905E-07, delta=1e-06, label='torqx')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_parallel
-    def test_PnPn_Parallel(self):
-        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        pres = self.get_value_from_log('PRES ', column=-4)
-        self.assertAlmostEqualDelayed(pres, target_val=0., delta=100., label='PRES')
-
-        umin = self.get_value_from_log('umin', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(umin, target_val=-1.453402E-03, delta=1e-03, label='umin')
-
-        torqx = self.get_value_from_log('torqx', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(torqx, target_val=-1.7399905E-07, delta=1e-06, label='torqx')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_serial
-    def test_PnPn2_Serial(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        solver_time = self.get_value_from_log('total solver time', column=-2)
-        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=80., label='total solver time')
-
-        upress = self.get_value_from_log('U-Press', column=-5)
-        self.assertAlmostEqualDelayed(upress, target_val=0., delta=100, label='U-Press')
-
-        umin = self.get_value_from_log('umin', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(umin, target_val=-2.448980E-03, delta=1e-03, label='umin')
-
-        torqx = self.get_value_from_log('torqx', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(torqx, target_val=-1.6276138E-07, delta=1e-06, label='torqx')
-
-        self.assertDelayedFailures()
-
-    @pn_pn_2_parallel
-    def test_PnPn2_Parallel(self):
-        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
-        self.build_nek()
-        self.run_nek(step_limit=None)
-
-        upress = self.get_value_from_log('U-Press', column=-5)
-        self.assertAlmostEqualDelayed(upress, target_val=0., delta=100, label='U-Press')
-
-        umin = self.get_value_from_log('umin', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(umin, target_val=-2.448980E-03, delta=1e-03, label='umin')
-
-        torqx = self.get_value_from_log('torqx', column=-2, row=-1)
-        self.assertAlmostEqualDelayed(torqx, target_val=-1.6276138E-07, delta=1e-06, label='torqx')
 
         self.assertDelayedFailures()
 

--- a/short_tests/README.md
+++ b/short_tests/README.md
@@ -1,8 +1,91 @@
-# Nek5000 Short Tests
+NekTests
+========
+Nek unittests
+-------------
 
-This directory contains a small subset of tests which could be useful for quick
-verification or regression testing.  For example, the 
-[Nek5000 Travis tests](https://travis-ci.org/Nek5000/Nek5000) will run these
-tests upon a pull request in GitHub.  The full set of Nek5000 examples 
-(including these) are available in a separate repo,
-[NekExamples](https://github.com/Nek5000/NekExamples).
+The NekUnitTests.py module contains the Nek5000 verification tests, implmented 
+using the Python standard-library unittests framework.  The modules require 
+Python 2.7 or higher.  
+
+### Quick Start
+
+NekTests may be run as a standalone executable or as a unittest module.
+The standalone executable may be run as:
+
+`$ ./NekTests.py [-h] [--f77 F77] [--cc CC] [--ifmpi {true,false}] [--nprocs NPROCS] [-v]
+`
+
+with the following optional arguments:
+optional arguments:
+*  -h, --help: show this help message and exit
+*  --f77:  The Fortran 77 compiler to use (default: mpif77)
+*  --cc:  The C compiler to use (default: mpicc_
+*  --ifmpi {true,false}:  Enable/disable parallel tests with MPI (default: true)
+*  --nprocs NPROCS:  Number of processes to use for MPI tests (default: 4)
+*  -v, --verbose:  Enable verbose output
+
+The unittest module itself is described below.
+
+### Module Contents
+
+The module contains a separate class for each test problem.  The classes are:
+* Axi
+* Benard_Ray9
+* Benard_RayDD
+* Benard_RayDN
+* Benard_RayNN
+* Eddy_EddyUv
+* KovStState
+* LowMachTest
+* VarVis
+
+Each class also contains four methods for different formulations and
+parallelization modes:
+* test_PnPn_Serial
+* test_PnPn_Parallel
+* test_PnPn2_Serial
+* test_PnPn2_Parallel
+
+### Running unittest Modules
+
+The tests may be run using the Python standard-library 'unittest' module, which
+requires no additional dependencies.  The tests may also be run with any
+third-party testing tool compatable with unittest, such as nose, py.test,
+TwistedTrial, and others.  
+
+#### Environment
+
+Before running the tests, these environment variables should be defined:
+
+* `SOURCE_ROOT`: Points to the top-level Nek5000 repository. For example, 
+  `$HOME/Nek5000`.
+* `CC`: The C compiler you wish to use (default: gcc).
+* `F77`: The Fortran 77 compiler you wish to use (default gfortran).
+* `IFMPI=[true|false]`: If true, run tests with MPI. (default: true)
+* `PARALLEL_PROCS`: The number of processes to use when running with MPI
+  (default: 2)
+
+These environment variables may optionally be defined:
+* `EXAMPLES_ROOT`: Points to an alternate Nek5000 examples directory.  For
+   example, `$HOME/NekExamples`. (default: this directory)
+* `TOOLS_ROOT`: Points to an alternate directory for Nek5000 tools. (default:
+   $SOURCE_ROOT/tools)
+* `SCRIPTS_ROOT`: Points to an alternate directory Nek5000 scripts directory. 
+* `TOOLS_BIN`: If defined, compile tools in this directory. (default: `$TOOLS_ROOT/bin`)
+* `LOG_ROOT`: If defined, move complted logs into this directory.  If not defined,
+  leave logs in the example folders.  (default: undefined)
+* `VERBOSE_TESTS=[true|false]`: If true, display standard output from compiler and
+   Nek5000 to terminal window.  Standard output will always be recorded in
+   logfiles, whether VERBOSE_TESTS is true or false.  (default: false)
+
+#### unittest
+
+To run all the tests, first `cd` into this directory and then run:
+`$ python -m 'unittest' NekUnitTests`
+
+If you wish to run tests for one example problem (for example, "TurbChannel"), run:
+`$ python -m 'unittest' NekUnitTests.TurbChannel`
+
+If you wish to run tests for one example problem and one
+formulation/parallelization (for example, test_PnPn_Serial), run:
+`$ python -m 'unittest' NekUnitTests.TurbChannel.test_PnPn_Serial`

--- a/short_tests/README.md
+++ b/short_tests/README.md
@@ -55,22 +55,15 @@ TwistedTrial, and others.
 
 #### Environment
 
-Before running the tests, these environment variables should be defined:
-
-* `SOURCE_ROOT`: Points to the top-level Nek5000 repository. For example, 
-  `$HOME/Nek5000`.
-* `CC`: The C compiler you wish to use (default: gcc).
-* `F77`: The Fortran 77 compiler you wish to use (default gfortran).
+Before running the tests, these environment variables may be optionally defined:
+* `SOURCE_ROOT`: Points to the top-level Nek5000 repository. 
+* `CC`: The C compiler you wish to use (default: mpicc).
+* `F77`: The Fortran 77 compiler you wish to use (default mpif77).
 * `IFMPI=[true|false]`: If true, run tests with MPI. (default: true)
 * `PARALLEL_PROCS`: The number of processes to use when running with MPI
-  (default: 2)
-
-These environment variables may optionally be defined:
-* `EXAMPLES_ROOT`: Points to an alternate Nek5000 examples directory.  For
-   example, `$HOME/NekExamples`. (default: this directory)
-* `TOOLS_ROOT`: Points to an alternate directory for Nek5000 tools. (default:
-   $SOURCE_ROOT/tools)
-* `SCRIPTS_ROOT`: Points to an alternate directory Nek5000 scripts directory. 
+  (default: 4)
+* `EXAMPLES_ROOT`: Points to an alternate Nek5000 examples directory (default: this directory)
+* `TOOLS_ROOT`: Points to an alternate directory for Nek5000 tools. (default: $SOURCE_ROOT/tools)
 * `TOOLS_BIN`: If defined, compile tools in this directory. (default: `$TOOLS_ROOT/bin`)
 * `LOG_ROOT`: If defined, move complted logs into this directory.  If not defined,
   leave logs in the example folders.  (default: undefined)

--- a/short_tests/axi/SIZE
+++ b/short_tests/axi/SIZE
@@ -1,99 +1,37 @@
-C     Dimension file to be included
-C
-C     HCUBE array dimensions
-C
-      parameter (ldim=2)
-      parameter (lx1=6,ly1=lx1,lz1=1,lelt=80,lelv=lelt)
-      parameter (lxd=9,lyd=lxd,lzd=1)
-      parameter (lelx=20,lely=60,lelz=1)
- 
-      parameter (lzl=3 + 2*(ldim-3))
- 
-      parameter (lx2=lx1-2)
-      parameter (ly2=ly1-2)
-      parameter (lz2=1)
-      parameter (lx3=lx2)
-      parameter (ly3=ly2)
-      parameter (lz3=lz2)
+c
+c     Include file to dimension static arrays
+c     and to set some hardwired run-time parameters
+c
+      integer ldim,lx1,lxd,lx2,lx1m,lelg,lp,lelt,ldimt
+      integer ax1,ax2,lpx1,lpx2,lpelt,lbx1,lbx2,lbelt
+      integer lelcmt,toteq
+      integer lelx,lely,lelz,mxprev,lgmres,lorder,lhis
+      integer maxobj,maxmbr,lpert,nsessmax,nmaxl,nfldmax,nmaxcom
 
-      parameter (lp = 8)                         !max number of processor
-      parameter (lelg = 300)                        
-c
-c     parameter (lpelv=lelv,lpelt=lelt,lpert=3)  ! perturbation
-c     parameter (lpx1=lx1,lpy1=ly1,lpz1=lz1)     ! array sizes
-c     parameter (lpx2=lx2,lpy2=ly2,lpz2=lz2)
-c
-      parameter (lpelv=1,lpelt=1,lpert=1)        ! perturbation
-      parameter (lpx1=1,lpy1=1,lpz1=1)           ! array sizes
-      parameter (lpx2=1,lpy2=1,lpz2=1)
-c
-c     parameter (lbelv=lelv,lbelt=lelt)          ! MHD
-c     parameter (lbx1=lx1,lby1=ly1,lbz1=lz1)     ! array sizes
-c     parameter (lbx2=lx2,lby2=ly2,lbz2=lz2)
-c
-      parameter (lbelv=1,lbelt=1)                ! MHD
-      parameter (lbx1=1,lby1=1,lbz1=1)           ! array sizes
-      parameter (lbx2=1,lby2=1,lbz2=1)
- 
-c     LX1M=LX1 when there are moving meshes; =1 otherwise
-      parameter (lx1m=lx1,ly1m=ly1,lz1m=lz1)
-      parameter (ldimt= 4)                       ! 3 passive scalars + T
-      parameter (ldimt1=ldimt+1)
-      parameter (ldimt3=ldimt+3)
-c
-c     Note:  In the new code, LELGEC should be about sqrt(LELG)
-c
-      PARAMETER (LELGEC = 1)
-      PARAMETER (LXYZ2  = 1)
-      PARAMETER (LXZ21  = 1)
- 
-      PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
-      PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
-      PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
-      PARAMETER (LXZ=LX1*LZ1)
-      PARAMETER (LORDER=3)
-      PARAMETER (MAXOBJ=4,MAXMBR=LELT*6)
-      PARAMETER (lhis=100)         ! # of pts a proc reads from hpts.in 
-                                   ! Note: lhis*np > npoints in hpts.in
-C
-C     Common Block Dimensions
-C
-      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)
-      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
-C
-C     The parameter LVEC controls whether an additional 42 field arrays
-C     are required for Steady State Solutions.  If you are not using
-C     Steady State, it is recommended that LVEC=1.
-C
-      PARAMETER (LVEC=1)
-C
-C     Uzawa projection array dimensions
-C
-      parameter (mxprev = 80)
-      parameter (lgmres = 40)
-C
-C     Split projection array dimensions
-C
-      parameter(lmvec = 1)
-      parameter(lsvec = 1)
-      parameter(lstore=lmvec*lsvec)
-c
-c     NONCONFORMING STUFF
-c
-      parameter (maxmor = lelt)
-C
-C     Array dimensions
-C
-      COMMON/DIMN/NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
-     $,NX3,NY3,NZ3,NDIM,NFIELD,NPERT,NID
-     $,NXD,NYD,NZD
+      ! GENERAL
+      parameter (ldim=2)        ! domain dimension
+      parameter (lx1=6)         ! polynomial order; in 2D set lz1=1
+      parameter (lxd=9)        ! polynomial order for over-integration 
+      parameter (lx2=lx1-2)     ! polynomial order for pressure
+      parameter (lx1m=lx1)        ! polynomial order mesh solver; =1 no mesh motion
 
-c automatically added by makenek
-      parameter(lxo   = lx1) ! max output grid size (lxo>=lx1)
+      parameter (lelg=300)     ! max total number of elements
+      parameter (lp=8)       ! max number of MPI ranks
+      parameter (lelt=80)      ! max number of elements per MPI rank 
+      parameter (ldimt=4)       ! max number of auxiliary fields (temperature + scalars)
 
-c automatically added by makenek
-      parameter(lpart = 1  ) ! max number of particles
+      ! OPTIONAL
+      parameter (lelx=20,lely=60,lelz=1)          ! global tensor mesh dimensions
+      parameter (ax1=lx1,ax2=lx2)                   ! averages
+      parameter (lbx1=1,lbx2=1,lbelt=1)         ! mhd
+      parameter (lpx1=1,lpx2=1,lpelt=1,lpert=1) ! linear stability
+      parameter (lelcmt=1,toteq=1)              ! cmt
 
-c automatically added by makenek
-      integer ax1,ay1,az1,ax2,ay2,az2
-      parameter (ax1=lx1,ay1=ly1,az1=lz1,ax2=lx2,ay2=ly2,az2=lz2) ! running averages
+      parameter (mxprev=80,lgmres=40)           ! projection + Krylov space dimension
+      parameter (lorder=3)                      ! upper limit for order in time
+      parameter (lhis=100)                      ! max intp points per MPI rank
+      parameter (maxobj=4,maxmbr=lelt*6)        ! max number number of objects
+      parameter (nsessmax=1,nmaxl=1,nfldmax=1,nmaxcom=1) ! multimesh parameters
+
+      ! INTERNALS
+      include 'SIZE.h'

--- a/short_tests/benard/SIZE
+++ b/short_tests/benard/SIZE
@@ -1,99 +1,37 @@
-C     Dimension file to be included
-C
-C     HCUBE array dimensions
-C
-      parameter (ldim=2)
-      parameter (lx1=8,ly1=lx1,lz1=1,lelt=200,lelv=lelt)
-      parameter (lxd=12,lyd=lxd,lzd=1)
-      parameter (lelx=1,lely=1,lelz=1)
- 
-      parameter (lzl=3 + 2*(ldim-3))
- 
-      parameter (lx2=lx1-2)
-      parameter (ly2=ly1-2)
-      parameter (lz2=lz1  )
-      parameter (lx3=lx1)
-      parameter (ly3=ly1)
-      parameter (lz3=lz1)
+c
+c     Include file to dimension static arrays
+c     and to set some hardwired run-time parameters
+c
+      integer ldim,lx1,lxd,lx2,lx1m,lelg,lp,lelt,ldimt
+      integer ax1,ax2,lpx1,lpx2,lpelt,lbx1,lbx2,lbelt
+      integer lelcmt,toteq
+      integer lelx,lely,lelz,mxprev,lgmres,lorder,lhis
+      integer maxobj,maxmbr,lpert,nsessmax,nmaxl,nfldmax,nmaxcom
 
-      parameter (lp   = 512)
-      parameter (lelg = 5000)
-c
-c     parameter (lpelv=lelv,lpelt=lelt,lpert=3)  ! perturbation
-c     parameter (lpx1=lx1,lpy1=ly1,lpz1=lz1)     ! array sizes
-c     parameter (lpx2=lx2,lpy2=ly2,lpz2=lz2)
-c
-      parameter (lpelv=1,lpelt=1,lpert=1)        ! perturbation
-      parameter (lpx1=1,lpy1=1,lpz1=1)           ! array sizes
-      parameter (lpx2=1,lpy2=1,lpz2=1)
-c
-c     parameter (lbelv=lelv,lbelt=lelt)          ! MHD
-c     parameter (lbx1=lx1,lby1=ly1,lbz1=lz1)     ! array sizes
-c     parameter (lbx2=lx2,lby2=ly2,lbz2=lz2)
-c
-      parameter (lbelv=1,lbelt=1)                ! MHD
-      parameter (lbx1=1,lby1=1,lbz1=1)           ! array sizes
-      parameter (lbx2=1,lby2=1,lbz2=1)
- 
-C     LX1M=LX1 when there are moving meshes; =1 otherwise
-      parameter (lx1m=1,ly1m=1,lz1m=1)
-      parameter (ldimt= 1)                       ! 3 passive scalars + T
-      parameter (ldimt1=ldimt+1)
-      parameter (ldimt3=ldimt+3)
-c
-c     Note:  In the new code, LELGEC should be about sqrt(LELG)
-c
-      PARAMETER (LELGEC = 1)
-      PARAMETER (LXYZ2  = 1)
-      PARAMETER (LXZ21  = 1)
- 
-      PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
-      PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
-      PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
-      PARAMETER (LXZ=LX1*LZ1)
-      PARAMETER (LORDER=3)
-      PARAMETER (MAXOBJ=4,MAXMBR=LELT*6)
-      PARAMETER (lhis=100)         ! # of pts a proc reads from hpts.in
-                                   ! Note: lhis*np > npoints in hpts.in
-C
-C     Common Block Dimensions
-C
-      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)
-      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
-C
-C     The parameter LVEC controls whether an additional 42 field arrays
-C     are required for Steady State Solutions.  If you are not using
-C     Steady State, it is recommended that LVEC=1.
-C
-      PARAMETER (LVEC=1)
-C
-C     Uzawa projection array dimensions
-C
-      parameter (mxprev = 20)
-      parameter (lgmres = 20)
-C
-C     Split projection array dimensions
-C
-      parameter(lmvec = 1)
-      parameter(lsvec = 1)
-      parameter(lstore=lmvec*lsvec)
-c
-c     NONCONFORMING STUFF
-c
-      parameter (maxmor = lelt)
-C
-C     Array dimensions
-C
-      COMMON/DIMN/NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
-     $,NX3,NY3,NZ3,NDIM,NFIELD,NPERT,NID
-     $,NXD,NYD,NZD
+      ! GENERAL
+      parameter (ldim=2)        ! domain dimension
+      parameter (lx1=8)         ! polynomial order; in 2D set lz1=1
+      parameter (lxd=12)        ! polynomial order for over-integration 
+      parameter (lx2=lx1-2)     ! polynomial order for pressure
+      parameter (lx1m=1)        ! polynomial order mesh solver; =1 no mesh motion
 
-c automatically added by makenek
-      parameter(lxo   = lx1) ! max output grid size (lxo>=lx1)
+      parameter (lelg=5000)     ! max total number of elements
+      parameter (lp=512)       ! max number of MPI ranks
+      parameter (lelt=200)      ! max number of elements per MPI rank 
+      parameter (ldimt=1)       ! max number of auxiliary fields (temperature + scalars)
 
-c automatically added by makenek
-      parameter(lpart = 1  ) ! max number of particles
+      ! OPTIONAL
+      parameter (lelx=1,lely=1,lelz=1)          ! global tensor mesh dimensions
+      parameter (ax1=lx1,ax2=lx2)                   ! averages
+      parameter (lbx1=1,lbx2=1,lbelt=1)         ! mhd
+      parameter (lpx1=1,lpx2=1,lpelt=1,lpert=1) ! linear stability
+      parameter (lelcmt=1,toteq=1)              ! cmt
 
-c automatically added by makenek
-      integer ax1,ay1,az1,ax2,ay2,az2
-      parameter (ax1=lx1,ay1=ly1,az1=lz1,ax2=lx2,ay2=ly2,az2=lz2) ! running averages
+      parameter (mxprev=20,lgmres=20)           ! projection + Krylov space dimension
+      parameter (lorder=3)                      ! upper limit for order in time
+      parameter (lhis=100)                      ! max intp points per MPI rank
+      parameter (maxobj=4,maxmbr=lelt*6)        ! max number number of objects
+      parameter (nsessmax=1,nmaxl=1,nfldmax=1,nmaxcom=1) ! multimesh parameters
+
+      ! INTERNALS
+      include 'SIZE.h'

--- a/short_tests/eddy/SIZE
+++ b/short_tests/eddy/SIZE
@@ -1,99 +1,37 @@
-C     Dimension file to be included
-C
-C     HCUBE array dimensions
-C
-      parameter (ldim=2)
-      parameter (lx1=8,ly1=lx1,lz1=1,lelt=300,lelv=lelt)
-      parameter (lxd=12,lyd=lxd,lzd=1)
-      parameter (lelx=20,lely=20,lelz=1)
- 
-      parameter (lzl=3 + 2*(ldim-3))
- 
-      parameter (lx2=lx1-2)
-      parameter (ly2=ly1-2)
-      parameter (lz2=lz1  )
-      parameter (lx3=lx1)
-      parameter (ly3=ly1)
-      parameter (lz3=lz1)
+c
+c     Include file to dimension static arrays
+c     and to set some hardwired run-time parameters
+c
+      integer ldim,lx1,lxd,lx2,lx1m,lelg,lp,lelt,ldimt
+      integer ax1,ax2,lpx1,lpx2,lpelt,lbx1,lbx2,lbelt
+      integer lelcmt,toteq
+      integer lelx,lely,lelz,mxprev,lgmres,lorder,lhis
+      integer maxobj,maxmbr,lpert,nsessmax,nmaxl,nfldmax,nmaxcom
 
-      parameter (lp = 512)
-      parameter (lelg = 4100)
-c
-c     parameter (lpelv=lelv,lpelt=lelt,lpert=3)  ! perturbation
-c     parameter (lpx1=lx1,lpy1=ly1,lpz1=lz1)     ! array sizes
-c     parameter (lpx2=lx2,lpy2=ly2,lpz2=lz2)
-c
-      parameter (lpelv=1,lpelt=1,lpert=1)        ! perturbation
-      parameter (lpx1=1,lpy1=1,lpz1=1)           ! array sizes
-      parameter (lpx2=1,lpy2=1,lpz2=1)
-c
-c     parameter (lbelv=lelv,lbelt=lelt)          ! MHD
-c     parameter (lbx1=lx1,lby1=ly1,lbz1=lz1)     ! array sizes
-c     parameter (lbx2=lx2,lby2=ly2,lbz2=lz2)
-c
-      parameter (lbelv=1,lbelt=1)                ! MHD
-      parameter (lbx1=1,lby1=1,lbz1=1)           ! array sizes
-      parameter (lbx2=1,lby2=1,lbz2=1)
- 
-C     LX1M=LX1 when there are moving meshes; =1 otherwise
-      parameter (lx1m=1,ly1m=1,lz1m=1)
-      parameter (ldimt= 2)                       ! 2 passive scalars + T
-      parameter (ldimt1=ldimt+1)
-      parameter (ldimt3=ldimt+3)
-c
-c     Note:  In the new code, LELGEC should be about sqrt(LELG)
-c
-      PARAMETER (LELGEC = 1)
-      PARAMETER (LXYZ2  = 1)
-      PARAMETER (LXZ21  = 1)
- 
-      PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
-      PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
-      PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
-      PARAMETER (LXZ=LX1*LZ1)
-      PARAMETER (LORDER=3)
-      PARAMETER (MAXOBJ=4,MAXMBR=LELT*6)
-      PARAMETER (lhis=100)         ! # of pts a proc reads from hpts.in
-                                   ! Note: lhis*np > npoints in hpts.in
-C
-C     Common Block Dimensions
-C
-      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)
-      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
-C
-C     The parameter LVEC controls whether an additional 42 field arrays
-C     are required for Steady State Solutions.  If you are not using
-C     Steady State, it is recommended that LVEC=1.
-C
-      PARAMETER (LVEC=1)
-C
-C     Uzawa projection array dimensions
-C
-      parameter (mxprev = 20)
-      parameter (lgmres = 30)
-C
-C     Split projection array dimensions
-C
-      parameter(lmvec = 1)
-      parameter(lsvec = 1)
-      parameter(lstore=lmvec*lsvec)
-c
-c     NONCONFORMING STUFF
-c
-      parameter (maxmor = lelt)
-C
-C     Array dimensions
-C
-      COMMON/DIMN/NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
-     $,NX3,NY3,NZ3,NDIM,NFIELD,NPERT,NID
-     $,NXD,NYD,NZD
+      ! GENERAL
+      parameter (ldim=2)        ! domain dimension
+      parameter (lx1=8)         ! polynomial order; in 2D set lz1=1
+      parameter (lxd=12)        ! polynomial order for over-integration 
+      parameter (lx2=lx1-2)     ! polynomial order for pressure
+      parameter (lx1m=1)        ! polynomial order mesh solver; =1 no mesh motion
 
-c automatically added by makenek
-      parameter(lxo   = lx1) ! max output grid size (lxo>=lx1)
+      parameter (lelg=4100)     ! max total number of elements
+      parameter (lp=512)       ! max number of MPI ranks
+      parameter (lelt=300)      ! max number of elements per MPI rank 
+      parameter (ldimt=2)       ! max number of auxiliary fields (temperature + scalars)
 
-c automatically added by makenek
-      parameter(lpart = 1  ) ! max number of particles
+      ! OPTIONAL
+      parameter (lelx=20,lely=20,lelz=1)          ! global tensor mesh dimensions
+      parameter (ax1=lx1,ax2=lx2)                   ! averages
+      parameter (lbx1=1,lbx2=1,lbelt=1)         ! mhd
+      parameter (lpx1=1,lpx2=1,lpelt=1,lpert=1) ! linear stability
+      parameter (lelcmt=1,toteq=1)              ! cmt
 
-c automatically added by makenek
-      integer ax1,ay1,az1,ax2,ay2,az2
-      parameter (ax1=lx1,ay1=ly1,az1=lz1,ax2=lx2,ay2=ly2,az2=lz2) ! running averages
+      parameter (mxprev=20,lgmres=30)           ! projection + Krylov space dimension
+      parameter (lorder=3)                      ! upper limit for order in time
+      parameter (lhis=100)                      ! max intp points per MPI rank
+      parameter (maxobj=4,maxmbr=lelt*6)        ! max number number of objects
+      parameter (nsessmax=1,nmaxl=1,nfldmax=1,nmaxcom=1) ! multimesh parameters
+
+      ! INTERNALS
+      include 'SIZE.h'

--- a/short_tests/kov_st_state/SIZE
+++ b/short_tests/kov_st_state/SIZE
@@ -1,105 +1,37 @@
-C     Dimension file to be included
-C
-C     HCUBE array dimensions
-C
-      parameter (ldim=2)
-      parameter (lx1=14,ly1=lx1,lz1=1,lelt=80,lelv=lelt)
-      parameter (lxd=20,lyd=lxd,lzd=1)
-      parameter (lelx=1,lely=1,lelz=1)
-
-      parameter (lzl=3 + 2*(ldim-3))
-
-      parameter (lx2=lx1-2)
-      parameter (ly2=ly1-2)
-      parameter (lz2=lz1)
-      parameter (lx3=lx2)
-      parameter (ly3=ly2)
-      parameter (lz3=lz2)
-
-      parameter (lp =    64)   ! upper limit for number of CPUs
-      parameter (lelg = 500)    ! upper limit for total number of elements
-
-c     parameter (lpelv=lelv,lpelt=lelt,lpert=3)  ! perturbation
-c     parameter (lpx1=lx1,lpy1=ly1,lpz1=lz1)     ! array sizes
-c     parameter (lpx2=lx2,lpy2=ly2,lpz2=lz2)
 c
-      parameter (lpelv=1,lpelt=1,lpert=1)        ! perturbation
-      parameter (lpx1=1,lpy1=1,lpz1=1)           ! array sizes
-      parameter (lpx2=1,lpy2=1,lpz2=1)
+c     Include file to dimension static arrays
+c     and to set some hardwired run-time parameters
 c
-c     parameter (lbelv=lelv,lbelt=lelt)          ! MHD
-c     parameter (lbx1=lx1,lby1=ly1,lbz1=lz1)     ! array sizes
-c     parameter (lbx2=lx2,lby2=ly2,lbz2=lz2)
-c
-      parameter (lbelv=1,lbelt=1)                ! MHD
-      parameter (lbx1=1,lby1=1,lbz1=1)           ! array sizes
-      parameter (lbx2=1,lby2=1,lbz2=1)
+      integer ldim,lx1,lxd,lx2,lx1m,lelg,lp,lelt,ldimt
+      integer ax1,ax2,lpx1,lpx2,lpelt,lbx1,lbx2,lbelt
+      integer lelcmt,toteq
+      integer lelx,lely,lelz,mxprev,lgmres,lorder,lhis
+      integer maxobj,maxmbr,lpert,nsessmax,nmaxl,nfldmax,nmaxcom
 
-C     LX1M=LX1 when there are moving meshes; =1 otherwise
-      parameter (lx1m=1,ly1m=1,lz1m=1)
-      parameter (ldimt= 1)              ! upper limit for passive scalars + T
-      parameter (ldimt1=ldimt+1)
-      parameter (ldimt3=ldimt+3)
-c
-c     Note:  In the new code, LELGEC should be about sqrt(LELG)
-c
-      PARAMETER (LELGEC = 1)
-      PARAMETER (LXYZ2  = 1)
-      PARAMETER (LXZ21  = 1)
+      ! GENERAL
+      parameter (ldim=2)        ! domain dimension
+      parameter (lx1=14)         ! polynomial order; in 2D set lz1=1
+      parameter (lxd=20)        ! polynomial order for over-integration 
+      parameter (lx2=lx1-2)     ! polynomial order for pressure
+      parameter (lx1m=1)        ! polynomial order mesh solver; =1 no mesh motion
 
-      PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
-      PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
-      PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
-      PARAMETER (LXZ=LX1*LZ1)
-      PARAMETER (LORDER=3)
-      PARAMETER (MAXOBJ=4,MAXMBR=LELT*6)
-      PARAMETER (lhis=100)         ! # of pts a proc reads from hpts.in
-                                   ! Note: lhis*np > npoints in hpts.in
-C
-C     Common Block Dimensions
-C
-      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)
-      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
-C
-C     The parameter LVEC controls whether an additional 42 field arrays
-C     are required for Steady State Solutions.  If you are not using
-C     Steady State, it is recommended that LVEC=1.
-C
-      PARAMETER (LVEC=1)
-C
-C     Uzawa projection array dimensions
-C
-      parameter (mxprev = 20)
-      parameter (lgmres = 40)
-C
-C     Split projection array dimensions
-C
-      parameter(lmvec = 1)
-      parameter(lsvec = 1)
-      parameter(lstore=lmvec*lsvec)
-c
-c     NONCONFORMING STUFF
-c
-      parameter (maxmor = lelt)
+      parameter (lelg=500)     ! max total number of elements
+      parameter (lp=64)       ! max number of MPI ranks
+      parameter (lelt=80)      ! max number of elements per MPI rank 
+      parameter (ldimt=1)       ! max number of auxiliary fields (temperature + scalars)
 
-C     Array dimensions
+      ! OPTIONAL
+      parameter (lelx=1,lely=1,lelz=1)          ! global tensor mesh dimensions
+      parameter (ax1=lx1,ax2=lx2)                   ! averages
+      parameter (lbx1=1,lbx2=1,lbelt=1)         ! mhd
+      parameter (lpx1=1,lpx2=1,lpelt=1,lpert=1) ! linear stability
+      parameter (lelcmt=1,toteq=1)              ! cmt
 
-      common/dimn/nelv,nelt,nx1,ny1,nz1,nx2,ny2,nz2
-     $,nx3,ny3,nz3,ndim,nfield,npert,nid
-     $,nxd,nyd,nzd
+      parameter (mxprev=20,lgmres=40)           ! projection + Krylov space dimension
+      parameter (lorder=3)                      ! upper limit for order in time
+      parameter (lhis=100)                      ! max intp points per MPI rank
+      parameter (maxobj=4,maxmbr=lelt*6)        ! max number number of objects
+      parameter (nsessmax=1,nmaxl=1,nfldmax=1,nmaxcom=1) ! multimesh parameters
 
-c automatically added by makenek
-      parameter(lxo   = lx1) ! max output grid size (lxo>=lx1)
-
-c automatically added by makenek
-      parameter(lpart = 1  ) ! max number of particles
-
-c automatically added by makenek
-      integer ax1,ay1,az1,ax2,ay2,az2
-      parameter (ax1=lx1,ay1=ly1,az1=lz1,ax2=lx2,ay2=ly2,az2=lz2) ! running averages
-
-c automatically added by makenek
-      parameter (lxs=1,lys=lxs,lzs=(lxs-1)*(ldim-2)+1) !New Pressure Preconditioner
-
-c automatically added by makenek
-      parameter (lfdm=0)  ! == 1 for fast diagonalization method
+      ! INTERNALS
+      include 'SIZE.h'

--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -67,23 +67,19 @@ def config_basics_inc(infile, outfile, nelm):
         f.writelines(lines)
 
 
-def config_size(infile, outfile, lx2=None, ly2=None, lz2=None):
+def config_size( infile, outfile, **kwargs ):
 
     with open(infile, 'r') as f:
         lines = f.readlines()
 
-    if lx2:
-        lines = [re.sub(r'(^ {6}parameter *\( *lx2 *= *)\S+?( *\))',
-                        r'\g<1>{0}\g<2>'.format(lx2), l, flags=re.I)
-                 for l in lines]
-    if ly2:
-        lines = [re.sub(r'(^ {6}parameter *\( *ly2 *= *)\S+?( *\))',
-                        r'\g<1>{0}\g<2>'.format(ly2), l, flags=re.I)
-                 for l in lines]
-    if lz2:
-        lines = [re.sub(r'(^ {6}parameter *\( *lz2 *= *)\S+?( *\))',
-                        r'\g<1>{0}\g<2>'.format(lz2), l, flags=re.I)
-                 for l in lines]
+    # Substitute all the variables
+    for key, value in kwargs.iteritems():
+        if value:
+            lines = [
+                re.sub(
+                    r'(.*\bparameter\b.*\b{0} *= *)\S+?( *[),])'.format(key),
+                    r'\g<1>{0}\g<2>'.format(value), l, flags=re.I)
+                for l in lines ]
 
     with open(outfile, 'w') as f:
         f.writelines(lines)

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -99,23 +99,22 @@ class NekTestCase(unittest.TestCase):
     """
     # Defined in subclasses only; declared here to make syntax checker happy
     example_subdir      = ""
-    case_name            = ""
+    case_name           = ""
 
     def __init__(self, *args, **kwargs):
         # These can be overridden by self.get_opts
-        self.f77            = "gfortran"
-        self.cc             = "gcc"
-        self.ifmpi          = False
-        self.verbose        = False
-        self.source_root    = ''
-        #self.examples_root  = os.path.join(os.path.dirname(inspect.getabsfile(self.__class__)), 'examples')
-        self.examples_root  = os.path.join(os.path.dirname(inspect.getabsfile(self.__class__)), 'examples')
+        self.f77            = 'mpif77'
+        self.cc             = 'mpicc'
+        self.ifmpi          = True
+        self.verbose        = True
+        self.source_root    = os.path.dirname(os.path.dirname(inspect.getabsfile(self.__class__)))
+        self.examples_root  = os.path.dirname(inspect.getabsfile(self.__class__))
         self.tools_root     = ''
         self.tools_bin      = ''
         self.log_root       = ''
         self.makenek        = ''
         self.serial_procs   = 1
-        self.parallel_procs = 2
+        self.parallel_procs = 4
         self.size_params    = {}
 
         # These are overridden by method decorators (pn_pn_serial, pn_pn_parallel,

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -116,6 +116,7 @@ class NekTestCase(unittest.TestCase):
         self.makenek        = ''
         self.serial_procs   = 1
         self.parallel_procs = 2
+        self.size_params    = {}
 
         # These are overridden by method decorators (pn_pn_serial, pn_pn_parallel,
         # pn_pn_2_serial, and pn_pn_2_parallel)
@@ -256,22 +257,16 @@ class NekTestCase(unittest.TestCase):
             verbose    = verbose    if verbose    else self.verbose
         )
 
-    def config_size(self, infile=None, outfile=None, lx2=None, ly2=None, lz2=None):
+    def config_size(self, infile=None, outfile=None, *args, **kwargs):
         from lib.nekFileConfig import config_size
         cls = self.__class__
 
         if not infile:
-            infile = os.path.join(self.examples_root, cls.example_subdir, 'SIZE')
+            infile = os.path.join(self.source_root, 'core', 'SIZE.template')
         if not outfile:
             outfile = os.path.join(self.examples_root, cls.example_subdir, 'SIZE')
 
-        config_size(
-            infile  = infile,
-            outfile = outfile,
-            lx2 = lx2,
-            ly2 = ly2,
-            lz2 = lz2
-        )
+        config_size(infile, outfile, *args, **kwargs)
 
     def run_genmap(self, rea_file=None, tol='0.5'):
 

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -265,8 +265,11 @@ class NekTestCase(unittest.TestCase):
             infile = os.path.join(self.source_root, 'core', 'SIZE.template')
         if not outfile:
             outfile = os.path.join(self.examples_root, cls.example_subdir, 'SIZE')
+        if not kwargs:
+            config_size(infile, outfile, *args, **self.size_params)
+        else:
+            config_size(infile, outfile, *args, **self.size_params)
 
-        config_size(infile, outfile, *args, **kwargs)
 
     def run_genmap(self, rea_file=None, tol='0.5'):
 

--- a/short_tests/lib/parseSize.py
+++ b/short_tests/lib/parseSize.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python2
+
+"""
+Takes stdin or a filenameand parses paramemter assignments.  Outputs parameters required by SIZE.template.
+
+To use:
+    $ cat SIZE | parseSize.py
+or
+    $ parseSize.py SIZE
+
+"""
+
+
+import fileinput
+import re
+params = {}
+
+for line in fileinput.input():
+    if not line.startswith(('c', 'C')):
+        for m in re.finditer(r'\b(?P<name>\w+)\b *= *(?P<value>(?:[a-z0-9\+\-\*/ \t]+|\([a-z0-9\+\-\*/ \t]+\))+)', line, re.I):
+            params[m.group('name').lower().strip()] = m.group('value').lower().strip()
+
+# print all
+for x in sorted(params):
+   print "{0} = {1}".format(x, params[x])
+
+# print only variables in size.template
+# template_params = [
+#             'ldim',
+#             'lx1',
+#             'lxd',
+#             'lx2',
+#             'lx1m',
+#             'lelg',
+#             'lp',
+#             'lelt',
+#             'ldimt',
+#             'lelx',
+#             'lely',
+#             'lelz',
+#             'ax1',
+#             'ax2',
+#             'lbx1',
+#             'lbx2',
+#             'lbelt',
+#             'lpx1',
+#             'lpx2',
+#             'lpelt',
+#             'lpert',
+#             'lelecmt',
+#             'toteq',
+#             'mxprev',
+#             'lgmres',
+#             'lorder',
+#             'lhis',
+#             'maxobj',
+#             'maxmbr',
+#             'nsessmax',
+#             'nmaxl',
+#             'nfldmax',
+#             'nmaxcom',
+# ]
+#
+# for x in template_params:
+#     print "{0} = {1}".format(x, params.get(x, None))
+
+

--- a/short_tests/lib/parseSize.py
+++ b/short_tests/lib/parseSize.py
@@ -1,67 +1,79 @@
 #!/usr/bin/env python2
 
 """
-Takes stdin or a filenameand parses paramemter assignments.  Outputs parameters required by SIZE.template.
+Takes stdin or a filename and parses FORTRAN variable assignments.  Prints assigned variables to stdout.  This is intended to be used for
 
 To use:
-    $ cat SIZE | parseSize.py
+    $ parseSize.py location/of/SIZE
 or
-    $ parseSize.py SIZE
+    $ cat location/of/SIZE | parseSize.py
 
 """
-
-
 import fileinput
 import re
-params = {}
 
-for line in fileinput.input():
-    if not line.startswith(('c', 'C')):
-        for m in re.finditer(r'\b(?P<name>\w+)\b *= *(?P<value>(?:[a-z0-9\+\-\*/ \t]+|\([a-z0-9\+\-\*/ \t]+\))+)', line, re.I):
-            params[m.group('name').lower().strip()] = m.group('value').lower().strip()
+def getSizeParams(files=None):
+    """ Parse variable assignments from a Nek5000 SIZE file.
 
-# print all
-for x in sorted(params):
-   print "{0} = {1}".format(x, params[x])
+    This is intended to be used for Nek5000 SIZE files but may work for other FORTRAN source files.
 
-# print only variables in size.template
-# template_params = [
-#             'ldim',
-#             'lx1',
-#             'lxd',
-#             'lx2',
-#             'lx1m',
-#             'lelg',
-#             'lp',
-#             'lelt',
-#             'ldimt',
-#             'lelx',
-#             'lely',
-#             'lelz',
-#             'ax1',
-#             'ax2',
-#             'lbx1',
-#             'lbx2',
-#             'lbelt',
-#             'lpx1',
-#             'lpx2',
-#             'lpelt',
-#             'lpert',
-#             'lelecmt',
-#             'toteq',
-#             'mxprev',
-#             'lgmres',
-#             'lorder',
-#             'lhis',
-#             'maxobj',
-#             'maxmbr',
-#             'nsessmax',
-#             'nmaxl',
-#             'nfldmax',
-#             'nmaxcom',
-# ]
-#
-# for x in template_params:
-#     print "{0} = {1}".format(x, params.get(x, None))
+    :param files: May be a list of filenames to parse sequentially.
+            * If None, then takes filenames from sys.argv[1:].
+            * If None and if sys.argv[1:] is None, then takes contents of stdin
+    :return:  A dict of {variable : value} pairs.  All variables are forced to lowercase.  All values are strings.
+    """
+    params = {}
+    for line in fileinput.input(files):
+        if not line.startswith(('c', 'C')):
+            for m in re.finditer(r'\b(?P<name>\w+)\b *= *(?P<value>(?:[a-z0-9\+\-\*/ \t]+|\([a-z0-9\+\-\*/ \t]+\))+)', line, re.I):
+                params[m.group('name').lower().strip()] = m.group('value').lower().strip()
+    return params
+
+if __name__ == '__main__':
+    params = getSizeParams()
+
+    # Print all params in alphabetical order.
+    for x in sorted(params):
+        print "{0} = {1}".format(x, params[x])
+
+    # Print only variables in SIZE.template in the order that they appear in SIZE.template
+    # template_params = [
+    #             'ldim',
+    #             'lx1',
+    #             'lxd',
+    #             'lx2',
+    #             'lx1m',
+    #             'lelg',
+    #             'lp',
+    #             'lelt',
+    #             'ldimt',
+    #             'lelx',
+    #             'lely',
+    #             'lelz',
+    #             'ax1',
+    #             'ax2',
+    #             'lbx1',
+    #             'lbx2',
+    #             'lbelt',
+    #             'lpx1',
+    #             'lpx2',
+    #             'lpelt',
+    #             'lpert',
+    #             'lelecmt',
+    #             'toteq',
+    #             'mxprev',
+    #             'lgmres',
+    #             'lorder',
+    #             'lhis',
+    #             'maxobj',
+    #             'maxmbr',
+    #             'nsessmax',
+    #             'nmaxl',
+    #             'nfldmax',
+    #             'nmaxcom',
+    # ]
+    #
+    # for x in template_params:
+    #     print "{0} = {1}".format(x, params.get(x, None))
 
 

--- a/short_tests/lowMach_test/SIZE
+++ b/short_tests/lowMach_test/SIZE
@@ -12,7 +12,7 @@ c
       parameter (ldim=2)        ! domain dimension
       parameter (lx1=14)         ! polynomial order; in 2D set lz1=1
       parameter (lxd=20)        ! polynomial order for over-integration 
-      parameter (lx2=lx1-0)     ! polynomial order for pressure
+      parameter (lx2=lx1-2)     ! polynomial order for pressure
       parameter (lx1m=1)        ! polynomial order mesh solver; =1 no mesh motion
 
       parameter (lelg=5000)     ! max total number of elements

--- a/short_tests/var_vis/SIZE
+++ b/short_tests/var_vis/SIZE
@@ -1,99 +1,37 @@
-C     Dimension file to be included
-C
-C     HCUBE array dimensions
-C
-      parameter (ldim=2)
-      parameter (lx1=8,ly1=lx1,lz1=1,lelt=300,lelv=lelt)
-      parameter (lxd=12,lyd=lxd,lzd=1)
-      parameter (lelx=20,lely=20,lelz=1)
- 
-      parameter (lzl=3 + 2*(ldim-3))
- 
-      parameter (lx2=lx1-2)
-      parameter (ly2=ly1-2)
-      parameter (lz2=lz1  )
-      parameter (lx3=lx1)
-      parameter (ly3=ly1)
-      parameter (lz3=lz1)
+c
+c     Include file to dimension static arrays
+c     and to set some hardwired run-time parameters
+c
+      integer ldim,lx1,lxd,lx2,lx1m,lelg,lp,lelt,ldimt
+      integer ax1,ax2,lpx1,lpx2,lpelt,lbx1,lbx2,lbelt
+      integer lelcmt,toteq
+      integer lelx,lely,lelz,mxprev,lgmres,lorder,lhis
+      integer maxobj,maxmbr,lpert,nsessmax,nmaxl,nfldmax,nmaxcom
 
-      parameter (lp = 512)
-      parameter (lelg = 4100)
-c
-c     parameter (lpelv=lelv,lpelt=lelt,lpert=3)  ! perturbation
-c     parameter (lpx1=lx1,lpy1=ly1,lpz1=lz1)     ! array sizes
-c     parameter (lpx2=lx2,lpy2=ly2,lpz2=lz2)
-c
-      parameter (lpelv=1,lpelt=1,lpert=1)        ! perturbation
-      parameter (lpx1=1,lpy1=1,lpz1=1)           ! array sizes
-      parameter (lpx2=1,lpy2=1,lpz2=1)
-c
-c     parameter (lbelv=lelv,lbelt=lelt)          ! MHD
-c     parameter (lbx1=lx1,lby1=ly1,lbz1=lz1)     ! array sizes
-c     parameter (lbx2=lx2,lby2=ly2,lbz2=lz2)
-c
-      parameter (lbelv=1,lbelt=1)                ! MHD
-      parameter (lbx1=1,lby1=1,lbz1=1)           ! array sizes
-      parameter (lbx2=1,lby2=1,lbz2=1)
- 
-C     LX1M=LX1 when there are moving meshes; =1 otherwise
-      parameter (lx1m=lx1,ly1m=ly1,lz1m=lz1)
-      parameter (ldimt= 2)                       ! 2 passive scalars + T
-      parameter (ldimt1=ldimt+1)
-      parameter (ldimt3=ldimt+3)
-c
-c     Note:  In the new code, LELGEC should be about sqrt(LELG)
-c
-      PARAMETER (LELGEC = 1)
-      PARAMETER (LXYZ2  = 1)
-      PARAMETER (LXZ21  = 1)
- 
-      PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
-      PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
-      PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
-      PARAMETER (LXZ=LX1*LZ1)
-      PARAMETER (LORDER=3)
-      PARAMETER (MAXOBJ=4,MAXMBR=LELT*6)
-      PARAMETER (lhis=100)         ! # of pts a proc reads from hpts.in
-                                   ! Note: lhis*np > npoints in hpts.in
-C
-C     Common Block Dimensions
-C
-      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)
-      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
-C
-C     The parameter LVEC controls whether an additional 42 field arrays
-C     are required for Steady State Solutions.  If you are not using
-C     Steady State, it is recommended that LVEC=1.
-C
-      PARAMETER (LVEC=1)
-C
-C     Uzawa projection array dimensions
-C
-      parameter (mxprev = 20)
-      parameter (lgmres = 30)
-C
-C     Split projection array dimensions
-C
-      parameter(lmvec = 1)
-      parameter(lsvec = 1)
-      parameter(lstore=lmvec*lsvec)
-c
-c     NONCONFORMING STUFF
-c
-      parameter (maxmor = lelt)
-C
-C     Array dimensions
-C
-      COMMON/DIMN/NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
-     $,NX3,NY3,NZ3,NDIM,NFIELD,NPERT,NID
-     $,NXD,NYD,NZD
+      ! GENERAL
+      parameter (ldim=2)        ! domain dimension
+      parameter (lx1=8)         ! polynomial order; in 2D set lz1=1
+      parameter (lxd=12)        ! polynomial order for over-integration 
+      parameter (lx2=lx1-2)     ! polynomial order for pressure
+      parameter (lx1m=lx1)        ! polynomial order mesh solver; =1 no mesh motion
 
-c automatically added by makenek
-      parameter(lxo   = lx1) ! max output grid size (lxo>=lx1)
+      parameter (lelg=4100)     ! max total number of elements
+      parameter (lp=512)       ! max number of MPI ranks
+      parameter (lelt=300)      ! max number of elements per MPI rank 
+      parameter (ldimt=2)       ! max number of auxiliary fields (temperature + scalars)
 
-c automatically added by makenek
-      parameter(lpart = 1  ) ! max number of particles
+      ! OPTIONAL
+      parameter (lelx=20,lely=20,lelz=1)          ! global tensor mesh dimensions
+      parameter (ax1=lx1,ax2=lx2)                   ! averages
+      parameter (lbx1=1,lbx2=1,lbelt=1)         ! mhd
+      parameter (lpx1=1,lpx2=1,lpelt=1,lpert=1) ! linear stability
+      parameter (lelcmt=1,toteq=1)              ! cmt
 
-c automatically added by makenek
-      integer ax1,ay1,az1,ax2,ay2,az2
-      parameter (ax1=lx1,ay1=ly1,az1=lz1,ax2=lx2,ay2=ly2,az2=lz2) ! running averages
+      parameter (mxprev=20,lgmres=30)           ! projection + Krylov space dimension
+      parameter (lorder=3)                      ! upper limit for order in time
+      parameter (lhis=100)                      ! max intp points per MPI rank
+      parameter (maxobj=4,maxmbr=lelt*6)        ! max number number of objects
+      parameter (nsessmax=1,nmaxl=1,nfldmax=1,nmaxcom=1) ! multimesh parameters
+
+      ! INTERNALS
+      include 'SIZE.h'


### PR DESCRIPTION
This PR introduces a number of updates to short_tests:
* When using the NekTests.py, the SIZE files for short_tests are generated from SIZE.template
* Each example in short_tests also contains a SIZE file based on SIZE.template, should any users want to run standalone Nek5000.   
* Users may run NekTests.py from the short_tests/ directory without setting any environment variables.  The defaults correspond to the current directory structure but may still be overriden; see short_tests/README for more info
* Users may run NekTests.py as a standalone executable with command-line arguments instead of env variables.  For example `./NekTests.py --f77 pgif77 --cc pgicc --ifmpi false`.  See short_tests/README for more info