### PR TITLE
Added short_test for eddy w/ legacy SIZE file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,11 @@ env:
     # - TEST_CASE=Benard_RayNN::test_PnPn_Serial  IFMPI=true F77=mpif77 CC=mpicc # Exceeds time limit for Travis jobs
     # - TEST_CASE=Benard_RayNN::test_PnPn2_Serial IFMPI=true F77=mpif77 CC=mpicc # Exceeds time limit for Travis jobs
 
-    # - TEST_CASE=Eddy_EddyUv::test_PnPn_Serial  IFMPI=true F77=mpif77 CC=mpicc
     - TEST_CASE=Eddy_EddyUv::test_PnPn_Parallel  IFMPI=true F77=mpif77 CC=mpicc
-    # - TEST_CASE=Eddy_EddyUv::test_PnPn2_Serial IFMPI=true F77=mpif77 CC=mpicc
     - TEST_CASE=Eddy_EddyUv::test_PnPn2_Parallel IFMPI=true F77=mpif77 CC=mpicc
+
+    - TEST_CASE=Eddy_LegacySize::test_PnPn_Parallel  IFMPI=true F77=mpif77 CC=mpicc
+    - TEST_CASE=Eddy_LegacySize::test_PnPn2_Parallel IFMPI=true F77=mpif77 CC=mpicc
 
     # - TEST_CASE=KovStState::test_PnPn2_Serial IFMPI=true F77=mpif77 CC=mpicc
     - TEST_CASE=KovStState::test_PnPn2_Parallel IFMPI=true F77=mpif77 CC=mpicc

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -700,6 +700,121 @@ class Eddy_EddyUv(NekTestCase):
     def tearDown(self):
         self.move_logs()
 
+
+class Eddy_LegacySize(NekTestCase):
+    example_subdir  = 'eddy'
+    case_name       = 'eddy_uv'
+
+    def setUp(self):
+
+        # Default SIZE parameters. Can be overridden in test cases
+        self.size_params = dict(
+            lx2       = '',
+            ly2       = '',
+            lz2       = '',
+        )
+
+        self.build_tools(['genmap'])
+
+        # Tweak the .rea file and run genmap
+        from re import sub
+        cls = self.__class__
+        rea_path = os.path.join(self.examples_root, cls.example_subdir, cls.case_name + '.rea')
+        with open(rea_path, 'r') as f:
+            lines = [sub(r'^.*DIVERGENCE$', '      0.10000E-08', l) for l in f]
+        with open(rea_path, 'w') as f:
+            f.writelines(lines)
+        self.run_genmap()
+
+    @pn_pn_serial
+    def test_PnPn_Serial(self):
+        # Update SIZE parameters for PnPn
+        self.size_params['lx2'] = 'lx1'
+        self.size_params['ly2'] = 'ly1'
+        self.size_params['lz2'] = 'lz1'
+        self.config_size(infile=os.path.join(self.examples_root, self.__class__.example_subdir, 'SIZE.legacy'))
+        self.build_nek()
+        self.run_nek(step_limit=None)
+
+        gmres = self.get_value_from_log('gmres ', column=-7,)
+        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=34., label='gmres')
+
+        xerr = self.get_value_from_log('X err', column=-6, row=-1)
+        self.assertAlmostEqualDelayed(xerr, target_val=6.007702E-07, delta=1E-06, label='X err')
+
+        yerr = self.get_value_from_log('Y err', column=-6, row=-1)
+        self.assertAlmostEqualDelayed(yerr, target_val=6.489061E-07, delta=1E-06, label='Y err')
+
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=80, label='total solver time')
+
+        self.assertDelayedFailures()
+
+    @pn_pn_parallel
+    def test_PnPn_Parallel(self):
+        self.size_params['lx2'] = 'lx1'
+        self.size_params['ly2'] = 'ly1'
+        self.size_params['lz2'] = 'lz1'
+        self.config_size(infile=os.path.join(self.examples_root, self.__class__.example_subdir, 'SIZE.legacy'))
+        self.build_nek()
+        self.run_nek(step_limit=None)
+
+        gmres = self.get_value_from_log('gmres ', column=-7,)
+        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=34., label='gmres')
+
+        xerr = self.get_value_from_log('X err', column=-6, row=-1)
+        self.assertAlmostEqualDelayed(xerr, target_val=6.007702E-07, delta=1E-06, label='X err')
+
+        yerr = self.get_value_from_log('Y err', column=-6, row=-1)
+        self.assertAlmostEqualDelayed(yerr, target_val=6.489061E-07, delta=1E-06, label='Y err')
+
+        self.assertDelayedFailures()
+
+    @pn_pn_2_serial
+    def test_PnPn2_Serial(self):
+        self.size_params['lx2'] = 'lx1-2'
+        self.size_params['ly2'] = 'ly1-2'
+        self.size_params['lz2'] = 'lz1'
+        self.config_size(infile=os.path.join(self.examples_root, self.__class__.example_subdir, 'SIZE.legacy'))
+        self.build_nek()
+        self.run_nek(step_limit=None)
+
+        gmres = self.get_value_from_log('gmres ', column=-6,)
+        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=22., label='gmres')
+
+        xerr = self.get_value_from_log('X err', column=-6, row=-1)
+        self.assertAlmostEqualDelayed(xerr, target_val=6.759103E-05, delta=1E-06, label='X err')
+
+        yerr = self.get_value_from_log('Y err', column=-6, row=-1)
+        self.assertAlmostEqualDelayed(yerr, target_val=7.842019E-05, delta=1E-06, label='Y err')
+
+        # solver_time = self.get_value_from_log('total solver time', column=-2)
+        # self.assertAlmostEqualDelayed(solver_time, 0.1, delta=80, label='total solver time')
+
+        self.assertDelayedFailures()
+
+    @pn_pn_2_parallel
+    def test_PnPn2_Parallel(self):
+        self.size_params['lx2'] = 'lx1-2'
+        self.size_params['ly2'] = 'ly1-2'
+        self.size_params['lz2'] = 'lz1'
+        self.config_size(infile=os.path.join(self.examples_root, self.__class__.example_subdir, 'SIZE.legacy'))
+        self.build_nek()
+        self.run_nek(step_limit=None)
+
+        gmres = self.get_value_from_log('gmres ', column=-6,)
+        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=22., label='gmres')
+
+        xerr = self.get_value_from_log('X err', column=-6, row=-1)
+        self.assertAlmostEqualDelayed(xerr, target_val=6.759103E-05, delta=1E-06, label='X err')
+
+        yerr = self.get_value_from_log('Y err', column=-6, row=-1)
+        self.assertAlmostEqualDelayed(yerr, target_val=7.842019E-05, delta=1E-06, label='Y err')
+
+        self.assertDelayedFailures()
+
+    def tearDown(self):
+        self.move_logs()
 ####################################################################
 #  kov_st_state; kov_st_stokes.rea
 ####################################################################

--- a/short_tests/eddy/SIZE.legacy
+++ b/short_tests/eddy/SIZE.legacy
@@ -1,0 +1,89 @@
+C     Dimension file to be included
+C
+C     HCUBE array dimensions
+C
+      parameter (ldim=2)
+      parameter (lx1=8,ly1=lx1,lz1=1,lelt=300,lelv=lelt)
+      parameter (lxd=12,lyd=lxd,lzd=1)
+      parameter (lelx=20,lely=20,lelz=1)
+ 
+      parameter (lzl=3 + 2*(ldim-3))
+ 
+      parameter (lx2=lx1-2)
+      parameter (ly2=ly1-2)
+      parameter (lz2=lz1  )
+      parameter (lx3=lx1)
+      parameter (ly3=ly1)
+      parameter (lz3=lz1)
+
+      parameter (lp = 512)
+      parameter (lelg = 4100)
+c
+c     parameter (lpelv=lelv,lpelt=lelt,lpert=3)  ! perturbation
+c     parameter (lpx1=lx1,lpy1=ly1,lpz1=lz1)     ! array sizes
+c     parameter (lpx2=lx2,lpy2=ly2,lpz2=lz2)
+c
+      parameter (lpelv=1,lpelt=1,lpert=1)        ! perturbation
+      parameter (lpx1=1,lpy1=1,lpz1=1)           ! array sizes
+      parameter (lpx2=1,lpy2=1,lpz2=1)
+c
+c     parameter (lbelv=lelv,lbelt=lelt)          ! MHD
+c     parameter (lbx1=lx1,lby1=ly1,lbz1=lz1)     ! array sizes
+c     parameter (lbx2=lx2,lby2=ly2,lbz2=lz2)
+c
+      parameter (lbelv=1,lbelt=1)                ! MHD
+      parameter (lbx1=1,lby1=1,lbz1=1)           ! array sizes
+      parameter (lbx2=1,lby2=1,lbz2=1)
+ 
+C     LX1M=LX1 when there are moving meshes; =1 otherwise
+      parameter (lx1m=1,ly1m=1,lz1m=1)
+      parameter (ldimt= 2)                       ! 2 passive scalars + T
+      parameter (ldimt1=ldimt+1)
+      parameter (ldimt3=ldimt+3)
+c
+c     Note:  In the new code, LELGEC should be about sqrt(LELG)
+c
+      PARAMETER (LELGEC = 1)
+      PARAMETER (LXYZ2  = 1)
+      PARAMETER (LXZ21  = 1)
+ 
+      PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
+      PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
+      PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
+      PARAMETER (LXZ=LX1*LZ1)
+      PARAMETER (LORDER=3)
+      PARAMETER (MAXOBJ=4,MAXMBR=LELT*6)
+      PARAMETER (lhis=100)         ! # of pts a proc reads from hpts.in
+                                   ! Note: lhis*np > npoints in hpts.in
+C
+C     Common Block Dimensions
+C
+      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)
+      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
+C
+C     The parameter LVEC controls whether an additional 42 field arrays
+C     are required for Steady State Solutions.  If you are not using
+C     Steady State, it is recommended that LVEC=1.
+C
+      PARAMETER (LVEC=1)
+C
+C     Uzawa projection array dimensions
+C
+      parameter (mxprev = 20)
+      parameter (lgmres = 30)
+C
+C     Split projection array dimensions
+C
+      parameter(lmvec = 1)
+      parameter(lsvec = 1)
+      parameter(lstore=lmvec*lsvec)
+c
+c     NONCONFORMING STUFF
+c
+      parameter (maxmor = lelt)
+C
+C     Array dimensions
+C
+      COMMON/DIMN/NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
+     $,NX3,NY3,NZ3,NDIM,NFIELD,NPERT,NID
+     $,NXD,NYD,NZD


### PR DESCRIPTION
Fixes #153 

In NekTests.py, I have implemented tests for eddy using the legacy SIZE file.  Tests are implemented for PnPn serial, PnPn parallel, PnPn-2 serial, and PnPn-2 parallel.

The .travis.yml only runs two of those tests: PnPn parallel and PnPn-2 parallel.  If anyone desires, we can easily add all four tests to .travis.yml