### PR TITLE
Fixes dependency of Fortran objects on SIZE

### DIFF
--- a/core/makefile.template
+++ b/core/makefile.template
@@ -88,7 +88,10 @@ TMP1 += $(CMTCORE)
 OPT_INCDIR += -I $(SCMT)
 endif
 
-NOBJS = $(patsubst %,$(OBJDIR)/%,$(TMP1))
+NOBJS_F = $(patsubst %,$(OBJDIR)/%,$(TMP1))
+TMP2 = $(JLCORE) $(JLINTP) $(CGS) 
+NOBJS_C = $(patsubst %,$(OBJDIR)/%,$(TMP2))
+NOBJS  = $(NOBJS_F) $(NOBJS_C)
 
 L0 = $(G) -O0
 L2 = $(G) -O2


### PR DESCRIPTION
Fixes issue #267 

The Fortran objects should be automatically rebuilt when SIZE changes, but this dependency tracking was broken in PR #258.  

In makefile.template, the rule for rebuilding the Fortran objects when SIZE changes is:
``` makefile
 $(NOBJS_F) : SIZE
```
Prior to PR #258, the variable `$(NOBJ_F)` was set to be all the Fortran objects.  However, after PR #258, `$(NOBJ_F)` was no longer set to anything.  

