### PR TITLE
Issue115

### DIFF
--- a/core/navier0.f
+++ b/core/navier0.f
@@ -36,6 +36,7 @@ c     write(6,*) solver_type,' solver type',iesolv
                CALL UZAWA (RES,H1,H2,H2INV,INTYPE,ICG)
             else
                call uzawa_gmres(res,h1,h2,h2inv,intype,icg)
+c               call uzawa_lgmres(res,h1,h2,h2inv,intype,icg)
             endif
          endif
       else


### PR DESCRIPTION
Summary of changes:
* uzawa_gmres() is modified so that the inner products are directly weighted with bm2inv, instead of using the arrays ml and mu.
* To detect possible issues in orthogonality of the Krylov vectors due to the classical Gram-Schmidt orthogonalization, modified Gram-Schmidt is turned on after the first restart.
* For high iteration counts where the solver needs to be restarted multiple times, the restart vector might become nearly parallel to the restart vector two restarts ago (due to lack of orthogonality to previous Krylov spaces). To overcome such issues LGMRES (Baker et al. 2005) is implemented (not activated by default). A test has also been implemented for checking the angles between three consecutive residual vectors (commented by default) so the user can assess whether activating LGMRES would be beneficial.