### PR TITLE
Expanded OpenACC kernels

### DIFF
--- a/core/gmres.f
+++ b/core/gmres.f
@@ -478,13 +478,16 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 !$ACC UPDATE DEVICE(h_gmres)
 
 #ifdef _OPENACC
-!$ACC KERNELS PRESENT(w_gmres, h_gmres, v_gmres)
-            do i=1,j
-               do k=1,n
-                  w_gmres(k) = w_gmres(k) - h_gmres(i,j) * v_gmres(k,i)
+!$ACC PARALLEL PRESENT(w_gmres, h_gmres, v_gmres)
+!$ACC LOOP PRIVATE(temp)
+            do k=1,n
+               temp = w_gmres(k)
+               do i=1,j
+                  temp = temp - h_gmres(i,j) * v_gmres(k,i)
                enddo
+               w_gmres(k) = temp
             enddo                                                !          i,j  i
-!$ACC END KERNELS
+!$ACC END PARALLEL
 #else
             do i=1,j
                call add2s2(w_gmres,v_gmres(1,i),-h_gmres(i,j),n) ! w = w - h    v

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -456,23 +456,14 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 #ifdef _OPENACC
 
-c ROR, 05-12-2017: Though we attempted to implement vlsc3_acc() with an
-c ACC REDUCTION clause, it did not give the correct results (see
-c comments in vlsc3_acc).  This working implementation is based on
-c dependency analysis from the compiler.  
-
 !$ACC PARALLEL PRESENT(h_gmres, w_gmres, v_gmres, wt)
-!$ACC LOOP GANG, VECTOR
-            do i=1,j
-              h_gmres(i,j) = 0.0
-            enddo
-!$ACC LOOP SEQ
-            do k=1,n
-!$ACC LOOP GANG, VECTOR
-              do i=1,j
-                h_gmres(i,j) = h_gmres(i,j) + w_gmres(k) 
-     $            * v_gmres(k,i) *  wt(k)
-              enddo
+!$ACC LOOP PRIVATE(temp)
+            do i=1,j 
+               temp = 0.0
+               do k=1,n
+                  temp = temp + w_gmres(k) * v_gmres(k,i) *  wt(k)
+               enddo
+               h_gmres(i,j) = temp
             enddo                                            !  i,j       i
 !$ACC END PARALLEL
 

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -460,6 +460,7 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 !$ACC LOOP PRIVATE(temp)
             do i=1,j 
                temp = 0.0
+!$ACC LOOP
                do k=1,n
                   temp = temp + w_gmres(k) * v_gmres(k,i) *  wt(k)
                enddo
@@ -479,13 +480,12 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 #ifdef _OPENACC
 !$ACC PARALLEL PRESENT(w_gmres, h_gmres, v_gmres)
-!$ACC LOOP PRIVATE(temp)
-            do k=1,n
-               temp = w_gmres(k)
-               do i=1,j
-                  temp = temp - h_gmres(i,j) * v_gmres(k,i)
+!$ACC LOOP SEQ
+            do i=1,j
+!$ACC LOOP
+               do k=1,n
+                  w_gmres(k) = w_gmres(k) - h_gmres(i,j) * v_gmres(k,i)
                enddo
-               w_gmres(k) = temp
             enddo                                                !          i,j  i
 !$ACC END PARALLEL
 #else

--- a/core/math.f
+++ b/core/math.f
@@ -1943,4 +1943,18 @@ c--------------------------------------------------------
          a(i) = a(i) * b(i)
       enddo
 !$ACC END PARALLEL LOOP
+      return
       end
+c-----------------------------------------------------------------------
+      subroutine col3_acc(a,b,c,n)
+      real a(n),b(n),c(n)
+
+!$ACC PARALLEL LOOP PRESENT(a,b,c)
+      do i=1,n
+         a(i)=b(i)*c(i)
+      enddo
+!$ACC END PARALLEL
+
+      return
+      end
+c-----------------------------------------------------------------------


### PR DESCRIPTION
This PR expands and optimizes the OpenACC kernels in hmh_gmres, including additional math subroutines.  This includes OpenACC kernels for:
* `vlsc3()`:  The new kernel is written to enable an implicit ACC REDUCTION, which is implemented by the compiler.  The ACC REDUCTION leads to ~300x speedup in the kernel (vs. ACC with no REDUCTION), and reduces the total runtime of that kernel from 91% of solve time to 4% of solve time.
* `add2s2()`:  This kernel does not use an ACC REDUCTION.  Even though the nested loop can be inverted to allow a reduction over w_gmres (see e41df3b), the reduction is actually ~10x slower.  