### PR TITLE
Decreased host/device data movement in hmh_gmres

### DIFF
--- a/core/acc.f
+++ b/core/acc.f
@@ -29,6 +29,7 @@
 !$ACC ENTER DATA COPYIN(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC ENTER DATA COPYIN(h_gmres,w_gmres,v_gmres,z_gmres)
 !$ACC ENTER DATA COPYIN(c_gmres,s_gmres,x_gmres,gamma_gmres)
+!$ACC ENTER DATA COPYIN(r_gmres)
 !$ACC ENTER DATA COPYIN(ml_gmres,mu_gmres)
 !$ACC ENTER DATA COPYIN(h1,h2)
 
@@ -65,6 +66,7 @@
 !$ACC EXIT DATA DELETE(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC EXIT DATA COPYOUT(h_gmres,w_gmres,v_gmres,z_gmres)
 !$ACC EXIT DATA COPYOUT(c_gmres,s_gmres,x_gmres,gamma_gmres)
+!$ACC EXIT DATA COPYOUT(r_gmres)
 !$ACC EXIT DATA COPYOUT(ml_gmres,mu_gmres)
 !$ACC EXIT DATA COPYOUT(h1,h2)
 

--- a/core/acc.f
+++ b/core/acc.f
@@ -28,7 +28,7 @@
 !$ACC ENTER DATA COPYIN(mg_work,mg_fast_s,mg_fast_d)
 !$ACC ENTER DATA COPYIN(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC ENTER DATA COPYIN(h_gmres,w_gmres,v_gmres,z_gmres)
-!$ACC ENTER DATA COPYIN(c_gmres,s_gmres)
+!$ACC ENTER DATA COPYIN(c_gmres,s_gmres,gamma_gmres)
 !$ACC ENTER DATA COPYIN(ml_gmres,mu_gmres)
 !$ACC ENTER DATA COPYIN(h1,h2)
 
@@ -64,7 +64,7 @@
 !$ACC EXIT DATA DELETE(mg_work,mg_fast_s,mg_fast_d)
 !$ACC EXIT DATA DELETE(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC EXIT DATA COPYOUT(h_gmres,w_gmres,v_gmres,z_gmres)
-!$ACC EXIT DATA COPYOUT(c_gmres,s_gmres)
+!$ACC EXIT DATA COPYOUT(c_gmres,s_gmres,gamma_gmres)
 !$ACC EXIT DATA COPYOUT(ml_gmres,mu_gmres)
 !$ACC EXIT DATA COPYOUT(h1,h2)
 

--- a/core/acc.f
+++ b/core/acc.f
@@ -28,8 +28,11 @@
 !$ACC ENTER DATA COPYIN(mg_work,mg_fast_s,mg_fast_d)
 !$ACC ENTER DATA COPYIN(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC ENTER DATA COPYIN(h_gmres,w_gmres,v_gmres,z_gmres)
+!$ACC ENTER DATA COPYIN(c_gmres,s_gmres)
 !$ACC ENTER DATA COPYIN(ml_gmres,mu_gmres)
 !$ACC ENTER DATA COPYIN(h1,h2)
+
+
       return
       end
 
@@ -61,6 +64,7 @@
 !$ACC EXIT DATA DELETE(mg_work,mg_fast_s,mg_fast_d)
 !$ACC EXIT DATA DELETE(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC EXIT DATA COPYOUT(h_gmres,w_gmres,v_gmres,z_gmres)
+!$ACC EXIT DATA COPYOUT(c_gmres,s_gmres)
 !$ACC EXIT DATA COPYOUT(ml_gmres,mu_gmres)
 !$ACC EXIT DATA COPYOUT(h1,h2)
 

--- a/core/acc.f
+++ b/core/acc.f
@@ -28,7 +28,7 @@
 !$ACC ENTER DATA COPYIN(mg_work,mg_fast_s,mg_fast_d)
 !$ACC ENTER DATA COPYIN(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC ENTER DATA COPYIN(h_gmres,w_gmres,v_gmres,z_gmres)
-!$ACC ENTER DATA COPYIN(c_gmres,s_gmres,gamma_gmres)
+!$ACC ENTER DATA COPYIN(c_gmres,s_gmres,x_gmres,gamma_gmres)
 !$ACC ENTER DATA COPYIN(ml_gmres,mu_gmres)
 !$ACC ENTER DATA COPYIN(h1,h2)
 
@@ -64,7 +64,7 @@
 !$ACC EXIT DATA DELETE(mg_work,mg_fast_s,mg_fast_d)
 !$ACC EXIT DATA DELETE(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC EXIT DATA COPYOUT(h_gmres,w_gmres,v_gmres,z_gmres)
-!$ACC EXIT DATA COPYOUT(c_gmres,s_gmres,gamma_gmres)
+!$ACC EXIT DATA COPYOUT(c_gmres,s_gmres,x_gmres,gamma_gmres)
 !$ACC EXIT DATA COPYOUT(ml_gmres,mu_gmres)
 !$ACC EXIT DATA COPYOUT(h1,h2)
 

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -478,13 +478,16 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 !$ACC UPDATE DEVICE(h_gmres)
 
 #ifdef _OPENACC
-!$ACC KERNELS PRESENT(w_gmres, h_gmres, v_gmres)
-            do i=1,j
-               do k=1,n
-                  w_gmres(k) = w_gmres(k) - h_gmres(i,j) * v_gmres(k,i)
+!$ACC PARALLEL PRESENT(w_gmres, h_gmres, v_gmres)
+!$ACC LOOP PRIVATE(temp)
+            do k=1,n
+               temp = w_gmres(k)
+               do i=1,j
+                  temp = temp - h_gmres(i,j) * v_gmres(k,i)
                enddo
+               w_gmres(k) = temp
             enddo                                                !          i,j  i
-!$ACC END KERNELS
+!$ACC END PARALLEL
 #else
             do i=1,j
                call add2s2(w_gmres,v_gmres(1,i),-h_gmres(i,j),n) ! w = w - h    v

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -547,14 +547,18 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
          !back substitution
          !     -1
          !c = H   gamma
-         call acc_copy_all_out()
+!$ACC PARALLEL PRESENT(gamma_gmres, h_gmres, c_gmres)
+!$ACC LOOP SEQ
          do k=j,1,-1
             temp = gamma_gmres(k)
+!$ACC LOOP
             do i=j,k+1,-1
                temp = temp - h_gmres(k,i)*c_gmres(i)
             enddo
             c_gmres(k) = temp/h_gmres(k,k)
          enddo
+!$ACC END PARALLEL
+         call acc_copy_all_out()
          !sum up Arnoldi vectors
          do i=1,j
             call add2s2(x_gmres,z_gmres(1,i),c_gmres(i),n) ! x = x + c  z

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -456,23 +456,14 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 #ifdef _OPENACC
 
-c ROR, 05-12-2017: Though we attempted to implement vlsc3_acc() with an
-c ACC REDUCTION clause, it did not give the correct results (see
-c comments in vlsc3_acc).  This working implementation is based on
-c dependency analysis from the compiler.  
-
 !$ACC PARALLEL PRESENT(h_gmres, w_gmres, v_gmres, wt)
-!$ACC LOOP GANG, VECTOR
-            do i=1,j
-              h_gmres(i,j) = 0.0
-            enddo
-!$ACC LOOP SEQ
-            do k=1,n
-!$ACC LOOP GANG, VECTOR
-              do i=1,j
-                h_gmres(i,j) = h_gmres(i,j) + w_gmres(k) 
-     $            * v_gmres(k,i) *  wt(k)
-              enddo
+!$ACC LOOP PRIVATE(temp)
+            do i=1,j 
+               temp = 0.0
+               do k=1,n
+                  temp = temp + w_gmres(k) * v_gmres(k,i) *  wt(k)
+               enddo
+               h_gmres(i,j) = temp
             enddo                                            !  i,j       i
 !$ACC END PARALLEL
 

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -399,10 +399,10 @@ c           call copy(r,res,n)
          if(gamma_gmres(1) .eq. 0.) goto 9000
          temp = 1./gamma_gmres(1)
          call cmult2(v_gmres(1,1),r_gmres,temp,n) ! v  = r / gamma
+
+         call acc_copy_all_in()
                                                    !  1            1
          do j=1,m
-
-            call acc_copy_all_in()
 
             iter = iter+1
                                                        !       -1
@@ -538,8 +538,6 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
             temp = 1./alpha
             call cmult2(v_gmres(1,j+1),w_gmres,temp,n) ! v    = w / alpha
 #endif
-                                                       !  j+1
-         call acc_copy_all_out()
 
          enddo
   900    iconv = 1
@@ -575,8 +573,8 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
          enddo                                             !          i  i
 #endif
 c        if(iconv.eq.1) call dbg_write(x,nx1,ny1,nz1,nelv,'esol',3)
-         call acc_copy_all_out()
       enddo
+      call acc_copy_all_out()
  9000 continue
 
       divex = rnorm

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -460,6 +460,7 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 !$ACC LOOP PRIVATE(temp)
             do i=1,j 
                temp = 0.0
+!$ACC LOOP
                do k=1,n
                   temp = temp + w_gmres(k) * v_gmres(k,i) *  wt(k)
                enddo
@@ -479,13 +480,12 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 #ifdef _OPENACC
 !$ACC PARALLEL PRESENT(w_gmres, h_gmres, v_gmres)
-!$ACC LOOP PRIVATE(temp)
-            do k=1,n
-               temp = w_gmres(k)
-               do i=1,j
-                  temp = temp - h_gmres(i,j) * v_gmres(k,i)
+!$ACC LOOP SEQ
+            do i=1,j
+!$ACC LOOP
+               do k=1,n
+                  w_gmres(k) = w_gmres(k) - h_gmres(i,j) * v_gmres(k,i)
                enddo
-               w_gmres(k) = temp
             enddo                                                !          i,j  i
 !$ACC END PARALLEL
 #else

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -548,17 +548,15 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
          !     -1
          !c = H   gamma
 
-!$ACC PARALLEL PRESENT(gamma_gmres, h_gmres, c_gmres)
-!$ACC LOOP SEQ
+!$ACC KERNELS PRESENT(gamma_gmres, h_gmres, c_gmres)
          do k=j,1,-1
             temp = gamma_gmres(k)
-!$ACC LOOP
             do i=j,k+1,-1
                temp = temp - h_gmres(k,i)*c_gmres(i)
             enddo
             c_gmres(k) = temp/h_gmres(k,k)
          enddo
-!$ACC END PARALLEL
+!$ACC END KERNELS
 
 ! Sum of Arnoldi vectors
 #ifdef _OPENACC

--- a/core/math.f
+++ b/core/math.f
@@ -1943,4 +1943,18 @@ c--------------------------------------------------------
          a(i) = a(i) * b(i)
       enddo
 !$ACC END PARALLEL LOOP
+      return
       end
+c-----------------------------------------------------------------------
+      subroutine col3_acc(a,b,c,n)
+      real a(n),b(n),c(n)
+
+!$ACC PARALLEL LOOP PRESENT(a,b,c)
+      do i=1,n
+         a(i)=b(i)*c(i)
+      enddo
+!$ACC END PARALLEL
+
+      return
+      end
+c-----------------------------------------------------------------------

--- a/core/math.f
+++ b/core/math.f
@@ -1938,11 +1938,11 @@ c--------------------------------------------------------
 !MJO - 3/15/17 - ACC version of col2
 !     a little hack to make dsavg work easily
 
-!$ACC PARALLEL LOOP GANG VECTOR PRESENT(a,b)
+!$ACC PARALLEL LOOP PRESENT(a,b)
       do i=1,n
          a(i) = a(i) * b(i)
       enddo
-!$ACC END PARALLEL LOOP
+!$ACC END PARALLEL
       return
       end
 c-----------------------------------------------------------------------
@@ -1957,4 +1957,29 @@ c-----------------------------------------------------------------------
 
       return
       end
+c-----------------------------------------------------------------------
+      subroutine copy_acc(a,b,n)
+      real a(n),b(n)
+
+!$ACC PARALLEL LOOP PRESENT(a,b)
+      do i=1,n
+         a(i)=b(i)
+      enddo
+!$ACC END PARALLEL
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine add2s2_acc(a,b,c1,n)
+      real a(1),b(1)
+
+!$ACC PARALLEL LOOP PRESENT(a,b)
+      do i=1,n
+        a(i)=a(i)+c1*b(i)
+      enddo
+!$ACC END PARALLEL
+
+      return
+      end
+
 c-----------------------------------------------------------------------

--- a/core/subs2.f
+++ b/core/subs2.f
@@ -2310,3 +2310,12 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
+      subroutine cmult2_acc (a,b,const,n)
+      dimension a(n),b(n)
+!$ACC PARALLEL LOOP
+      do i=1,n
+         a(i)=b(i)*const
+      enddo
+!$ACC END PARALLEL
+      return
+      end


### PR DESCRIPTION
This PR is the culmination of the several previous PRs ( #281, #282, and #283).  It finally moves the `acc_copy_all_in()` and `acc_copy_all_out()` calls outside the `j = 1, lgmres` loop in hmh_gmres().  

The decreased data traffic can be seen by comparing profiles from this PR (top) to PR #281 (bottom).  In the newer version, the total host-to-device memcopies take 24% as long, compared to the older version.  Likewise, device-to-host memcopies take 30% as long.  

## This PR:

Time(%)  |     Time     | Calls  |      Avg  |      Min  |      Max  | Name
---------| -------------| -------| ----------| ----------| ----------| -------------------------
 33.34%  | 3.11617s     |   490  | 6.3595ms  | 1.6532ms  | 13.037ms  | `hsmg_do_fast_acc_1128_gpu`
 17.89%  | 1.67186s     |  5141  | 325.20us  |    928ns  | 2.7584ms  | `[CUDA memcpy HtoD]`
 15.44%  | 1.44335s     |  4912  | 293.84us  | 2.0800us  | 2.9826ms  | `[CUDA memcpy DtoH]`
 10.77%  | 1.00606s     |   245  | 4.1064ms  | 4.0340ms  | 4.8542ms  | `hmh_gmres_459_gpu`
  3.45%  | 321.98ms     |  2459  | 130.94us  | 118.59us  | 170.30us  | `hsmg_extrude_544_gpu`
  3.15%  | 294.00ms     |   245  | 1.2000ms  | 1.1795ms  | 1.4396ms  | `global_grad3_123_gpu`
  3.14%  | 293.86ms     |   245  | 1.1994ms  | 1.1786ms  | 1.4308ms  | `global_div3_169_gpu`

## Previous PR #281

Time(%)  |     Time     | Calls  |      Avg  |      Min  |      Max  | Name
---------|--------------|--------|-----------|-----------|-----------|--------------------------
 43.73%  | 6.85225s     |  7826  | 875.57us  |    928ns  | 2.7926ms  | `[CUDA memcpy HtoD]`
 31.15%  | 4.88104s     |  4842  | 1.0081ms  | 2.0800us  | 2.9868ms  | `[CUDA memcpy DtoH]`
 12.67%  | 1.98475s     |   310  | 6.4024ms  | 1.6530ms  | 13.063ms  | `hsmg_do_fast_acc_1128_gpu`
  4.09%  | 640.11ms     |   155  | 4.1298ms  | 4.0422ms  | 4.8471ms  | `hmh_gmres_459_gpu`
  1.31%  | 204.86ms     |  1559  | 131.40us  | 117.89us  | 169.92us  | `hsmg_extrude_544_gpu`
  1.20%  | 188.37ms     |   155  | 1.2153ms  | 1.1799ms  | 1.8874ms  | `global_div3_165_gpu`
  1.20%  | 187.60ms     |   155  | 1.2104ms  | 1.1793ms  | 1.4251ms  | `global_grad3_119_gpu`

