### PR TITLE
Correct PPLIST when IFPROFILING=true and IFMPI=false

### DIFF
--- a/core/makenek.inc
+++ b/core/makenek.inc
@@ -269,7 +269,11 @@ if [ "$UNDERSCORE" == "true" ]; then
 fi 
 
 if [ "$IFPROFILING" == "true" -o "$IFPROFILING" == "yes" ]; then
+  if [ "$IFMPI" == "true" -o "IFMPI" == "yes" ]; then
     PPLIST="${PPLIST} TIMER MPITIMER"
+  else
+    PPLIST="${PPLIST} TIMER"
+  fi
 fi
 
 PPLIST="${PPLIST} GLOBAL_LONG_LONG"


### PR DESCRIPTION
When IFPROFILING=true and IFMPI=fase, the MPITIMER symbol was still added to PPLIST.  This caused fatal compilation errors in all serial builds, as seen in [Travis](https://travis-ci.org/Nek5000/Nek5000/builds/181045970) and [Jenkins](https://jenkins-ci.cels.anl.gov/job/Nek5000/34/).  

With this PR, MPITIMER is not added to PPLIST when IFMPI=false