### PR TITLE
Fixed regex in NekTests to config makenek correctly

### DIFF
--- a/core/makenek
+++ b/core/makenek
@@ -11,7 +11,7 @@ F77="mpif77"
 CC="mpicc"
 
 # pre-processor list (set to "?" to get a list of available symbols)
-PPLIST="" 
+#PPLIST="" 
 
 # generic compiler flags
 #G="-g"

--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -21,7 +21,7 @@ def config_makenek(opts, infile, outfile):
         lines = f.readlines()
 
     for key, val in opts.iteritems():
-        lines = [re.sub(r'^#*{0}=\"+.+?\"+'.format(key), r'{0}="{1}"'.format(key, val), l) for l in lines]
+        lines = [re.sub(r'^#*{0}=\"+.*?\"+'.format(key), r'{0}="{1}"'.format(key, val), l) for l in lines]
 
     lines = [re.sub(r'(^source\s+\$SOURCE_ROOT/makenek.inc)', r'\g<1> >compiler.out', l)
              for l in lines]


### PR DESCRIPTION
After a slight change in makenek, the NekTests.py script got confused and couldn't configure makenek properly.  In particular, the NekTests script didn't add CVODE or CMTNEK to PPLIST in makenek.  This caused the errors first seen in this build:
https://travis-ci.org/Nek5000/Nek5000/builds/196727609

This PR fixes that issue with a tweak to NekTests.  The tweaks to makenek aren't necessary; they're just a reversion to the older version prior to @stgeke's workaround.  