### PR TITLE
Refactored interface for NekTests environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
 
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e3
+    -  IFMPI=true F77=mpif77 CC=mpicc PPLIST="$PPLIST CVODE" TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e3
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e4 # Exceeds time limit for Travis jobs
 
 before_install: 
@@ -60,16 +60,17 @@ before_install:
   - export PYTHONPATH="$ROOT_DIR/short_tests:$PYTHONPATH"
 
   # Install cvode
-  - export CVODE_DIR=$ROOT_DIR/cvode-2.9.0
-  - mkdir -p $CVODE_DIR
+  - export CVODE_INSTALL_DIR=$ROOT_DIR/cvode-2.9.0-install
+  - export USR_LFLAGS="$USR_LFLAGS -L$CVODE_INSTALL_DIR/lib -lsundials_fcvode -lsundials_cvode -lsundials_fnvecparallel -lsundials_nvecparallel"
+  - mkdir -p $CVODE_INSTALL_DIR
   - wget http://computation.llnl.gov/projects/sundials/download/cvode-2.9.0.tar.gz
   - tar -zxf cvode-2.9.0.tar.gz
   - mkdir -p cvode-2.9.0/build
   - cd cvode-2.9.0/build
-  - cmake -DCMAKE_INSTALL_PREFIX=$CVODE_DIR -DEXAMPLES_INSTALL=OFF -DMPI_ENABLE=ON -DFCMIX_ENABLE=ON -DBUILD_SHARED_LIBS=OFF ../
+  - cmake -DCMAKE_INSTALL_PREFIX=$CVODE_INSTALL_DIR -DEXAMPLES_INSTALL=OFF -DMPI_ENABLE=ON -DFCMIX_ENABLE=ON -DBUILD_SHARED_LIBS=OFF ../
   - make
   - make install
-  - ls -R $CVODE_DIR
+  - ls -R $CVODE_INSTALL_DIR
  
 install:
   - pip install --upgrade pip

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -964,7 +964,7 @@ class MvCylCvode(NekTestCase):
     @pn_pn_parallel
     def test_PnPn_Parallel_Steps1e3(self):
         if not "CVODE" in self.pplist:
-            self.skipTest("Skipping \"{0}\"; \"CVODE\" is not listed in $PPLIST.".format(self.id()))
+            self.fail("\"CVODE\" is not listed in $PPLIST. This test cannot be run.".format(self.id()))
 
         self.log_suffix += '.steps_1e3'
         self.config_parfile({'GENERAL' : {'numSteps' : '1e3', 'dt' : '1e-3'}})
@@ -984,7 +984,7 @@ class MvCylCvode(NekTestCase):
     @pn_pn_parallel
     def test_PnPn_Parallel_Steps1e4(self):
         if not "CVODE" in self.pplist:
-            self.skipTest("Skipping \"{0}\"; \"CVODE\" is not listed in $PPLIST.".format(self.id()))
+            self.fail("\"CVODE\" is not listed in $PPLIST. This test cannot be run.".format(self.id()))
 
         self.log_suffix += '.steps_1e4'
         self.config_parfile({'GENERAL' : {'numSteps' : '1e4', 'dt' : '1e-4'}})

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -857,8 +857,8 @@ class LowMachTest(NekTestCase):
         vx = self.get_value_from_log(label='ERROR VX', column=-5, row=-1)
         self.assertAlmostEqualDelayed(vx, target_val=2.4635E-09, delta=1e-06, label='VX')
 
-        t = self.get_value_from_log(label='ERROR T', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(t, target_val=4.5408E-12, delta=1e-06, label='T')
+        errt = self.get_value_from_log(label='ERROR T', column=-5, row=-1)
+        self.assertAlmostEqualDelayed(errt, target_val=4.5408E-12, delta=1e-06, label='T')
 
         qtl = self.get_value_from_log(label='ERROR QTL', column=-5, row=-1)
         self.assertAlmostEqualDelayed(qtl, target_val=2.6557E-06, delta=1e-06, label='QTL')
@@ -878,8 +878,8 @@ class LowMachTest(NekTestCase):
         vx = self.get_value_from_log(label='ERROR VX', column=-5, row=-1)
         self.assertAlmostEqualDelayed(vx, target_val=2.4635E-09, delta=1e-06, label='VX')
 
-        t = self.get_value_from_log(label='ERROR T', column=-5, row=-1)
-        self.assertAlmostEqualDelayed(t, target_val=4.5408E-12, delta=1e-06, label='T')
+        errt = self.get_value_from_log(label='ERROR T', column=-5, row=-1)
+        self.assertAlmostEqualDelayed(errt, target_val=4.5408E-12, delta=1e-06, label='T')
 
         qtl = self.get_value_from_log(label='ERROR QTL', column=-5, row=-1)
         self.assertAlmostEqualDelayed(qtl, target_val=2.6557E-06, delta=1e-06, label='QTL')
@@ -958,23 +958,19 @@ class MvCylCvode(NekTestCase):
             nfldmax  = '1',
             nmaxcom  = '1',
         )
-
-        if not self.cvode_dir:
-            self.fail('Must define $CVODE_DIR in environment before running this test.')
-
         self.build_tools(['genmap'])
         self.run_genmap()
 
     @pn_pn_parallel
     def test_PnPn_Parallel_Steps1e3(self):
+        if not "CVODE" in self.pplist:
+            self.skipTest("Skipping \"{0}\"; \"CVODE\" is not listed in $PPLIST.".format(self.id()))
+
         self.log_suffix += '.steps_1e3'
         self.config_parfile({'GENERAL' : {'numSteps' : '1e3', 'dt' : '1e-3'}})
         self.size_params['lx2'] = 'lx1'
         self.config_size()
-        self.build_nek(opts=dict(
-            PPLIST="CVODE",
-            USR_LFLAGS="-L{0}/lib -lsundials_fcvode -lsundials_cvode -lsundials_fnvecparallel -lsundials_nvecparallel".format(self.cvode_dir)
-        ))
+        self.build_nek()
         self.run_nek()
 
         err3 = self.get_value_from_log('err', column=-3, row=-1)
@@ -987,14 +983,14 @@ class MvCylCvode(NekTestCase):
 
     @pn_pn_parallel
     def test_PnPn_Parallel_Steps1e4(self):
+        if not "CVODE" in self.pplist:
+            self.skipTest("Skipping \"{0}\"; \"CVODE\" is not listed in $PPLIST.".format(self.id()))
+
         self.log_suffix += '.steps_1e4'
         self.config_parfile({'GENERAL' : {'numSteps' : '1e4', 'dt' : '1e-4'}})
         self.size_params['lx2'] = 'lx1'
         self.config_size()
-        self.build_nek(opts=dict(
-            PPLIST="CVODE",
-            USR_LFLAGS="-L{0}/lib -lsundials_fcvode -lsundials_cvode -lsundials_fnvecparallel -lsundials_nvecparallel".format(self.cvode_dir)
-        ))
+        self.build_nek()
         self.run_nek()
 
         err3 = self.get_value_from_log('err', column=-3, row=-1)

--- a/short_tests/README.md
+++ b/short_tests/README.md
@@ -55,11 +55,19 @@ TwistedTrial, and others.
 
 #### Environment
 
-Before running the tests, these environment variables may be optionally defined:
-* `SOURCE_ROOT`: Points to the top-level Nek5000 repository. 
-* `CC`: The C compiler you wish to use (default: mpicc).
-* `F77`: The Fortran 77 compiler you wish to use (default mpif77).
+Before running the tests, several environment variables may be optionally defined.
+
+Setting the following in your environement (e.g. `export SOURCE_ROOT=$HOME/repos/Nek5000`)
+will set the corresponding variables in makenek.  They affect compilation of Nek5000.
+* `SOURCE_ROOT`: Points to the top-level Nek5000 repository (default: this repository).
+* `F77`: The Fortran 77 compiler (default mpif77).
+* `CC`: The C compiler (default: mpicc).
+* `G`: Generic compiler flags, such as -g (default: none)
+* `PPLIST`: List of pre-processor symbols (default: none)
+* `USR_LFLAGS`: Linking flags (default: none)
 * `IFMPI=[true|false]`: If true, run tests with MPI. (default: true)
+
+Setting the following in your enviroment will affect the execution of NekTests
 * `PARALLEL_PROCS`: The number of processes to use when running with MPI
   (default: 4)
 * `EXAMPLES_ROOT`: Points to an alternate Nek5000 examples directory (default: this directory)

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -105,18 +105,21 @@ class NekTestCase(unittest.TestCase):
         # These can be overridden by self.get_opts
         self.f77            = 'mpif77'
         self.cc             = 'mpicc'
+        self.g              = ""
+        self.pplist         = ""
+        self.usr_lflags     = ""
         self.ifmpi          = True
-        self.verbose        = True
+
         self.source_root    = os.path.dirname(os.path.dirname(inspect.getabsfile(self.__class__)))
         self.examples_root  = os.path.dirname(inspect.getabsfile(self.__class__))
-        self.tools_root     = ''
-        self.tools_bin      = ''
-        self.log_root       = ''
-        self.makenek        = ''
+        self.makenek        = os.path.join(self.source_root, 'core', 'makenek')
+        self.tools_root     = os.path.join(self.source_root, 'tools')
+        self.tools_bin      = os.path.join(self.source_root, 'bin')
+        self.log_root       = ""
+        self.verbose        = True
         self.serial_procs   = 1
         self.parallel_procs = 4
         self.size_params    = {}
-        self.cvode_dir      = ""
 
         # These are overridden by method decorators (pn_pn_serial, pn_pn_parallel,
         # pn_pn_2_serial, and pn_pn_2_parallel)
@@ -164,88 +167,65 @@ class NekTestCase(unittest.TestCase):
 
         print("Getting setup options...")
 
-        # Get compilers from env, default to GNU
-        # --------------------------------------
-        self.f77     = os.environ.get('F77',   self.f77)
-        self.cc      = os.environ.get('CC',    self.cc)
-        self.ifmpi   = os.environ.get('IFMPI', self.ifmpi)
-        self.verbose = os.environ.get('VERBOSE_TESTS', self.verbose)
+        # Get compiler options from env
+        self.f77            = os.environ.get('F77', self.f77)
+        self.cc             = os.environ.get('CC', self.cc)
+        self.g              = os.environ.get('G', self.g)
+        self.pplist         = os.environ.get('PPLIST', self.pplist)
+        self.usr_lflags     = os.environ.get('USR_LFLAGS', self.usr_lflags)
+        self.ifmpi          = os.environ.get('IFMPI', self.ifmpi).lower() == 'true'
+
+        # Get paths from env
+        try:
+            self.source_root = os.path.abspath(os.environ['SOURCE_ROOT'])
+        except KeyError:
+            pass
+        else:
+            self.makenek        = os.path.join(self.source_root, 'core', 'makenek')
+            self.tools_root     = os.path.join(self.source_root, 'tools')
+            self.tools_bin      = os.path.join(self.source_root, 'bin')
+
+        self.examples_root = os.path.abspath(os.environ.get('EXAMPLES_ROOT', self.examples_root))
+        self.tools_root    = os.path.abspath(os.environ.get('TOOLS_ROOT', self.tools_root))
+        self.tools_bin     = os.path.abspath(os.environ.get('TOOLS_BIN', self.tools_bin))
+
+        try:
+            self.log_root = os.path.abspath(os.environ['LOG_ROOT'])
+        except KeyError:
+            pass
+
+        self.verbose        = os.environ.get('VERBOSE_TESTS', self.verbose).lower() == 'true'
         self.parallel_procs = int(os.environ.get('PARALLEL_PROCS', self.parallel_procs))
 
-        # String/bool conversions
-        self.ifmpi = str(self.ifmpi).lower()
-        self.ifmpi = self.ifmpi == 'yes' or self.ifmpi == 'true'
-
-        self.verbose = str(self.verbose).lower()
-        self.verbose = self.verbose == 'yes' or self.verbose == 'true'
-
+        # Print everything out
         for varname, varval in (
                 ('F77', self.f77),
                 ('CC', self.cc),
-                ('IFMPI', str(self.ifmpi).lower()),
-                ('VERBOSE_TESTS', str(self.verbose).lower()),
+                ('G', self.g),
+                ('PPLIST', self.pplist),
+                ('USR_LFLAGS', self.usr_lflags),
+                ('IFMPI', self.ifmpi),
+                ('SOURCE_ROOT', self.source_root),
+                ('EXAMPLES_ROOT', self.examples_root),
+                ('LOG_ROOT', self.log_root),
+                ('TOOLS_ROOT', self.tools_root),
+                ('TOOLS_BIN', self.tools_bin),
+                ('VERBOSE_TESTS', self.verbose),
                 ('PARALLEL_PROCS', self.parallel_procs)
         ):
-            print('    Using {0}={1}'.format(varname, varval))
-
-        # SOURCE_ROOT and EXAMPLES_ROOT must be defined.  Get from env and fail early if they don't exist
-        # -----------------------------------------------------------------------------------------------
-        self.source_root   = os.path.abspath(os.environ.get('SOURCE_ROOT',   self.source_root))
-        self.examples_root = os.path.abspath(os.environ.get('EXAMPLES_ROOT', self.examples_root))
-
-        for (varname, varval) in (('SOURCE_ROOT', self.source_root), ('EXAMPLES_ROOT', self.examples_root)):
-            if os.path.isdir(varval):
-                print('    Using {0} at {1}'.format(varname, varval))
-            else:
-                raise ValueError(
-                    'The {0} directory "{1}" does not exist. Please provide a valid directory using the env variable {0} ROOT.'.format(varname, varval))
-
-        # TOOLS_ROOT and TOOLS_BIN have default values, if not defined.  Raise error if they don't exist
-        # ------------------------------------------------------------------------------------------------
-        self.tools_root = os.environ.get('TOOLS_ROOT', self.tools_root)
-        if self.tools_root:
-            self.tools_root = os.path.abspath(self.tools_root)
-        else:
-            self.tools_root = os.path.abspath(os.path.join(self.source_root, 'tools'))
-
-        if os.path.isdir(self.tools_root):
-            print('    Using {0} at {1}'.format('TOOLS_ROOT', self.tools_root))
-        else:
-            raise ValueError(
-                'The {0} directory "{1}" does not exist. Please provide a valid directory using the env variable {0} ROOT.'.format('TOOLS_ROOT', self.tools_root))
-
-        # TOOLS_BIN has a default value.
-        # -----------------------------
-        self.tools_bin = os.environ.get('TOOLS_BIN', self.tools_bin)
-        if self.tools_bin:
-            self.tools_bin = os.path.abspath(self.tools_bin)
-        else:
-            self.tools_bin = os.path.abspath(os.path.join(self.source_root, 'bin'))
-
-        # LOG_ROOT has no default value and can remain undefined
-        # ------------------------------------------------------
-        self.log_root = os.environ.get('LOG_ROOT', '')
-        if self.log_root:
-            self.log_root = os.path.abspath(self.log_root)
-
-        # If TOOLS_BIN or LOG_ROOT don't exist, make them
-        #------------------------------------------------
-        for varval, varname in ((self.tools_bin, 'TOOLS_BIN'), (self.log_root,  'LOG_ROOT')):
             if varval:
-                if os.path.isdir(varval):
-                    print('    Using {0} at {1}'.format(varname, varval))
-                else:
-                    print('    The {0} directory, "{1}" does not exist.  It will be created'.format(varname, varval))
-                    os.makedirs(varval)
+                print('    Using {0:14} = "{1}"'.format(varname, varval))
 
-        # CVODE_DIR doesn't need to be defined.  It defaults to ""
-        #---------------------------------------------------------
-        self.cvode_dir = os.environ.get('CVODE_DIR', self.cvode_dir)
-
-        # Default destination of makenek
-        # ------------------------------
-        if not self.makenek:
-            self.makenek   = os.path.join(self.source_root, 'core', 'makenek')
+        # Verify that pathnames are valid
+        for varname, varval in (
+                ('SOURCE_ROOT', self.source_root),
+                ('EXAMPLES_ROOT', self.examples_root),
+                ('LOG_ROOT', self.log_root),
+                ('TOOLS_ROOT', self.tools_root),
+                ('TOOLS_BIN', self.tools_bin),
+        ):
+            if varval and not os.path.isdir(varval):
+                raise OSError('The {0} directory "{1}" does not exist. Please the env variable ${0} to a valid directory.'.format(varname, varval))
 
         print("Finished getting setup options!")
 
@@ -335,8 +315,11 @@ class NekTestCase(unittest.TestCase):
             usr_file = cls.case_name
 
         all_opts = dict(
-            F77   = self.f77,
-            CC    = self.cc,
+            F77 = self.f77,
+            CC = self.cc,
+            G = self.g,
+            PPLIST = self.pplist,
+            USR_LFLAGS = self.usr_lflags,
             IFMPI = str(self.ifmpi).lower(),
         )
         if opts:


### PR DESCRIPTION
This PR cleans-up the interface for the NekTests runtime options.  Previously, the interface relied on several environment varibles (such as `$CVODE_DIR`) that had no counterparts in makenek.  In this PR, the interface omits those variables and replaces them with useful variables from makenek such as:
* `$G`
* `$USR_LFLAGS`
* `$PPLIST`

This should future-proof NekTests for upcoming Nek functionalities, such as CMT, which also rely on `$PPLIST` and `$USR_FLAGS`.  