### PR TITLE
Exclude serial tests when IFMPI=true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,48 +4,48 @@ sudo: required
 
 env:
   matrix:
-    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
-    - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
+    - TEST_CASE=Eddy_EddyUv::test_PnPn_Serial  IFMPI=false F77=gfortran CC=gcc
+    - TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial IFMPI=false F77=gfortran CC=gcc
 
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Serial
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Parallel
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Serial
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Parallel
+    # - TEST_CASE=Axi::test_PnPn_Serial  IFMPI=true F77=mpif77 CC=mpicc
+    - TEST_CASE=Axi::test_PnPn_Parallel  IFMPI=true F77=mpif77 CC=mpicc
+    # - TEST_CASE=Axi::test_PnPn2_Serial IFMPI=true F77=mpif77 CC=mpicc
+    - TEST_CASE=Axi::test_PnPn2_Parallel IFMPI=true F77=mpif77 CC=mpicc
 
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn_Serial
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn2_Serial
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn_Parallel
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn2_Parallel
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn2_Serial
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
+    # - TEST_CASE=Benard_Ray9::test_PnPn_Serial   IFMPI=true F77=mpif77 CC=mpicc
+    # - TEST_CASE=Benard_Ray9::test_PnPn2_Serial  IFMPI=true F77=mpif77 CC=mpicc
+    - TEST_CASE=Benard_Ray9::test_PnPn_Parallel   IFMPI=true F77=mpif77 CC=mpicc
+    - TEST_CASE=Benard_Ray9::test_PnPn2_Parallel  IFMPI=true F77=mpif77 CC=mpicc
+    # - TEST_CASE=Benard_RayDD::test_PnPn_Serial  IFMPI=true F77=mpif77 CC=mpicc # Exceeds time limit for Travis jobs
+    # - TEST_CASE=Benard_RayDD::test_PnPn2_Serial IFMPI=true F77=mpif77 CC=mpicc # Stdout exceeds Travis' max log length
+    # - TEST_CASE=Benard_RayDN::test_PnPn_Serial  IFMPI=true F77=mpif77 CC=mpicc # Exceeds time limit for Travis jobs
+    # - TEST_CASE=Benard_RayDN::test_PnPn2_Serial IFMPI=true F77=mpif77 CC=mpicc
+    # - TEST_CASE=Benard_RayNN::test_PnPn_Serial  IFMPI=true F77=mpif77 CC=mpicc # Exceeds time limit for Travis jobs
+    # - TEST_CASE=Benard_RayNN::test_PnPn2_Serial IFMPI=true F77=mpif77 CC=mpicc # Exceeds time limit for Travis jobs
 
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Parallel
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Parallel
+    # - TEST_CASE=Eddy_EddyUv::test_PnPn_Serial  IFMPI=true F77=mpif77 CC=mpicc
+    - TEST_CASE=Eddy_EddyUv::test_PnPn_Parallel  IFMPI=true F77=mpif77 CC=mpicc
+    # - TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial IFMPI=true F77=mpif77 CC=mpicc
+    - TEST_CASE=Eddy_EddyUv::test_PnPn2_Parallel IFMPI=true F77=mpif77 CC=mpicc
 
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Serial
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Parallel
+    # - TEST_CASE=KovStState::test_PnPn2_Serial IFMPI=true F77=mpif77 CC=mpicc
+    - TEST_CASE=KovStState::test_PnPn2_Parallel IFMPI=true F77=mpif77 CC=mpicc
 
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Serial
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Parallel
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Serial
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Parallel
+    # - TEST_CASE=LowMachTest::test_PnPn_Serial  IFMPI=true F77=mpif77 CC=mpicc
+    - TEST_CASE=LowMachTest::test_PnPn_Parallel  IFMPI=true F77=mpif77 CC=mpicc
+    # - TEST_CASE=LowMachTest::test_PnPn2_Serial IFMPI=true F77=mpif77 CC=mpicc
+    - TEST_CASE=LowMachTest::test_PnPn2_Parallel IFMPI=true F77=mpif77 CC=mpicc
 
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn_Serial    # Stdout exceeds Travis' max log length
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn_Parallel  # Stdout exceeds Travis' max log length
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Serial   # Stdout exceeds Travis' max log length
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn2_Parallel # Stdout exceeds Travis' max log length
+    # - TEST_CASE=VarVis::test_PnPn_Serial    IFMPI=true F77=mpif77 CC=mpicc # Stdout exceeds Travis' max log length
+    # - TEST_CASE=VarVis::test_PnPn_Parallel  IFMPI=true F77=mpif77 CC=mpicc # Stdout exceeds Travis' max log length
+    # - TEST_CASE=VarVis::test_PnPn2_Serial   IFMPI=true F77=mpif77 CC=mpicc # Stdout exceeds Travis' max log length
+    # - TEST_CASE=VarVis::test_PnPn2_Parallel IFMPI=true F77=mpif77 CC=mpicc # Stdout exceeds Travis' max log length
 
-    # - IFMPI=true F77=mpif77 CC=mpicc PPLIST="$PPLIST CMTNEK" TEST_CASE=CmtInviscidVortex::test_PnPn_Serial
-    # - IFMPI=true F77=mpif77 CC=mpicc PPLIST="$PPLIST CMTNEK" TEST_CASE=CmtInviscidVortex::test_PnPn_Parallel
+    # - TEST_CASE=CmtInviscidVortex::test_PnPn_Serial   IFMPI=true F77=mpif77 CC=mpicc PPLIST="$PPLIST CMTNEK"
+    # - TEST_CASE=CmtInviscidVortex::test_PnPn_Parallel IFMPI=true F77=mpif77 CC=mpicc PPLIST="$PPLIST CMTNEK"
 
-    - IFMPI=true F77=mpif77 CC=mpicc PPLIST="$PPLIST CVODE" TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e3
-    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e4 # Exceeds time limit for Travis jobs
+    - TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e3   IFMPI=true F77=mpif77 CC=mpicc PPLIST="$PPLIST CVODE"
+    # - TEST_CASE=MvCylCvode::test_PnPn_Parallel_Steps1e4 IFMPI=true F77=mpif77 CC=mpicc PPLIST="$PPLIST CVODE" # Exceeds time limit for Travis jobs
 
 before_install: 
   - export ROOT_DIR=`pwd`

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,31 +7,33 @@ env:
     - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
     - IFMPI=false F77=gfortran CC=gcc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
 
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Serial
     - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn_Parallel
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Serial
     - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Axi::test_PnPn2_Parallel
 
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn_Serial
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn2_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn2_Serial
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn_Parallel
+    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_Ray9::test_PnPn2_Parallel
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDD::test_PnPn_Serial   # Exceeds time limit for Travis jobs
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDD::test_PnPn2_Serial  # Stdout exceeds Travis' max log length
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn2_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayDN::test_PnPn2_Serial
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayNN::test_PnPn_Serial   # Exceeds time limit for Travis jobs
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Benard_RayNN::test_PnPn2_Serial  # Exceeds time limit for Travis jobs
 
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Serial
     - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn_Parallel
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial
     - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=Eddy_EddyUv::test_PnPn2_Parallel
 
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Serial
     - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=KovStState::test_PnPn2_Parallel
 
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Serial
     - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn_Parallel
-    - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Serial
+    # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Serial
     - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=LowMachTest::test_PnPn2_Parallel
 
     # - IFMPI=true F77=mpif77 CC=mpicc TEST_CASE=VarVis::test_PnPn_Serial    # Stdout exceeds Travis' max log length


### PR DESCRIPTION
As @stgeke requested, this PR excludes serial Travis tests when IFMPI=true.  Jenkins still runs a serial tests when IFMPI=true.  