### PR TITLE
Added flexible checkpoint functionality

### DIFF
--- a/core/TSTEP
+++ b/core/TSTEP
@@ -26,18 +26,20 @@ c
      $       ,nmxh,nmxp,nmxe,nmxnl,ninter
      $       ,nelfld(0:ldimt1)
      $       ,nconv,nconv_max
+     $       ,ioinfodmp
       common /istep2/ ifield,imesh,istep,nsteps,iostep,lastep,iocomm
      $               ,instep
      $               ,nab,nbd,nbdinp,ntaubd 
      $               ,nmxh,nmxp,nmxe,nmxnl,ninter
      $               ,nelfld
      $               ,nconv,nconv_max
+     $               ,ioinfodmp
 
       real pi,betag,gtheta
       common /tstep3/ pi,betag,gtheta
       
-      logical ifprnt,if_full_pres
-      common /tstep4/ ifprnt,if_full_pres
+      logical ifprnt,if_full_pres,ifoutfld
+      common /tstep4/ ifprnt,if_full_pres,ifoutfld
       
 
       real lyap(3,lpert)

--- a/core/drive1.f
+++ b/core/drive1.f
@@ -197,8 +197,10 @@ c-----------------------------------------------------------------------
 
       do kstep=1,nsteps,msteps
          call nek__multi_advance(kstep,msteps)
+         call check_ioinfo  
+         call set_outfld
          call userchk
-         call prepost (.false.,'his')
+         call prepost (ifoutfld,'his')
          call in_situ_check()
          if (lastep .eq. 1) goto 1001
       enddo

--- a/core/prepost.f
+++ b/core/prepost.f
@@ -1,22 +1,44 @@
 c-----------------------------------------------------------------------
-      subroutine prepost(ifdoin,prefin)
+      subroutine set_outfld
 
-c     Store results for later postprocessing
-c
-c     Recent updates:
-c
-c     p65 now indicates the number of parallel i/o files; iff p66 >= 6
-
+c     Check if we are going to checkpoint at this timestep
+c     and set ifoutfld accordingly
 
       include 'SIZE'
       include 'TOTAL'
-      include 'CTIMER'
 
-C     Work arrays and temporary arrays
+      common /rdump/ ntdump
 
-      common /scrcg/ pm1 (lx1,ly1,lz1,lelv)
+      ifoutfld = .false.
 
-c     note, this usage of CTMP1 will be less than elsewhere if NELT ~> 3.
+      if (iostep.lt.0 .or. timeio.lt.0) return
+
+      if (istep.ge.nsteps) lastep=1
+
+      timdump=0
+      if (timeio.ne.0.0) then
+         if (time.ge.(ntdump + 1)*timeio) then
+            timdump=1.
+            ntdump=ntdump+1
+         endif
+      endif
+
+      if (istep.gt.0 .and. iostep.gt.0) then
+         if(mod(istep,iostep) .eq. 0) ifoutfld=.true.
+      endif
+
+      if(ioinfodmp.ne.0.or.lastep.eq.1.or.timdump.eq.1.) ifoutfld=.true.
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine check_ioinfo
+
+c     Check for io request in file 'ioinfo'
+
+      include 'SIZE'
+      include 'TSTEP'
+
       parameter (lxyz=lx1*ly1*lz1)
       parameter (lpsc9=ldimt1+9)
       common /ctmp1/ tdump(lxyz,lpsc9)
@@ -24,35 +46,63 @@ c     note, this usage of CTMP1 will be less than elsewhere if NELT ~> 3.
       real           tdmp(4)
       equivalence   (tdump,tdmp)
 
-      real*4         test_pattern
-
-      character*3    prefin,prefix
-      character*1    fhdfle1(132)
-      character*132   fhdfle
-      equivalence   (fhdfle,fhdfle1)
-      character*1    fldfile2(120)
-      integer        fldfilei( 60)
-      equivalence   (fldfilei,fldfile2)
-
-      common /doit/ ifdoit
-      logical       ifdoit
-      logical       ifdoin
-
-      real hdump(25)
-      real xpart(10),ypart(10),zpart(10)
-      character*10 frmat
-      integer nopen(99)
-      save    nopen
-      data    nopen /99*0/
-      common /rdump/ ntdump
-      data ndumps / 0 /
-
-      logical ifhis
-
       integer maxstep
       save    maxstep
       data    maxstep /999999999/
 
+      if (iostep.lt.0 .or. timeio.lt.0) return
+
+      ioinfodmp=0
+      if (nid.eq.0 .and. (mod(istep,10).eq.0 .or. istep.lt.200)) then
+         open(unit=87,file='ioinfo',status='old',err=88)
+         read(87,*,end=87,err=87) idummy
+         if (ioinfodmp.eq.0) ioinfodmp=idummy
+         if (idummy.ne.0) then  ! overwrite last i/o request
+            rewind(87)
+            write(87,86)
+   86       format(' 0')
+         endif
+   87    continue
+         close(unit=87)
+   88    continue
+         if (ioinfodmp.ne.0) write(6,*) 'Output:',ioinfodmp
+      endif
+
+      tdmp(1)=ioinfodmp
+      call gop(tdmp,tdmp(3),'+  ',1)
+      ioinfodmp=tdmp(1)
+      if (ioinfodmp.lt.0) maxstep=abs(ioinfodmp)
+      if (istep.ge.maxstep.or.ioinfodmp.eq.-2) lastep=1
+      if (ioinfodmp.eq.-2) return
+      if (ioinfodmp.lt.0) ioinfodmp = 0
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine prepost(ifdoin,prefin)
+
+c     Store results for later postprocessing
+c
+c     Recent updates:
+c
+c     p65 now indicates the number of parallel i/o files; iff p66 >= 6
+c
+c     we now check whether we are going to checkpoint in set_outfld
+c
+      include 'SIZE'
+      include 'TOTAL'
+      include 'CTIMER'
+
+      common /scrcg/ pm1 (lx1,ly1,lz1,lelv)
+
+      character*3    prefin,prefix
+
+      logical  ifdoin
+      logical  ifhis
+
+      common /rdump/ ntdump
+      data ndumps / 0 /
+   
       if (iostep.lt.0 .or. timeio.lt.0) return
 
       icalld=icalld+1
@@ -87,52 +137,7 @@ c     Trigger history output only if prefix = 'his'   pff 8/18/05
 
       call prepost_map(0) ! map pr and axisymm. arrays
 
-      if(istep .ge. nsteps) lastep=1
-
-      timdump=0
-      if(timeio.ne.0.0)then
-         if(time .ge. (ntdump + 1) * timeio) then
-            timdump=1.
-            ntdump=ntdump+1
-         endif
-      endif
-
-      if (istep.gt.0 .and. iostep.gt.0) then
-         if(mod(istep,iostep) .eq. 0) ifdoit=.true.
-      endif
-
-
-      ! check for io request in file 'ioinfo'
-      iiidmp=0
-      if (nid.eq.0 .and. (mod(istep,10).eq.0 .or. istep.lt.200)) then 
-         open(unit=87,file='ioinfo',status='old',err=88)
-         read(87,*,end=87,err=87) idummy
-         if (iiidmp.eq.0) iiidmp=idummy
-         if (idummy.ne.0) then  ! overwrite last i/o request
-            rewind(87)
-            write(87,86)
-   86       format(' 0')
-         endif
-   87    continue
-         close(unit=87)
-   88    continue
-         if (iiidmp.ne.0) write(6,*) 'Output:',iiidmp
-      endif
-
-      tdmp(1)=iiidmp
-      call gop(tdmp,tdmp(3),'+  ',1)
-      iiidmp= tdmp(1)
-      if (iiidmp.lt.0) maxstep=abs(iiidmp)
-      if (istep.ge.maxstep.or.iiidmp.eq.-2) lastep=1
-      if (iiidmp.eq.-2) return
-      if (iiidmp.lt.0) iiidmp = 0
-
-      if (ifdoin) ifdoit=.true.
-      if (iiidmp.ne.0.or.lastep.eq.1.or.timdump.eq.1.) ifdoit=.true.
-
-
-c      if (ifdoit.and.nio.eq.0)write(6,*)'call outfld: ifpsco:',ifpsco(1)
-      if (ifdoit) call outfld(prefix)
+      if (ifdoin) call outfld(prefix)
 
       call outhis(ifhis)
 
@@ -144,9 +149,7 @@ c      if (ifdoit.and.nio.eq.0)write(6,*)'call outfld: ifpsco:',ifpsco(1)
       tprep=tprep+dnekclock()-etime1
 #endif
 
-      ifdoit=.false.
       return
-
       end
 c-----------------------------------------------------------------------
       subroutine prepost_map(isave) ! isave=0-->fwd, isave=1-->bkwd

--- a/core/prepost.f
+++ b/core/prepost.f
@@ -73,8 +73,6 @@ c     Check for io request in file 'ioinfo'
       ioinfodmp=tdmp(1)
       if (ioinfodmp.lt.0) maxstep=abs(ioinfodmp)
       if (istep.ge.maxstep.or.ioinfodmp.eq.-2) lastep=1
-      if (ioinfodmp.eq.-2) return
-      if (ioinfodmp.lt.0) ioinfodmp = 0
 
       return
       end
@@ -136,6 +134,8 @@ c     Trigger history output only if prefix = 'his'   pff 8/18/05
       endif
 
       call prepost_map(0) ! map pr and axisymm. arrays
+
+      if (ioinfodmp.eq.-2) return
 
       if (ifdoin) call outfld(prefix)
 


### PR DESCRIPTION
This was done by introducing the new common logical variable ifoutfld,
which is set to .TRUE. in set_outffld (called before userchk), when iostep
or iotime criteria are satisfied.

This flag can be used for example in userchk to synchronize dumping 
of the field files with the calculation of any additional post-processing 
quantities, even when using iotime for checkpointing.