### PR TITLE
Cvode build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,14 @@ before_install:
   - virtualenv -p python2.7 $ROOT_DIR/python2-env
   - source $ROOT_DIR/python2-env/bin/activate
   - export PYTHONPATH="$ROOT_DIR/short_tests:$PYTHONPATH"
+
+  - wget http://computation.llnl.gov/projects/sundials/download/cvode-2.9.0.tar.gz
+  - tar -zxf cvode-2.9.0.tar.gz
+  - mkdir -p cvode-2.9.0/build
+  - cd cvode-2.9.0/build
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/lib/cvode -DEXAMPLES_INSTALL=OFF -DMPI_ENABLE=ON -DFCMIX_ENABLE=ON -DBUILD_SHARED_LIBS=OFF ../
+  - make
+  - make install
  
 install:
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ before_install:
   - cmake -DCMAKE_INSTALL_PREFIX=$HOME/lib/cvode -DEXAMPLES_INSTALL=OFF -DMPI_ENABLE=ON -DFCMIX_ENABLE=ON -DBUILD_SHARED_LIBS=OFF ../
   - make
   - make install
+  - ls -R $HOME/lib
  
 install:
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
 
     - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e3
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e4
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e4 # Exceeds time limit for Travis jobs
 
 before_install: 
   - export ROOT_DIR=`pwd`

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,30 +4,8 @@ sudo: required
 
 env:
   matrix:
-    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Axi::test_PnPn_Serial
-    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Axi::test_PnPn2_Serial
-
-    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_Ray9::test_PnPn_Serial
-    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_Ray9::test_PnPn2_Serial
-    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
-    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayDN::test_PnPn2_Serial
-    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
-
     - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
     - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
-
-    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=KovStState::test_PnPn2_Serial
-
-    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=LowMachTest::test_PnPn_Serial
-    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=LowMachTest::test_PnPn2_Serial
-
-    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn_Serial    # Stdout exceeds Travis' max log length
-    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn_Parallel  # Stdout exceeds Travis' max log length
-    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
-    # - IFMPI=false F77=gfortran CC=gcc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
 
     - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Serial
     - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Parallel
@@ -61,6 +39,9 @@ env:
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
 
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e3
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e4
+
 before_install: 
   - export ROOT_DIR=`pwd`
 
@@ -69,21 +50,26 @@ before_install:
   - export VERBOSE_TESTS=true
   - export PARALLEL_PROCS=2
 
+  # Install MPICH
   - sudo apt-get update -qq
   - sudo apt-get install -y libmpich-dev mpich
 
+  # Set up Python virtualenv
   - virtualenv -p python2.7 $ROOT_DIR/python2-env
   - source $ROOT_DIR/python2-env/bin/activate
   - export PYTHONPATH="$ROOT_DIR/short_tests:$PYTHONPATH"
 
+  # Install cvode
+  - export CVODE_DIR=$ROOT_DIR/cvode-2.9.0
+  - mkdir -p $CVODE_DIR
   - wget http://computation.llnl.gov/projects/sundials/download/cvode-2.9.0.tar.gz
   - tar -zxf cvode-2.9.0.tar.gz
   - mkdir -p cvode-2.9.0/build
   - cd cvode-2.9.0/build
-  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/lib/cvode -DEXAMPLES_INSTALL=OFF -DMPI_ENABLE=ON -DFCMIX_ENABLE=ON -DBUILD_SHARED_LIBS=OFF ../
+  - cmake -DCMAKE_INSTALL_PREFIX=$CVODE_DIR -DEXAMPLES_INSTALL=OFF -DMPI_ENABLE=ON -DFCMIX_ENABLE=ON -DBUILD_SHARED_LIBS=OFF ../
   - make
   - make install
-  - ls -R $HOME/lib
+  - ls -R $CVODE_DIR
  
 install:
   - pip install --upgrade pip

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -954,7 +954,10 @@ class MvCyl_1e3(NekTestCase):
         )
 
         self.build_tools(['genmap'])
-        self.config_parfile(general=dict(numSteps='1e3', dt='1e-3'))
+        self.config_parfile({'GENERAL' : {'numSteps' : '1e3', 'dt' : '1e-3'}})
+
+    def test_dummy(self):
+        self.assertTrue(True)
 
 
 ####################################################################

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -265,9 +265,11 @@ class Benard_RayDD(NekTestCase):
             source_root = self.source_root,
             usr_file    = 'ray_cr',
             cwd         = os.path.join(self.examples_root, 'benard', 'benard_split'),
-            f77         = self.f77,
-            cc          = self.cc,
-            ifmpi       = str(self.ifmpi).lower(),
+            opts        = dict(
+                F77   = self.f77,
+                CC    = self.cc,
+                IFMPI = str(self.ifmpi).lower(),
+            ),
         )
         lib.nekBinRun.run_nek(
             cwd        = os.path.join(self.examples_root, 'benard', 'benard_split'),
@@ -382,10 +384,12 @@ class Benard_RayDN(NekTestCase):
             source_root = self.source_root,
             usr_file    = 'ray_cr',
             cwd         = os.path.join(self.examples_root, 'benard', 'benard_split'),
-            f77         = self.f77,
-            cc          = self.cc,
-            ifmpi       = str(self.ifmpi).lower(),
-            )
+            opts        = dict(
+                F77   = self.f77,
+                CC    = self.cc,
+                IFMPI = str(self.ifmpi).lower(),
+            ),
+        )
         lib.nekBinRun.run_nek(
             cwd        = os.path.join(self.examples_root, 'benard', 'benard_split'),
             rea_file   = 'ray_dn',
@@ -394,7 +398,7 @@ class Benard_RayDN(NekTestCase):
             n_procs    = self.mpi_procs,
             verbose    = self.verbose,
             step_limit = None,
-            )
+        )
 
         logfile=os.path.join(
             self.examples_root,
@@ -498,10 +502,12 @@ class Benard_RayNN(NekTestCase):
             source_root = self.source_root,
             usr_file    = 'ray_cr',
             cwd         = os.path.join(self.examples_root, 'benard', 'benard_split'),
-            f77         = self.f77,
-            cc          = self.cc,
-            ifmpi       = str(self.ifmpi).lower(),
-            )
+            opts        = dict(
+                F77   = self.f77,
+                CC    = self.cc,
+                IFMPI = str(self.ifmpi).lower(),
+            ),
+        )
         lib.nekBinRun.run_nek(
             cwd        = os.path.join(self.examples_root, 'benard', 'benard_split'),
             rea_file   = 'ray_nn',
@@ -510,7 +516,7 @@ class Benard_RayNN(NekTestCase):
             n_procs    = self.mpi_procs,
             verbose    = self.verbose,
             step_limit = None,
-            )
+        )
 
         logfile=os.path.join(
             self.examples_root,
@@ -955,6 +961,10 @@ class MvCyl_1e3(NekTestCase):
 
         self.build_tools(['genmap'])
         self.config_parfile({'GENERAL' : {'numSteps' : '1e3', 'dt' : '1e-3'}})
+
+    def test_PnPn_Serial(self):
+        self.size_params['lx2'] = 'lx1'
+        self.config_size()
 
     def test_dummy(self):
         self.assertTrue(True)

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -916,7 +916,7 @@ class LowMachTest(NekTestCase):
 #  mv_cyl with CVODE
 ####################################################################
 
-class MvCyl_1e3(NekTestCase):
+class MvCylCvode(NekTestCase):
     example_subdir = 'mv_cyl'
     case_name = 'mv_cyl'
 

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -907,6 +907,57 @@ class LowMachTest(NekTestCase):
 
 
 ####################################################################
+#  mv_cyl with CVODE
+####################################################################
+
+class MvCyl_1e3(NekTestCase):
+    example_subdir = 'mv_cyl'
+    case_name = 'mv_cyl'
+
+    def setUp(self):
+        self.size_params = dict (
+            ldim     = '2',
+            lx1      = '8',
+            lxd      = '12',
+            lx2      = 'lx1-0',
+            lx1m     = 'lx1',
+            lelg     = '520',
+            lp       = '64',
+            lelt     = '200',
+            ldimt    = '10',
+            lelx     = '1',
+            lely     = '1',
+            lelz     = '1',
+            ax1      = '1',
+            ax2      = '1',
+            lbx1     = '1',
+            lbx2     = '1',
+            lbelt    = '1',
+            lpx1     = '1',
+            lpx2     = '1',
+            lpelt    = '1',
+            lpert    = '1',
+            lelecmt  = '',
+            toteq    = '1',
+            lcvx1    = 'lx1',
+            lcvelt   = 'lelt',
+            mxprev   = '20',
+            lgmres   = '40',
+            lorder   = '3',
+            lhis     = '100',
+            maxobj   = '4',
+            maxmbr   = 'lelt*6',
+            nsessmax = '1',
+            nmaxl    = '1',
+            nfldmax  = '1',
+            nmaxcom  = '1',
+        )
+
+        self.build_tools(['genmap'])
+        self.config_parfile(general=dict(numSteps='1e3', dt='1e-3'))
+
+
+####################################################################
 #  var_vis; var_vis.rea
 ####################################################################
 

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -967,7 +967,7 @@ class MvCylCvode(NekTestCase):
 
     @pn_pn_parallel
     def test_PnPn_Parallel_Steps1e3(self):
-        self.log_suffix += 'steps_1e3'
+        self.log_suffix += '.steps_1e3'
         self.config_parfile({'GENERAL' : {'numSteps' : '1e3', 'dt' : '1e-3'}})
         self.size_params['lx2'] = 'lx1'
         self.config_size()
@@ -987,7 +987,7 @@ class MvCylCvode(NekTestCase):
 
     @pn_pn_parallel
     def test_PnPn_Parallel_Steps1e4(self):
-        self.log_suffix += 'steps_1e4'
+        self.log_suffix += '.steps_1e4'
         self.config_parfile({'GENERAL' : {'numSteps' : '1e4', 'dt' : '1e-4'}})
         self.size_params['lx2'] = 'lx1'
         self.config_size()

--- a/short_tests/lib/nekBinBuild.py
+++ b/short_tests/lib/nekBinBuild.py
@@ -57,7 +57,7 @@ def build_tools(tools_root, tools_bin, f77=None, cc=None, bigmem=None,
     else:
         print('Successfully compiled tools!')
 
-def build_nek(source_root, usr_file, cwd=None, f77=None, cc=None, ifmpi=None, verbose=False):
+def build_nek(source_root, usr_file, cwd=None, f77=None, cc=None, ifmpi=None, usr_lflags=None, pplist=None, verbose=False):
 
     print('Compiling nek5000...')
     print('    Using source directory "{0}"'.format(source_root))
@@ -66,6 +66,8 @@ def build_nek(source_root, usr_file, cwd=None, f77=None, cc=None, ifmpi=None, ve
     print('    Using F77 "{0}"'.format(f77))
     print('    Using CC "{0}"'.format(cc))
     print('    Using IFMPI "{0}"'.format(ifmpi))
+    print('    Using PPLIST "{0}"'.format(pplist))
+    print('    Using USR_LFLAGS "{0}"'.format(usr_lflags))
 
     makenek_in  = os.path.join(source_root, 'core', 'makenek')
     makenek_out = os.path.join(source_root, 'core', 'makenek.tests')
@@ -77,7 +79,9 @@ def build_nek(source_root, usr_file, cwd=None, f77=None, cc=None, ifmpi=None, ve
             f77         = f77,
             cc          = cc,
             source_root = source_root,
-            ifmpi       = ifmpi
+            ifmpi       = ifmpi,
+            pplist      = pplist,
+            usr_lflags  = usr_lflags
         )
 
         call([makenek_out, 'clean'], cwd=cwd)

--- a/short_tests/lib/nekBinBuild.py
+++ b/short_tests/lib/nekBinBuild.py
@@ -60,20 +60,27 @@ def build_tools(tools_root, tools_bin, f77=None, cc=None, bigmem=None,
 def build_nek(source_root, usr_file, cwd=None, opts=None, verbose=False):
 
     if not opts:
-        opts = {}
+        _opts = {}
+    else:
+        _opts = opts.copy()
+    _opts.update(SOURCE_ROOT=source_root)
 
     print('Compiling nek5000...')
     print('    Using source directory "{0}"'.format(source_root))
     print('    Using working directory "{0}"'.format(cwd))
     print('    Using .usr file "{0}"'.format(usr_file))
-    for key, val in opts.iteritems():
+    for key, val in _opts.iteritems():
         print('    Using {0}="{1}"'.format(key, val))
 
     makenek_in  = os.path.join(source_root, 'core', 'makenek')
     makenek_out = os.path.join(source_root, 'core', 'makenek.tests')
     logfile     = os.path.join(cwd, 'compiler.out')
     try:
-        config_makenek(opts=opts, infile=makenek_in, outfile=makenek_out)
+        config_makenek(
+            opts=_opts,
+            infile=makenek_in,
+            outfile=makenek_out
+        )
 
         call([makenek_out, 'clean'], cwd=cwd)
         if verbose:

--- a/short_tests/lib/nekBinBuild.py
+++ b/short_tests/lib/nekBinBuild.py
@@ -57,31 +57,26 @@ def build_tools(tools_root, tools_bin, f77=None, cc=None, bigmem=None,
     else:
         print('Successfully compiled tools!')
 
-def build_nek(source_root, usr_file, cwd=None, f77=None, cc=None, ifmpi=None, usr_lflags=None, pplist=None, verbose=False):
+def build_nek(source_root, usr_file, cwd=None, opts=None, verbose=False):
+
+    if not opts:
+        opts = {}
 
     print('Compiling nek5000...')
     print('    Using source directory "{0}"'.format(source_root))
     print('    Using working directory "{0}"'.format(cwd))
     print('    Using .usr file "{0}"'.format(usr_file))
-    print('    Using F77 "{0}"'.format(f77))
-    print('    Using CC "{0}"'.format(cc))
-    print('    Using IFMPI "{0}"'.format(ifmpi))
-    print('    Using PPLIST "{0}"'.format(pplist))
-    print('    Using USR_LFLAGS "{0}"'.format(usr_lflags))
+    for key, val in opts.iteritems():
+        print('    Using {0}="{1}"'.format(key, val))
 
     makenek_in  = os.path.join(source_root, 'core', 'makenek')
     makenek_out = os.path.join(source_root, 'core', 'makenek.tests')
     logfile     = os.path.join(cwd, 'compiler.out')
     try:
         config_makenek(
-            infile      = makenek_in,
-            outfile     = makenek_out,
-            f77         = f77,
-            cc          = cc,
-            source_root = source_root,
-            ifmpi       = ifmpi,
-            pplist      = pplist,
-            usr_lflags  = usr_lflags
+            infile  = makenek_in,
+            outfile = makenek_out,
+            opts    = opts
         )
 
         call([makenek_out, 'clean'], cwd=cwd)

--- a/short_tests/lib/nekBinBuild.py
+++ b/short_tests/lib/nekBinBuild.py
@@ -73,11 +73,7 @@ def build_nek(source_root, usr_file, cwd=None, opts=None, verbose=False):
     makenek_out = os.path.join(source_root, 'core', 'makenek.tests')
     logfile     = os.path.join(cwd, 'compiler.out')
     try:
-        config_makenek(
-            infile  = makenek_in,
-            outfile = makenek_out,
-            opts    = opts
-        )
+        config_makenek(opts=opts, infile=makenek_in, outfile=makenek_out)
 
         call([makenek_out, 'clean'], cwd=cwd)
         if verbose:

--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -1,7 +1,7 @@
 import os, stat, re
 
-def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=None, pplist=None, usr_lflags=None):
 
+def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=None, pplist=None, usr_lflags=None):
     with open(infile, 'r') as f:
         lines = f.readlines()
 
@@ -37,11 +37,10 @@ def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=N
     os.chmod(outfile,
              stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH |
              stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH |
-             stat.S_IWUSR )
+             stat.S_IWUSR)
 
 
 def config_maketools(infile, outfile, f77=None, cc=None, bigmem=None):
-
     with open(infile, 'r') as f:
         lines = f.readlines()
 
@@ -60,11 +59,10 @@ def config_maketools(infile, outfile, f77=None, cc=None, bigmem=None):
     os.chmod(outfile,
              stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH |
              stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH |
-             stat.S_IWUSR )
+             stat.S_IWUSR)
 
 
 def config_basics_inc(infile, outfile, nelm):
-
     with open(infile, 'r') as f:
         lines = f.readlines()
 
@@ -75,8 +73,7 @@ def config_basics_inc(infile, outfile, nelm):
         f.writelines(lines)
 
 
-def config_size( infile, outfile, **kwargs ):
-
+def config_size(infile, outfile, **kwargs):
     with open(infile, 'r') as f:
         lines = f.readlines()
 
@@ -87,48 +84,40 @@ def config_size( infile, outfile, **kwargs ):
                 re.sub(
                     r'(.*\bparameter\b.*\b{0} *= *)\S+?( *[),])'.format(key),
                     r'\g<1>{0}\g<2>'.format(value), l, flags=re.I)
-                for l in lines ]
+                for l in lines]
 
     with open(outfile, 'w') as f:
         f.writelines(lines)
 
 
-def config_parfile(infile, outfile, general=None, problemtype=None, mesh=None, pressure=None, velocity=None,
-                   temperature=None, cvode=None):
+def config_parfile(infile, outfile, opts):
+    """ Set values in a parfile using ConfigParser
+
+    Given a path to infile, substitute the options & values in kwargs, then
+    output to outfile.  The infile and outfile can be the same file.
+
+    opts is interpreted as a nested dict of the form:
+        {section: {optname: value, ...}, ...}
+    where "optname = value" are set in [section]. If 'optname' is not set in
+    infile, then it will be added to outfile.  If 'optname' is already set in
+    infile, then it will be overridden in outfile.  If an option is listed in
+    infile but is not listed in in 'opts', then it will be copied to outfile
+    without modification..
+
+    Args:
+        infile (str): Path to input file
+        outfile (str): Path to output file
+        opts ({section: {optname : value}}): Set each "optname = value" in
+            each "[section]"
+    """
     import ConfigParser
 
     parfile = ConfigParser.SafeConfigParser()
     parfile.read(infile)
 
-    if general:
-        for k,v in general.iteritems():
-            parfile.set('GENERAL', k, v)
-
-    if problemtype:
-        for k,v in problemtype.iteritems():
-            parfile.set('PROBLEMTYPE', k, v)
-
-    if mesh:
-        for k,v in mesh.iteritems():
-            parfile.set('MESH', k, v)
-
-    if pressure:
-        for k,v in pressure.iteritems():
-            parfile.set('PRESSURE', k, v)
-
-    if velocity:
-        for k,v in velocity.iteritems():
-            parfile.set('VELOCITY', k, v)
-
-    if temperature:
-        for k,v in temperature.iteritems():
-            parfile.set('TEMPERATURE', k, v)
-
-    if cvode:
-        for k,v in cvode.iteritems():
-            parfile.set('CVODE', k, v)
+    for section, name_vals in opts.iteritems():
+        for name, val in name_vals.iteritems():
+            parfile.set(section, name, val)
 
     with open(outfile, 'w') as f:
         parfile.write(f)
-
-

--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -1,30 +1,12 @@
 import os, stat, re
 
 
-def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=None, pplist=None, usr_lflags=None):
+def config_makenek(infile, outfile, opts):
     with open(infile, 'r') as f:
         lines = f.readlines()
 
-    if source_root:
-        lines = [re.sub(r'^SOURCE_ROOT=\"+.+?\"+', r'SOURCE_ROOT="{0}"'.format(source_root), l)
-                 for l in lines]
-    if f77:
-        lines = [re.sub(r'^F77=\"+.+?\"+', r'F77="{0}"'.format(f77), l)
-                 for l in lines]
-    if cc:
-        lines = [re.sub(r'^CC=\"+.+?\"+', r'CC="{0}"'.format(cc), l)
-                 for l in lines]
-    if ifmpi:
-        lines = [re.sub(r'^#*IFMPI=\"+.+?\"+', r'IFMPI="{0}"'.format(ifmpi), l)
-                 for l in lines]
-
-    if pplist:
-        lines = [re.sub(r'^#*PPLIST=\"+.+?\"+', r'PPLIST="{0}"'.format(pplist), l)
-                 for l in lines]
-
-    if usr_lflags:
-        lines = [re.sub(r'^#*USR_LFLAGS=\"+.+?\"+', r'USR_LFLAGS="{0}"'.format(usr_lflags), l)
-                 for l in lines]
+    for key, val in opts.iteritems():
+        lines = [re.sub(r'^#*{0}=\"+.+?\"+'.format(key), r'{0}="{1}"'.format(key, val), l) for l in lines]
 
     lines = [re.sub(r'(^source\s+\$SOURCE_ROOT/makenek.inc)', r'\g<1> >compiler.out', l)
              for l in lines]

--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -2,6 +2,21 @@ import os, stat, re
 
 
 def config_makenek(opts, infile, outfile):
+    """ Redefine variables in a makenek file
+
+    Given a path to infile, redefine the variables & values in opts, then
+    output to outfile.  The infile and outfile can be the same file.
+
+    Only the options already available in makenek may be set.  This function
+    doesn't allow you to declare arbitrary variables in makenek.
+    (TODO: Raise warning when attempting to set an unavailable variable.)
+
+    Args:
+        opts ({variable : value}): Set each "variable=value" in makenek
+        infile (): The input makenek file
+        outfile (): The output makenek file
+
+    """
     with open(infile, 'r') as f:
         lines = f.readlines()
 
@@ -55,12 +70,28 @@ def config_basics_inc(infile, outfile, nelm):
         f.writelines(lines)
 
 
-def config_size(opts, infile, outfile):
+def config_size(params, infile, outfile):
+    """ Redefine parameters in a SIZE file
+
+    Given a path to infile, redefine the variables & values in params, then
+    output to outfile.  The infile and outfile can be the same file.
+
+    Only the parameters already declared in infile may be set.  This function
+    doesn't allow you to declare any new parameters.
+    (TODO: Raise warning when attempting to declare a new parameter.)
+
+    Args:
+        params ({variable : value}): Each 'variable' will be set to 'value'
+            in the output SIZE file
+        infile (str): Path to the input SIZE file
+        outfile (str): Path to output SIZE file
+
+    """
     with open(infile, 'r') as f:
         lines = f.readlines()
 
     # Substitute all the variables
-    for key, value in opts.iteritems():
+    for key, value in params.iteritems():
         if value:
             lines = [
                 re.sub(
@@ -75,7 +106,7 @@ def config_size(opts, infile, outfile):
 def config_parfile(opts, infile, outfile):
     """ Set values in a parfile using ConfigParser
 
-    Given a path to infile, substitute the options & values in kwargs, then
+    Given a path to infile, substitute the options & values in opts, then
     output to outfile.  The infile and outfile can be the same file.
 
     opts is interpreted as a nested dict of the form:
@@ -87,10 +118,11 @@ def config_parfile(opts, infile, outfile):
     without modification..
 
     Args:
-        infile (str): Path to input file
-        outfile (str): Path to output file
         opts ({section: {optname : value}}): Set each "optname = value" in
             each "[section]"
+        infile (str): Path to input parfile
+        outfile (str): Path to output parfile
+
     """
     import ConfigParser
 

--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -1,7 +1,7 @@
 import os, stat, re
 
 
-def config_makenek(infile, outfile, opts):
+def config_makenek(opts, infile, outfile):
     with open(infile, 'r') as f:
         lines = f.readlines()
 
@@ -55,7 +55,7 @@ def config_basics_inc(infile, outfile, nelm):
         f.writelines(lines)
 
 
-def config_size(infile, outfile, opts):
+def config_size(opts, infile, outfile):
     with open(infile, 'r') as f:
         lines = f.readlines()
 
@@ -72,7 +72,7 @@ def config_size(infile, outfile, opts):
         f.writelines(lines)
 
 
-def config_parfile(infile, outfile, opts):
+def config_parfile(opts, infile, outfile):
     """ Set values in a parfile using ConfigParser
 
     Given a path to infile, substitute the options & values in kwargs, then

--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -1,6 +1,6 @@
 import os, stat, re
 
-def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=None):
+def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=None, pplist=None, usr_lflags=None):
 
     with open(infile, 'r') as f:
         lines = f.readlines()
@@ -16,6 +16,14 @@ def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=N
                  for l in lines]
     if ifmpi:
         lines = [re.sub(r'^#*IFMPI=\"+.+?\"+', r'IFMPI="{0}"'.format(ifmpi), l)
+                 for l in lines]
+
+    if pplist:
+        lines = [re.sub(r'^#*PPLIST=\"+.+?\"+', r'PPLIST="{0}"'.format(pplist), l)
+                 for l in lines]
+
+    if usr_lflags:
+        lines = [re.sub(r'^#*USR_LFLAGS=\"+.+?\"+', r'USR_LFLAGS="{0}"'.format(usr_lflags), l)
                  for l in lines]
 
     lines = [re.sub(r'(^source\s+\$SOURCE_ROOT/makenek.inc)', r'\g<1> >compiler.out', l)
@@ -83,3 +91,44 @@ def config_size( infile, outfile, **kwargs ):
 
     with open(outfile, 'w') as f:
         f.writelines(lines)
+
+
+def config_parfile(infile, outfile, general=None, problemtype=None, mesh=None, pressure=None, velocity=None,
+                   temperature=None, cvode=None):
+    import ConfigParser
+
+    parfile = ConfigParser.SafeConfigParser()
+    parfile.read(infile)
+
+    if general:
+        for k,v in general.iteritems():
+            parfile.set('GENERAL', k, v)
+
+    if problemtype:
+        for k,v in problemtype.iteritems():
+            parfile.set('PROBLEMTYPE', k, v)
+
+    if mesh:
+        for k,v in mesh.iteritems():
+            parfile.set('MESH', k, v)
+
+    if pressure:
+        for k,v in pressure.iteritems():
+            parfile.set('PRESSURE', k, v)
+
+    if velocity:
+        for k,v in velocity.iteritems():
+            parfile.set('VELOCITY', k, v)
+
+    if temperature:
+        for k,v in temperature.iteritems():
+            parfile.set('TEMPERATURE', k, v)
+
+    if cvode:
+        for k,v in cvode.iteritems():
+            parfile.set('CVODE', k, v)
+
+    with open(outfile, 'w') as f:
+        parfile.write(f)
+
+

--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -73,12 +73,12 @@ def config_basics_inc(infile, outfile, nelm):
         f.writelines(lines)
 
 
-def config_size(infile, outfile, **kwargs):
+def config_size(infile, outfile, opts):
     with open(infile, 'r') as f:
         lines = f.readlines()
 
     # Substitute all the variables
-    for key, value in kwargs.iteritems():
+    for key, value in opts.iteritems():
         if value:
             lines = [
                 re.sub(

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -269,8 +269,7 @@ class NekTestCase(unittest.TestCase):
         else:
             config_size(infile, outfile, *args, **self.size_params)
 
-    def config_parfile(self, infile=None, outfile=None, general=None, problemtype=None, mesh=None, pressure=None,
-                       velocity=None, temperature=None, cvode=None):
+    def config_parfile(self, opts=None, infile=None, outfile=None):
         from lib.nekFileConfig import config_parfile
         cls = self.__class__
 
@@ -278,18 +277,10 @@ class NekTestCase(unittest.TestCase):
             infile = os.path.join(self.examples_root, cls.example_subdir, cls.case_name + '.par')
         if not outfile:
             outfile = infile
+        if not opts:
+            opts = {}
 
-        config_parfile(
-            infile=infile,
-            outfile=outfile,
-            general=general,
-            problemtype=problemtype,
-            mesh=mesh,
-            pressure=pressure,
-            velocity=velocity,
-            temperature=temperature,
-            cvode=cvode,
-        )
+        config_parfile(infile=infile, outfile=outfile, opts=opts)
 
     def run_genmap(self, rea_file=None, tol='0.5'):
 

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -269,6 +269,27 @@ class NekTestCase(unittest.TestCase):
         else:
             config_size(infile, outfile, *args, **self.size_params)
 
+    def config_parfile(self, infile=None, outfile=None, general=None, problemtype=None, mesh=None, pressure=None,
+                       velocity=None, temperature=None, cvode=None):
+        from lib.nekFileConfig import config_parfile
+        cls = self.__class__
+
+        if not infile:
+            infile = os.path.join(self.examples_root, cls.example_subdir, cls.case_name + '.par')
+        if not outfile:
+            outfile = infile
+
+        config_parfile(
+            infile=infile,
+            outfile=outfile,
+            general=general,
+            problemtype=problemtype,
+            mesh=mesh,
+            pressure=pressure,
+            velocity=velocity,
+            temperature=temperature,
+            cvode=cvode,
+        )
 
     def run_genmap(self, rea_file=None, tol='0.5'):
 

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -267,7 +267,7 @@ class NekTestCase(unittest.TestCase):
         if not opts:
             opts = self.size_params
 
-        config_size(infile=infile, outfile=outfile, opts=opts)
+        config_size(opts=opts, infile=infile, outfile=outfile)
 
     def config_parfile(self, opts=None, infile=None, outfile=None):
         from lib.nekFileConfig import config_parfile
@@ -280,7 +280,7 @@ class NekTestCase(unittest.TestCase):
         if not opts:
             opts = {}
 
-        config_parfile(infile=infile, outfile=outfile, opts=opts)
+        config_parfile(opts=opts, infile=infile, outfile=outfile)
 
     def run_genmap(self, rea_file=None, tol='0.5'):
 

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -116,6 +116,7 @@ class NekTestCase(unittest.TestCase):
         self.serial_procs   = 1
         self.parallel_procs = 4
         self.size_params    = {}
+        self.cvode_dir      = ""
 
         # These are overridden by method decorators (pn_pn_serial, pn_pn_parallel,
         # pn_pn_2_serial, and pn_pn_2_parallel)
@@ -237,6 +238,10 @@ class NekTestCase(unittest.TestCase):
                     print('    The {0} directory, "{1}" does not exist.  It will be created'.format(varname, varval))
                     os.makedirs(varval)
 
+        # CVODE_DIR doesn't need to be defined.  It defaults to ""
+        #---------------------------------------------------------
+        self.cvode_dir = os.environ.get('CVODE_DIR', self.cvode_dir)
+
         # Default destination of makenek
         # ------------------------------
         if not self.makenek:
@@ -322,23 +327,27 @@ class NekTestCase(unittest.TestCase):
             cwd     = os.path.join(self.examples_root, self.__class__.example_subdir),
         )
 
-    def build_nek(self, usr_file=None):
+    def build_nek(self, opts=None, usr_file=None):
         from lib.nekBinBuild import build_nek
         cls = self.__class__
 
         if not usr_file:
             usr_file = cls.case_name
 
+        all_opts = dict(
+            F77   = self.f77,
+            CC    = self.cc,
+            IFMPI = str(self.ifmpi).lower(),
+        )
+        if opts:
+            all_opts.update(opts)
+
         build_nek(
             source_root = self.source_root,
             usr_file    = usr_file,
             cwd         = os.path.join(self.examples_root, cls.example_subdir),
-            opts        = dict(
-                F77   = self.f77,
-                CC    = self.cc,
-                IFMPI = str(self.ifmpi).lower()
-            ),
-            verbose     = self.verbose
+            opts        = all_opts,
+            verbose     = self.verbose,
         )
 
     def run_nek(self, rea_file=None, step_limit=None):

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -256,7 +256,7 @@ class NekTestCase(unittest.TestCase):
             verbose    = verbose    if verbose    else self.verbose
         )
 
-    def config_size(self, opts=None, infile=None, outfile=None):
+    def config_size(self, params=None, infile=None, outfile=None):
         from lib.nekFileConfig import config_size
         cls = self.__class__
 
@@ -264,10 +264,10 @@ class NekTestCase(unittest.TestCase):
             infile = os.path.join(self.source_root, 'core', 'SIZE.template')
         if not outfile:
             outfile = os.path.join(self.examples_root, cls.example_subdir, 'SIZE')
-        if not opts:
-            opts = self.size_params
+        if not params:
+            params = self.size_params
 
-        config_size(opts=opts, infile=infile, outfile=outfile)
+        config_size(params=params, infile=infile, outfile=outfile)
 
     def config_parfile(self, opts=None, infile=None, outfile=None):
         from lib.nekFileConfig import config_parfile

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -333,9 +333,11 @@ class NekTestCase(unittest.TestCase):
             source_root = self.source_root,
             usr_file    = usr_file,
             cwd         = os.path.join(self.examples_root, cls.example_subdir),
-            f77         = self.f77,
-            cc          = self.cc,
-            ifmpi       = str(self.ifmpi).lower(),
+            opts        = dict(
+                F77   = self.f77,
+                CC    = self.cc,
+                IFMPI = str(self.ifmpi).lower()
+            ),
             verbose     = self.verbose
         )
 

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -256,7 +256,7 @@ class NekTestCase(unittest.TestCase):
             verbose    = verbose    if verbose    else self.verbose
         )
 
-    def config_size(self, infile=None, outfile=None, *args, **kwargs):
+    def config_size(self, opts=None, infile=None, outfile=None):
         from lib.nekFileConfig import config_size
         cls = self.__class__
 
@@ -264,10 +264,10 @@ class NekTestCase(unittest.TestCase):
             infile = os.path.join(self.source_root, 'core', 'SIZE.template')
         if not outfile:
             outfile = os.path.join(self.examples_root, cls.example_subdir, 'SIZE')
-        if not kwargs:
-            config_size(infile, outfile, *args, **self.size_params)
-        else:
-            config_size(infile, outfile, *args, **self.size_params)
+        if not opts:
+            opts = self.size_params
+
+        config_size(infile=infile, outfile=outfile, opts=opts)
 
     def config_parfile(self, opts=None, infile=None, outfile=None):
         from lib.nekFileConfig import config_parfile

--- a/short_tests/lib/parseSize.py
+++ b/short_tests/lib/parseSize.py
@@ -33,47 +33,49 @@ if __name__ == '__main__':
     params = getSizeParams()
 
     # Print all params in alphabetical order.
-    for x in sorted(params):
-        print "{0} = {1}".format(x, params[x])
+    # for x in sorted(params):
+    #     print "{0} = {1}".format(x, params[x])
 
     # Print only variables in SIZE.template in the order that they appear in SIZE.template
-    # template_params = [
-    #             'ldim',
-    #             'lx1',
-    #             'lxd',
-    #             'lx2',
-    #             'lx1m',
-    #             'lelg',
-    #             'lp',
-    #             'lelt',
-    #             'ldimt',
-    #             'lelx',
-    #             'lely',
-    #             'lelz',
-    #             'ax1',
-    #             'ax2',
-    #             'lbx1',
-    #             'lbx2',
-    #             'lbelt',
-    #             'lpx1',
-    #             'lpx2',
-    #             'lpelt',
-    #             'lpert',
-    #             'lelecmt',
-    #             'toteq',
-    #             'mxprev',
-    #             'lgmres',
-    #             'lorder',
-    #             'lhis',
-    #             'maxobj',
-    #             'maxmbr',
-    #             'nsessmax',
-    #             'nmaxl',
-    #             'nfldmax',
-    #             'nmaxcom',
-    # ]
-    #
-    # for x in template_params:
-    #     print "{0} = {1}".format(x, params.get(x, None))
+    template_params = [
+                'ldim',
+                'lx1',
+                'lxd',
+                'lx2',
+                'lx1m',
+                'lelg',
+                'lp',
+                'lelt',
+                'ldimt',
+                'lelx',
+                'lely',
+                'lelz',
+                'ax1',
+                'ax2',
+                'lbx1',
+                'lbx2',
+                'lbelt',
+                'lpx1',
+                'lpx2',
+                'lpelt',
+                'lpert',
+                'lelecmt',
+                'toteq',
+                'lcvx1',
+                'lcvelt',
+                'mxprev',
+                'lgmres',
+                'lorder',
+                'lhis',
+                'maxobj',
+                'maxmbr',
+                'nsessmax',
+                'nmaxl',
+                'nfldmax',
+                'nmaxcom',
+    ]
+
+    for x in template_params:
+        print "{:<9}= '{}',".format(x, params.get(x, None))
 
 


### PR DESCRIPTION
This introduces regression tests for the moving cylinder case using cvode.  

In NekTests.py, I've added two new tests
1. PnPn parallel with 1e3 timesteps
2. PnPn parallel with 1e4 timesteps

.travis.yml has been updated to run the 1e3 timestep case.  The 1e4 timestep case exceeds the maximum allowable time limit for Travis jobs.  It can still be run with Jenkins (TODO). 

