### PR TITLE
Default BIGMEM=true in maketools

### DIFF
--- a/tools/maketools
+++ b/tools/maketools
@@ -11,7 +11,7 @@ CC="gcc"
 #USR_LFLAGS="-L$HOME/lib"
 
 # enable BIG MEMORY suuport
-#BIGMEM="true"
+BIGMEM="true"
 
 
 


### PR DESCRIPTION
Without BIGMEM=true I get the classic relocation trucncation error at link time for prenek:
```
/usr/bin/gfortran -o /home/rahaman/repos/Nek5000/bin/prex prenek.o curve.o edit.o build.o build1.o build2.o bound.o plot.o xinterface.o glomod.o legend.o vprops.o iolib.o subs.o zipper2.o postnek6.o screen.o revert.o crs.o mxm.o xdriver.o  -L/usr/lib/X11 -lX11 -lm
curve.o: In function `hex_transition_3d_e_':
curve.f:(.text+0x63f0): relocation truncated to fit: R_X86_64_PC32 against symbol `ctmp2_' defined in COMMON section in zipper2.o
```
This is on my 64-bit Ubuntu workstation with /usr/bin/gfortran.  This seems like a pretty representative system for our users.   

Can we set BIGMEM=true as the default?
