### PR TITLE
Fixed nekl behavior

### DIFF
--- a/bin/nekl
+++ b/bin/nekl
@@ -7,7 +7,7 @@ mv $1.his $1.his1 2>/dev/null
 mv $1.out $1.out1 2>/dev/null
 mv $1.ore $1.ore1 2>/dev/null
 mv $1.nre $1.nre1 2>/dev/null
-time nek5000 > $1.log
+time ./nek5000 > $1.log
 sleep 1
 rm logfile
 ln $1.log logfile


### PR DESCRIPTION
nekl was 'calling' nek5000 at the global scope instead of nek5000 in the directory where nekl was called.