### PR TITLE
Rewrite visnek script in bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Nek5000 
+# Nek5000
 
 | **`Short Tests`** | **`Examples`** |
-|-----------------|---------------------|------------------|-------------------|---------------|
-| [![Build](https://travis-ci.org/Nek5000/Nek5000.svg?branch=develop)](https://travis-ci.org/Nek5000/Nek5000) | [![Build Status](https://jenkins-ci.cels.anl.gov/buildStatus/icon?job=Nek5000)](https://jenkins-ci.cels.anl.gov/job/Nek5000/) | 
+|-----------------|---------------------|
+| [![Build](https://travis-ci.org/Nek5000/Nek5000.svg?branch=develop)](https://travis-ci.org/Nek5000/Nek5000) | [![Build Status](https://jenkins-ci.cels.anl.gov/buildStatus/icon?job=Nek5000)](https://jenkins-ci.cels.anl.gov/job/Nek5000/) |
 
 Nek5000 is an open source, fast and scalable spectral element CFD code designed to simulate unsteady incompressible and low Mach-number Navier-Stokes flows.
 
@@ -15,7 +15,7 @@ Nek5000 is an open source, fast and scalable spectral element CFD code designed 
 * Easy-to-build with minimal dependencies
 * High-order conformal curved quadrilateral/hexahedral meshes
 * 2nd/3rd order adaptive semi-implicit timestepping
-* Efficient multigrid preconditioners  
+* Efficient multigrid preconditioners
 * Parallel I/O
 * Moving mesh and free surface flow
 * Lagrangian particle tracking
@@ -41,10 +41,10 @@ export PATH=~/Nek5000/bin:$PATH
 cd ~/Nek5000/tools; ./maketools genmap
 cd ~/Nek5000/run; cp -r ~/Nek5000/short-tests/eddy .
 cp /Nek5000/core/makenek .
-./makenek eddy_uv 
+./makenek eddy_uv
 genmap             # on input type eddy_uv
 nekmpi eddy_uv 2   # to run on 2 ranks
-``` 
+```
 
 **Note:** For more information see [here](http://nek5000.github.io/NekDoc/Nek_usersch2.html)
 
@@ -61,17 +61,17 @@ Nek5000 is hosted on GitHub and all bugs are reported and tracked through the Is
 
 ## Contributing
 
-Our project is hosted on [GibHub](https://github.com/Nek5000/Nek5000). If you are planning a large contribution, we encourage you to discuss the concept here on GitHub and interact with us frequently to ensure that your effort is well-directed. 
+Our project is hosted on [GibHub](https://github.com/Nek5000/Nek5000). If you are planning a large contribution, we encourage you to discuss the concept here on GitHub and interact with us frequently to ensure that your effort is well-directed.
 
 ### How we do it
 - Anything in master is always deployable
 - Upcoming feature release get their own tags or branch that are branched out of master
 - All development happens on the master branch.
 - To work on something new, create a short lived local branch off of master
-- When you need feedback or help, or your change is ready for merging, open a pull request. 
+- When you need feedback or help, or your change is ready for merging, open a pull request.
 
 ### One-time Setup
-1. Fork our [GitHub project](https://github.com/Nek5000/Nek5000) 
+1. Fork our [GitHub project](https://github.com/Nek5000/Nek5000)
 2. Download fork with `git clone -o myfork https://github.com/<username>/Nek5000.git ~/Nek5000`
 3. Add our repo `cd ~/Nek5000; git remote add origin https://github.com/Nek5000/Nek5000.git`
 4. Download our repo `git fetch origin`
@@ -83,40 +83,38 @@ Our project is hosted on [GibHub](https://github.com/Nek5000/Nek5000). If you ar
 [hub]
         ...
         upstream = Nek5000/Nek5000
-        forkremote = myfork 
-``` 
+        forkremote = myfork
+```
 
 ### Typical Workflow
 1. Create a feature branch hosting your change with `nekgit_co <descriptive name>`. Using a dedicated branch for every feature helps you to move between different developments while some are work in progress or under review.
 2. Implement your code changes. To reset your branch and discard any changes run `git reset --hard origin/master`. To revert a set of files run `git checkout <file1 file2 ...>`
 3. Commit your changes to your local repo using e.g. `git commit -a`. Do this frequently to save your work.
 4. Periodically, changes made in our master should be pulled back into your local branch by `git pull -r`. This ensures that we do not end up in integration hell that will happen when many feature branches need to be combined at once.
-5. If there are no merge conflicts, go to the next step. In case of conflicts edit the unmerged files in question. Merge conflicts are indicated  by the conflict marker `<<<<<<<` in your file. 
+5. If there are no merge conflicts, go to the next step. In case of conflicts edit the unmerged files in question. Merge conflicts are indicated  by the conflict marker `<<<<<<<` in your file.
 6. Check with `git diff origin/master` what your push will do. Assuming you are happy run `nekgit_push`. This will create a pull request on GitHub and set your current branch back to master. When your pull request was merged, make sure you are on your local master branch. Then, delete the branch created in step (1) with `nekgit_rm <my branch name>` and update the current master branch using `git pull`.
 
 ## Code Structure
 
 Here's a brief description of each top-level directory:
 
-####`core`
+#### `core`
 contains the majority of the Nek5000 application sources.
 
-####`jl`
+#### `jl`
 contains gather/scatter communication ([gslib](https://github.com/gslib/gslib)), interpolation, and preconditioners written in highly general C code.
 
-####`bin`
+#### `bin`
 contains scripts for running nek5000 and manipulating its output.
 
 #### `tools`
 contains the sources for the pre- and post-processing tools which are stand-alone.
 
-#### `short-tests` 
-contains light-weight regression tests for validation.  
+#### `short-tests`
+contains light-weight regression tests for validation.
 
 #### `run`
 contains nothing. Its purpose it to provide a consistent place for users to place their cases.
 
 #### `3rd_party`
 contains nothing. Its purpose it to provide a consistent place for 3rd part developers to place their code.
-
-

--- a/bin/visnek
+++ b/bin/visnek
@@ -1,77 +1,72 @@
-#! /bin/tcsh
+#!/bin/bash
 #
 #  Shell script that generated VisIt metafile blah.nek5000 either from SESSION.NAME or from the first command line argument
 #
 
- set nfld = 0					# # of field files
+nfld=0					# # of field files
 
- if ($#argv == 0) then
-    if (-f SESSION.NAME) then
-       set base = `head -1 SESSION.NAME`	# case name
+if [[ $# -eq 0 ]]; then
+    if [[ -f SESSION.NAME ]]; then
+        base=$(head -1 SESSION.NAME)	# case name
     else
-       set nfld = -1				# exit
+       nfld=-1				# exit
        echo
        echo '  No SESSION.NAME file -- Use "visnek case_name"'
        echo
-    endif
- else
-       set base = $argv[1]
- endif
+    fi
+else
+    base="$1"
+fi
 
 
-if ($nfld != -1) then
+if [[ "$nfld" != -1 ]]; then
 
- echo
- echo '  Generating '$base'.nek5000 file ...'
- echo
- 
-#echo 'endian little'			>  $base.nek5000
-#echo 'endian big'			>  $base.nek5000
+    echo
+    echo "  Generating $base.nek5000 file ..."
+    echo
 
- if  (-e		        $base.fld01) then
-    set nfld = `ls -1	        $base{.fld[0-9][0-9]*}			| wc -l`
-    echo 'filetemplate:	       '$base'.fld%02d'			>  $base.nek5000
- else if (-e 		   'A0/'$base'0.f00001') then
-    set nfld = `ls -1	     A0/$base{0.f[0-9][0-9][0-9][0-9][0-9]}	| wc -l`
-    echo 'filetemplate:	 A%01d/'$base'%01d.f%05d'		>  $base.nek5000
- else if (-e 		        $base'00.f00001') then
-    set nfld = `ls -1	        $base{00.f[0-9][0-9][0-9][0-9][0-9]}	| wc -l`
-    echo 'filetemplate:	       '$base'%02d.f%05d'		>  $base.nek5000
- else if (-e 		  'A00/'$base'00.f00001') then
-    set nfld = `ls -1	    A00/$base{00.f[0-9][0-9][0-9][0-9][0-9]}	| wc -l`
-    echo 'filetemplate:	 A%02d/'$base'%02d.f%05d'		>  $base.nek5000
- else if (-e 		        $base'000.f00001') then
-    set nfld = `ls -1	        $base{000.f[0-9][0-9][0-9][0-9][0-9]}	| wc -l`
-    echo 'filetemplate:	       '$base'%03d.f%05d'		>  $base.nek5000
- else if (-e 		 'A000/'$base'000.f00001') then
-    set nfld = `ls -1	   A000/$base{000.f[0-9][0-9][0-9][0-9][0-9]}	| wc -l`
-    echo 'filetemplate:	 A%03d/'$base'%03d.f%05d'		>  $base.nek5000
- else if (-e 		'A0000/'$base'0000.f00001') then
-    set nfld = `ls -1	  A0000/$base{0000.f[0-9][0-9][0-9][0-9][0-9]}	| wc -l`
-    echo 'filetemplate:	 A%04d/'$base'%04d.f%05d'		>  $base.nek5000
- else
-    set nfld = `ls -1		$base{0.f[0-9][0-9][0-9][0-9][0-9]}	| wc -l`
-    echo 'filetemplate:	       '$base'%01d.f%05d'		>  $base.nek5000
- endif
- endif
- endif
+    #echo 'endian little'			>  $base.nek5000
+    #echo 'endian big'			>  $base.nek5000
+
+    if [[ -e $base.fld01 ]]; then
+        nfld=$(ls -1 $base.fld[0-9][0-9]* | wc -l)
+        echo "filetemplate:	${base}.fld%02d" > $base.nek5000
+    elif [[ -e "A0/${base}0.f00001" ]]; then
+        nfld=$(ls -1 A0/${base}0.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate:	A%01d/${base}%01d.f%05d" > $base.nek5000
+    elif [[ -e "${base}00.f00001" ]]; then
+        nfld=$(ls -1 ${base}00.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate:	${base}%02d.f%05d" > $base.nek5000
+    elif [[ -e "A00/${base}00.f00001" ]]; then
+        nfld=$(ls -1 A00/${base}00.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo 'filetemplate:	A%02d/'$base'%02d.f%05d' > $base.nek5000
+    elif [[ -e "${base}000.f00001" ]]; then
+        nfld=$(ls -1 ${base}000.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate:	${base}%03d.f%05d" > $base.nek5000
+    elif [[ -e "A000/${base}000.f00001" ]]; then
+        nfld=$(ls -1 A000/${base}000.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate:	A%03d/${base}%03d.f%05d" > $base.nek5000
+    elif [[ -e "A0000/${base}0000.f00001" ]]; then
+        nfld=$(ls -1 A0000/${base}0000.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate:	A%04d/${base}%04d.f%05d" > $base.nek5000
+    else
+        nfld=$(ls -1 ${base}0.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate:	${base}%01d.f%05d" > $base.nek5000
+    fi
+fi
 
 
- echo 'firsttimestep: 1'	 	>> $base.nek5000
- echo 'numtimesteps: '$nfld		>> $base.nek5000
+echo 'firsttimestep: 1' >> $base.nek5000
+echo "numtimesteps: $nfld" >> $base.nek5000
 
 #echo 'meshcoords: 1'			>> $base.nek5000
 
 
- echo
- echo ' Assuming that coordinates are in the first file '$base'*.f*01 -- otherwise edit $base.nek5000 file ...'
- echo
- echo ' Also one may need to correct for an endian by inserting the first line "endian big" or "endian little" in case of, e.g., files transfered from other systems'
- echo
- echo
- echo ' Total '$nfld' file(s) are in the generated file '$base'.nek5000 ... Done!'
- echo
-
-endif	# nfld != -1
-
-
+echo
+echo " Assuming that coordinates are in the first file ${base}*.f*01 -- otherwise edit $base.nek5000 file ..."
+echo
+echo ' Also one may need to correct for an endian by inserting the first line "endian big" or "endian little" in case of, e.g., files transfered from other systems'
+echo
+echo
+echo " Total $nfld file(s) are in the generated file $base.nek5000 ... Done!"
+echo

--- a/bin/visnek
+++ b/bin/visnek
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 #
 #  Shell script that generated VisIt metafile blah.nek5000 either from SESSION.NAME or from the first command line argument
 #
 
 nfld=0					# # of field files
 
-if [[ $# -eq 0 ]]; then
-    if [[ -f SESSION.NAME ]]; then
+if [ $# -eq 0 ]; then
+    if [ -f SESSION.NAME ]; then
         base=$(head -1 SESSION.NAME)	# case name
     else
        nfld=-1				# exit
@@ -19,7 +19,7 @@ else
 fi
 
 
-if [[ "$nfld" != -1 ]]; then
+if [ $nfld -ne -1 ]; then
 
     echo
     echo "  Generating $base.nek5000 file ..."
@@ -28,38 +28,38 @@ if [[ "$nfld" != -1 ]]; then
     #echo 'endian little'			>  $base.nek5000
     #echo 'endian big'			>  $base.nek5000
 
-    if [[ -e $base.fld01 ]]; then
-        nfld=$(ls -1 $base.fld[0-9][0-9]* | wc -l)
-        echo "filetemplate:	${base}.fld%02d" > $base.nek5000
-    elif [[ -e "A0/${base}0.f00001" ]]; then
-        nfld=$(ls -1 A0/${base}0.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
-        echo "filetemplate:	A%01d/${base}%01d.f%05d" > $base.nek5000
-    elif [[ -e "${base}00.f00001" ]]; then
-        nfld=$(ls -1 ${base}00.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
-        echo "filetemplate:	${base}%02d.f%05d" > $base.nek5000
-    elif [[ -e "A00/${base}00.f00001" ]]; then
-        nfld=$(ls -1 A00/${base}00.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
-        echo 'filetemplate:	A%02d/'$base'%02d.f%05d' > $base.nek5000
-    elif [[ -e "${base}000.f00001" ]]; then
-        nfld=$(ls -1 ${base}000.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
-        echo "filetemplate:	${base}%03d.f%05d" > $base.nek5000
-    elif [[ -e "A000/${base}000.f00001" ]]; then
-        nfld=$(ls -1 A000/${base}000.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
-        echo "filetemplate:	A%03d/${base}%03d.f%05d" > $base.nek5000
-    elif [[ -e "A0000/${base}0000.f00001" ]]; then
-        nfld=$(ls -1 A0000/${base}0000.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
-        echo "filetemplate:	A%04d/${base}%04d.f%05d" > $base.nek5000
+    if [ -e "$base.fld01" ]; then
+        nfld=$(ls -1 "$base".fld[0-9][0-9]* | wc -l)
+        echo "filetemplate: ${base}.fld%02d" > "$base.nek5000"
+    elif [ -e "A0/${base}0.f00001" ]; then
+        nfld=$(ls -1 A0/"${base}"0.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate: A%01d/${base}%01d.f%05d" > "$base.nek5000"
+    elif [ -e "${base}00.f00001" ]; then
+        nfld=$(ls -1 "${base}"00.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate: ${base}%02d.f%05d" > "$base.nek5000"
+    elif [ -e "A00/${base}00.f00001" ]; then
+        nfld=$(ls -1 A00/"${base}"00.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate: A%02d/${base}%02d.f%05d" > "$base.nek5000"
+    elif [ -e "${base}000.f00001" ]; then
+        nfld=$(ls -1 "${base}"000.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate: ${base}%03d.f%05d" > "$base.nek5000"
+    elif [ -e "A000/${base}000.f00001" ]; then
+        nfld=$(ls -1 A000/"${base}"000.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate: A%03d/${base}%03d.f%05d" > "$base.nek5000"
+    elif [ -e "A0000/${base}0000.f00001" ]; then
+        nfld=$(ls -1 A0000/"${base}"0000.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate: A%04d/${base}%04d.f%05d" > "$base.nek5000"
     else
-        nfld=$(ls -1 ${base}0.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
-        echo "filetemplate:	${base}%01d.f%05d" > $base.nek5000
+        nfld=$(ls -1 "${base}"0.f[0-9][0-9][0-9][0-9][0-9] | wc -l)
+        echo "filetemplate: ${base}%01d.f%05d" > "$base.nek5000"
     fi
 fi
 
 
-echo 'firsttimestep: 1' >> $base.nek5000
-echo "numtimesteps: $nfld" >> $base.nek5000
+echo 'firsttimestep: 1' >> "$base.nek5000"
+echo "numtimesteps: $nfld" >> "$base.nek5000"
 
-#echo 'meshcoords: 1'			>> $base.nek5000
+#echo 'meshcoords: 1'			>> "$base.nek5000"
 
 
 echo


### PR DESCRIPTION
I noticed that the visnek script which is referred to in the eddy_uv example in the user's manual is written in tcsh, which is likely not installed by default on most systems. I've change this script from tcsh to bash so that a user doesn't need to install tcsh.