### PR TITLE
Exact pressure solution

### DIFF
--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -202,6 +202,9 @@ class Eddy_EddyUv(NekTestCase):
         yerr = self.get_value_from_log('Y err', column=-6, row=-1)
         self.assertAlmostEqualDelayed(yerr, target_val=6.489061E-07, delta=1E-08, label='Y err')
 
+        perr = self.get_value_from_log('P err', column=-5, row=-1)
+        self.assertAlmostEqualDelayed(perr, target_val=1.448024E-05, delta=1E-06, label='P err')
+
         # solver_time = self.get_value_from_log('total solver time', column=-2)
         # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=80, label='total solver time')
 
@@ -223,6 +226,9 @@ class Eddy_EddyUv(NekTestCase):
         yerr = self.get_value_from_log('Y err', column=-6, row=-1)
         self.assertAlmostEqualDelayed(yerr, target_val=6.489061E-07, delta=1E-08, label='Y err')
 
+        perr = self.get_value_from_log('P err', column=-5, row=-1)
+        self.assertAlmostEqualDelayed(perr, target_val=1.448024E-05, delta=1E-06, label='P err')
+
         self.assertDelayedFailures()
 
     @pn_pn_2_serial
@@ -240,6 +246,9 @@ class Eddy_EddyUv(NekTestCase):
 
         yerr = self.get_value_from_log('Y err', column=-6, row=-1)
         self.assertAlmostEqualDelayed(yerr, target_val=7.842019E-05, delta=1E-06, label='Y err')
+
+        perr = self.get_value_from_log('P err', column=-5, row=-1)
+        self.assertAlmostEqualDelayed(perr, target_val=6.927878E-05, delta=1E-06, label='P err')
 
         # solver_time = self.get_value_from_log('total solver time', column=-2)
         # self.assertAlmostEqualDelayed(solver_time, 0.1, delta=80, label='total solver time')
@@ -261,6 +270,9 @@ class Eddy_EddyUv(NekTestCase):
 
         yerr = self.get_value_from_log('Y err', column=-6, row=-1)
         self.assertAlmostEqualDelayed(yerr, target_val=7.842019E-05, delta=1E-06, label='Y err')
+
+        perr = self.get_value_from_log('P err', column=-5, row=-1)
+        self.assertAlmostEqualDelayed(perr, target_val=6.896211E-05, delta=1E-06, label='P err')
 
         self.assertDelayedFailures()
 
@@ -312,6 +324,9 @@ class Eddy_LegacySize(NekTestCase):
         yerr = self.get_value_from_log('Y err', column=-6, row=-1)
         self.assertAlmostEqualDelayed(yerr, target_val=6.489061E-07, delta=1E-08, label='Y err')
 
+        perr = self.get_value_from_log('P err', column=-5, row=-1)
+        self.assertAlmostEqualDelayed(perr, target_val=1.448024E-05, delta=1E-06, label='P err')
+
         # solver_time = self.get_value_from_log('total solver time', column=-2)
         # self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=80, label='total solver time')
 
@@ -335,6 +350,9 @@ class Eddy_LegacySize(NekTestCase):
         yerr = self.get_value_from_log('Y err', column=-6, row=-1)
         self.assertAlmostEqualDelayed(yerr, target_val=6.489061E-07, delta=1E-08, label='Y err')
 
+        perr = self.get_value_from_log('P err', column=-5, row=-1)
+        self.assertAlmostEqualDelayed(perr, target_val=1.448024E-05, delta=1E-06, label='P err')
+
         self.assertDelayedFailures()
 
     @pn_pn_2_serial
@@ -354,6 +372,9 @@ class Eddy_LegacySize(NekTestCase):
 
         yerr = self.get_value_from_log('Y err', column=-6, row=-1)
         self.assertAlmostEqualDelayed(yerr, target_val=7.842019E-05, delta=1E-06, label='Y err')
+
+        perr = self.get_value_from_log('P err', column=-5, row=-1)
+        self.assertAlmostEqualDelayed(perr, target_val=6.927878E-05, delta=1E-06, label='P err')
 
         # solver_time = self.get_value_from_log('total solver time', column=-2)
         # self.assertAlmostEqualDelayed(solver_time, 0.1, delta=80, label='total solver time')
@@ -377,6 +398,9 @@ class Eddy_LegacySize(NekTestCase):
 
         yerr = self.get_value_from_log('Y err', column=-6, row=-1)
         self.assertAlmostEqualDelayed(yerr, target_val=7.842019E-05, delta=1E-06, label='Y err')
+
+        perr = self.get_value_from_log('P err', column=-5, row=-1)
+        self.assertAlmostEqualDelayed(perr, target_val=6.896211E-05, delta=1E-06, label='P err')
 
         self.assertDelayedFailures()
 

--- a/short_tests/eddy/eddy_uv.usr
+++ b/short_tests/eddy/eddy_uv.usr
@@ -198,39 +198,47 @@ c-----------------------------------------------------------------------
       include 'TOTAL' 
 c
       common /exacu/ ue(lx1,ly1,lz1,lelt),ve(lx1,ly1,lz1,lelt)
+      common /exacp/ pe(lx2,ly2,lz2,lelt)
       common /exacd/ ud(lx1,ly1,lz1,lelt),vd(lx1,ly1,lz1,lelt)
-
+     $              ,pd(lx2,ly2,lz2,lelt)
 
       ifield = 1  ! for outpost
 
       n    = nx1*ny1*nz1*nelv
+      n2   = nx2*ny2*nz2*nelv
       visc = param(2)
       u0   = param(96)
       v0   = param(97)
       call exact  (ue,ve,xm1,ym1,n,time,visc,u0,v0)
-      if (istep.eq.0     ) call outpost(ue,ve,vx,pr,t,'   ')
+      call exactp (pe,xm2,ym2,n2,time,visc,u0,v0)
+      if (istep.eq.0     ) call outpost(ue,ve,vx,pe,t,'   ')
 
       call sub3   (ud,ue,vx,n)
       call sub3   (vd,ve,vy,n)
-      if (istep.eq.nsteps) call outpost(ud,vd,vx,pr,t,'err')
+      call sub3   (pd,pe,pr,n2)
+      if (istep.eq.nsteps) call outpost(ud,vd,vx,pd,t,'err')
 
       umx = glamax(vx,n)
       vmx = glamax(vy,n)
+      pmx = glamax(pr,n2)
       uex = glamax(ue,n)
       vex = glamax(ve,n)
+      pex = glamax(pe,n2)
       udx = glamax(ud,n)
       vdx = glamax(vd,n)
+      pdx = glamax(pd,n2)
 
       if (nid.eq.0) then
           write(6,11) istep,time,udx,umx,uex,u0,'  X err'
           write(6,11) istep,time,vdx,vmx,vex,v0,'  Y err'
+          write(6,'(i5,1p4e14.6,a7)') istep,time,pdx,pmx,pex,'  P err'
    11     format(i5,1p5e14.6,a7)
       endif
 
-
-      if (istep.le.5) then        !  Reset velocity to eliminate 
+      if (istep.le.5) then        !  Reset velocity & pressure to eliminate
          call copy (vx,ue,n)      !  start-up contributions to
          call copy (vy,ve,n)      !  temporal-accuracy behavior.
+         call copy (pr,pe,n2)
       endif
 
       return
@@ -254,7 +262,9 @@ c-----------------------------------------------------------------------
       include 'NEKUSE'
 
       common /exacu/ ue(lx1,ly1,lz1,lelt),ve(lx1,ly1,lz1,lelt)
+      common /exacp/ pe(lx2,ly2,lz2,lelt)
       common /exacd/ ud(lx1,ly1,lz1,lelt),vd(lx1,ly1,lz1,lelt)
+     $              ,pd(lx2,ly2,lz2,lelt)
 
       integer icalld
       save    icalld

--- a/short_tests/eddy/eddy_uv.usr
+++ b/short_tests/eddy/eddy_uv.usr
@@ -146,7 +146,7 @@ c     of Computational Physics 307 (2016), 60--93.
       real x2(n),y2(n),pe(n)
       real x,y,e
 
-      e   = exp(-50*time*visc)
+      e = exp(-50*time*visc)
 
       do i=1,n2
          x = x2(i) - u0*time
@@ -211,7 +211,7 @@ c
       v0   = param(97)
       call exact  (ue,ve,xm1,ym1,n,time,visc,u0,v0)
       call exactp (pe,xm2,ym2,n2,time,visc,u0,v0)
-      if (istep.eq.0     ) call outpost(ue,ve,vx,pe,t,'   ')
+      if (istep.eq.0) call outpost(ue,ve,vx,pe,t,'   ')
 
       call sub3   (ud,ue,vx,n)
       call sub3   (vd,ve,vy,n)
@@ -229,10 +229,10 @@ c
       pdx = glamax(pd,n2)
 
       if (nid.eq.0) then
-          write(6,11) istep,time,udx,umx,uex,u0,'  X err'
-          write(6,11) istep,time,vdx,vmx,vex,v0,'  Y err'
-          write(6,'(i5,1p4e14.6,a7)') istep,time,pdx,pmx,pex,'  P err'
-   11     format(i5,1p5e14.6,a7)
+         write(6,11) istep,time,udx,umx,uex,u0,'  X err'
+         write(6,11) istep,time,vdx,vmx,vex,v0,'  Y err'
+         write(6,'(i5,1p4e14.6,a7)') istep,time,pdx,pmx,pex,'  P err'
+   11    format(i5,1p5e14.6,a7)
       endif
 
       if (istep.le.5) then        !  Reset velocity & pressure to eliminate

--- a/short_tests/eddy/eddy_uv.usr
+++ b/short_tests/eddy/eddy_uv.usr
@@ -143,7 +143,7 @@ c     James W. Lottes. "A Spectrally Accurate Method for Overlapping
 c     Grid Solution of Incompressible Navier-Stokes Equations." Journal
 c     of Computational Physics 307 (2016), 60--93.
 
-      real x2(n),y2(n),pe(n)
+      real x2(n2),y2(n2),pe(n2)
       real x,y,e
 
       e = exp(-50*time*visc)

--- a/short_tests/eddy/eddy_uv.usr
+++ b/short_tests/eddy/eddy_uv.usr
@@ -132,6 +132,36 @@ c
       return
       end
 c-----------------------------------------------------------------------
+      subroutine exactp(pe,x2,y2,n2,time,visc,u0,v0)
+
+c     This routine, complementary to the exact routine above, returns
+c     the exact pressure, given the pressure counterpart to the
+c     arguments for the exact routine i.e., xx -> x2, yy -> y2, n -> n2
+c
+c     Brandon E. Merrill, Yulia T. Peet, Paul F. Fischer, and
+c     James W. Lottes. "A Spectrally Accurate Method for Overlapping
+c     Grid Solution of Incompressible Navier-Stokes Equations." Journal
+c     of Computational Physics 307 (2016), 60--93.
+
+      real x2(n),y2(n),pe(n)
+      real x,y,e
+
+      e   = exp(-50*time*visc)
+
+      do i=1,n2
+         x = x2(i) - u0*time
+         y = y2(i) - v0*time
+
+         pe(i) = (1.0/64.0)*e*(16*cos(6*x) + 8*cos(8*x-4*y)
+     $         - 32*cos(2*(x-2*y)) + 9*cos(8*y) - 8*cos(4*(2*x+y))
+     $         + 32*cos(2*(x+2*y)) - 4*sin(3*(x-3*y)) + 32*sin(5*(x-y))
+     $         + 36*sin(3*x-y) - 32*sin(5*(x+y)) + 36*sin(3*x+y)
+     $         - 4*sin(3*(x+3*y)))
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
       subroutine uservp (ix,iy,iz,ieg)
       include 'SIZE'
       include 'TOTAL'


### PR DESCRIPTION
Added a exactp subroutine that calculates the exact pressure for the eddy case. In userchk, the pressure error gets written with the 'P err' string identifier. I'm not sure whether I should prescribe the exact pressure in useric, so please give me some guidance on that matter.