### PR TITLE
Fixed incorrect rzero() in hsmg_schwarz_toext3d()

### DIFF
--- a/core/hsmg.f
+++ b/core/hsmg.f
@@ -614,7 +614,6 @@ c----------------------------------------------------------------------
       write(*,*), 
      $'================================================================'
 
-
       zero =  0
       one  =  1
       onem = -1
@@ -655,6 +654,8 @@ c----------------------------------------------------------------------
         write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
+        write(*,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+     $     (mg_work(k + l**ndim), k=1,mg_nh(l))
 
 c     exchange interior nodes
 
@@ -667,6 +668,8 @@ c     exchange interior nodes
         write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
+        write(*,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+     $     (mg_work(k + l**ndim), k=1,mg_nh(l))
 
       call hsmg_schwarz_dssum2(mg_work,l,mg_work_size)
 
@@ -677,6 +680,8 @@ c     exchange interior nodes
         write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
+        write(*,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+     $     (mg_work(k + l**ndim), k=1,mg_nh(l))
 
       call hsmg_extrude(mg_work,0,one ,mg_work,2,onem,enx,eny,enz)
 
@@ -687,6 +692,8 @@ c     exchange interior nodes
         write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
+        write(*,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+     $     (mg_work(k + l**ndim), k=1,mg_nh(l))
 
       call hsmg_fdm(mg_work(i),mg_work,l) ! Do the local solves
 
@@ -697,6 +704,8 @@ c     exchange interior nodes
         write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
+        write(*,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+     $     (mg_work(k + l**ndim), k=1,mg_nh(l))
 
 c     Sum overlap region (border excluded)
       call hsmg_extrude(mg_work,0,zero,mg_work(i),0,one ,enx,eny,enz)
@@ -810,21 +819,11 @@ c----------------------------------------------------------------------
 
       integer i,j,k,ie
 
-!     call rzero(a,(n+2)*(n+2)*(n+2)*nelv)
-!MJO - 3/15/17 Inlined to avoid rearchitecting
-!              rzero
-
-!$ACC PARALLEL LOOP COLLAPSE(4) PRESENT(a,b)
-      do ie=1,nelv
-        do k=0,n+1 !FIXME: make n-1,n+1
-          do j=0,n+1
-            do i=0,n+1
-              a(i,j,k,ie)=b(i,j,k,ie)
-            enddo
-          enddo
-        enddo
-      enddo
-!$ACC END LOOP
+#ifdef _OPENACC
+      call rzero_acc(a,(n+2)*(n+2)*(n+2)*nelv)
+#else
+      call rzero(a,(n+2)*(n+2)*(n+2)*nelv)
+#endif
 
 !$ACC PARALLEL LOOP COLLAPSE(4) PRESENT(a,b)
 !$ACC&              GANG VECTOR

--- a/core/hsmg.f
+++ b/core/hsmg.f
@@ -610,8 +610,8 @@ c----------------------------------------------------------------------
 
       real e(1),r(1)
 
-      write(*,*), ''
-      write(*,*), 
+      write(0,*), ''
+      write(0,*), 
      $'================================================================'
 
       zero =  0
@@ -627,10 +627,10 @@ c----------------------------------------------------------------------
         !MJO - 3/15/17 Only put 3d on GPU
 
 !$ACC UPDATE HOST(mg_work)
-        write(*,*), ''
-        write(*,*), '**** BEFORE hsmg_schwarz_toext3d ****'
-        write(*,*), 'mg_nh(l)',  (mg_nh(l))
-        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+        write(0,*), ''
+        write(0,*), '**** BEFORE hsmg_schwarz_toext3d ****'
+        write(0,*), 'mg_nh(l)',  (mg_nh(l))
+        write(0,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
 
@@ -648,13 +648,13 @@ c----------------------------------------------------------------------
       mg_work_size = enx*eny*enz*nelv
 
 !$ACC UPDATE HOST(mg_work)
-        write(*,*), ''
-        write(*,*), '**** AFTER hsmg_schwarz_toext3d ****'
-        write(*,*), 'mg_nh(l)',  (mg_nh(l))
-        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+        write(0,*), ''
+        write(0,*), '**** AFTER hsmg_schwarz_toext3d ****'
+        write(0,*), 'mg_nh(l)',  (mg_nh(l))
+        write(0,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
-        write(*,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+        write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
      $     (mg_work(k + l**ndim), k=1,mg_nh(l))
 
 c     exchange interior nodes
@@ -662,49 +662,49 @@ c     exchange interior nodes
       call hsmg_extrude(mg_work,0,zero,mg_work,2,one,enx,eny,enz)
 
 !$ACC UPDATE HOST(mg_work)
-        write(*,*), ''
-        write(*,*), '**** AFTER hsmg_extrude, 1/5 ****'
-        write(*,*), 'mg_nh(l)',  (mg_nh(l))
-        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+        write(0,*), ''
+        write(0,*), '**** AFTER hsmg_extrude, 1/5 ****'
+        write(0,*), 'mg_nh(l)',  (mg_nh(l))
+        write(0,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
-        write(*,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+        write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
      $     (mg_work(k + l**ndim), k=1,mg_nh(l))
 
       call hsmg_schwarz_dssum2(mg_work,l,mg_work_size)
 
 !$ACC UPDATE HOST(mg_work)
-        write(*,*), ''
-        write(*,*), '**** AFTER hsmg_schwarz_dssum2 ****'
-        write(*,*), 'mg_nh(l)',  (mg_nh(l))
-        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+        write(0,*), ''
+        write(0,*), '**** AFTER hsmg_schwarz_dssum2 ****'
+        write(0,*), 'mg_nh(l)',  (mg_nh(l))
+        write(0,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
-        write(*,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+        write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
      $     (mg_work(k + l**ndim), k=1,mg_nh(l))
 
       call hsmg_extrude(mg_work,0,one ,mg_work,2,onem,enx,eny,enz)
 
 !$ACC UPDATE HOST(mg_work)
-        write(*,*), ''
-        write(*,*), '**** AFTER hsmg_extrude, 2/5 ****'
-        write(*,*), 'mg_nh(l)',  (mg_nh(l))
-        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+        write(0,*), ''
+        write(0,*), '**** AFTER hsmg_extrude, 2/5 ****'
+        write(0,*), 'mg_nh(l)',  (mg_nh(l))
+        write(0,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
-        write(*,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+        write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
      $     (mg_work(k + l**ndim), k=1,mg_nh(l))
 
       call hsmg_fdm(mg_work(i),mg_work,l) ! Do the local solves
 
 !$ACC UPDATE HOST(mg_work)
-        write(*,*), ''
-        write(*,*), '**** AFTER hsmg_fdm ****'
-        write(*,*), 'mg_nh(l)',  (mg_nh(l))
-        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+        write(0,*), ''
+        write(0,*), '**** AFTER hsmg_fdm ****'
+        write(0,*), 'mg_nh(l)',  (mg_nh(l))
+        write(0,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
-        write(*,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+        write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
      $     (mg_work(k + l**ndim), k=1,mg_nh(l))
 
 c     Sum overlap region (border excluded)
@@ -2517,7 +2517,7 @@ c----------------------------------------------------------------------
       n=mask(0)
 !$ACC LOOP SEQ
       do i=1,n
-c        write(6,*) i,mask(i),n,' MG_MASK'
+c        write(0,*) i,mask(i),n,' MG_MASK'
          w(mask(i)) = 0.
       enddo
 !$ACC END LOOP

--- a/core/hsmg.f
+++ b/core/hsmg.f
@@ -610,6 +610,10 @@ c----------------------------------------------------------------------
 
       real e(1),r(1)
 
+      write(*,*), ''
+      write(*,*), 
+     $'================================================================'
+
 
       zero =  0
       one  =  1
@@ -622,6 +626,15 @@ c----------------------------------------------------------------------
 
       if (if3d) then            ! extended array
         !MJO - 3/15/17 Only put 3d on GPU
+
+!$ACC UPDATE HOST(mg_work)
+        write(*,*), ''
+        write(*,*), '**** BEFORE hsmg_schwarz_toext3d ****'
+        write(*,*), 'mg_nh(l)',  (mg_nh(l))
+        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+     $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
+     $     k=1,mg_nh(l))
+
          call hsmg_schwarz_toext3d(mg_work,r,mg_nh(l))
       else
          call hsmg_schwarz_toext2d(mg_work,r,mg_nh(l))
@@ -635,13 +648,55 @@ c----------------------------------------------------------------------
       i = enx*eny*enz*nelv+1
       mg_work_size = enx*eny*enz*nelv
 
+!$ACC UPDATE HOST(mg_work)
+        write(*,*), ''
+        write(*,*), '**** AFTER hsmg_schwarz_toext3d ****'
+        write(*,*), 'mg_nh(l)',  (mg_nh(l))
+        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+     $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
+     $     k=1,mg_nh(l))
+
 c     exchange interior nodes
+
       call hsmg_extrude(mg_work,0,zero,mg_work,2,one,enx,eny,enz)
+
+!$ACC UPDATE HOST(mg_work)
+        write(*,*), ''
+        write(*,*), '**** AFTER hsmg_extrude, 1/5 ****'
+        write(*,*), 'mg_nh(l)',  (mg_nh(l))
+        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+     $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
+     $     k=1,mg_nh(l))
+
       call hsmg_schwarz_dssum2(mg_work,l,mg_work_size)
+
+!$ACC UPDATE HOST(mg_work)
+        write(*,*), ''
+        write(*,*), '**** AFTER hsmg_schwarz_dssum2 ****'
+        write(*,*), 'mg_nh(l)',  (mg_nh(l))
+        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+     $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
+     $     k=1,mg_nh(l))
 
       call hsmg_extrude(mg_work,0,one ,mg_work,2,onem,enx,eny,enz)
 
+!$ACC UPDATE HOST(mg_work)
+        write(*,*), ''
+        write(*,*), '**** AFTER hsmg_extrude, 2/5 ****'
+        write(*,*), 'mg_nh(l)',  (mg_nh(l))
+        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+     $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
+     $     k=1,mg_nh(l))
+
       call hsmg_fdm(mg_work(i),mg_work,l) ! Do the local solves
+
+!$ACC UPDATE HOST(mg_work)
+        write(*,*), ''
+        write(*,*), '**** AFTER hsmg_fdm ****'
+        write(*,*), 'mg_nh(l)',  (mg_nh(l))
+        write(*,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
+     $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
+     $     k=1,mg_nh(l))
 
 c     Sum overlap region (border excluded)
       call hsmg_extrude(mg_work,0,zero,mg_work(i),0,one ,enx,eny,enz)

--- a/core/hsmg.f
+++ b/core/hsmg.f
@@ -610,10 +610,6 @@ c----------------------------------------------------------------------
 
       real e(1),r(1)
 
-      write(0,*), ''
-      write(0,*), 
-     $'================================================================'
-
       zero =  0
       one  =  1
       onem = -1
@@ -623,22 +619,27 @@ c----------------------------------------------------------------------
 
       call h1mg_mask  (r,mg_imask(pm),nelfld(ifield))  ! Zero Dirichlet nodes
 
-      if (if3d) then            ! extended array
-        !MJO - 3/15/17 Only put 3d on GPU
-
+#ifdef DEBUG
 !$ACC UPDATE HOST(mg_work)
         write(0,*), ''
-        write(0,*), '**** BEFORE hsmg_schwarz_toext3d ****'
+        write(0,*), 
+     $'================================================================'
+        write(0,*), ''
+        write(0,*), '**** AFTER h1mg_mask ****'
         write(0,*), 'mg_nh(l)',  (mg_nh(l))
         write(0,*), 'mg_work(', mg_nh(l)+1, ',2,2,1): ', 
      $     (mg_work(1 + (mg_nh(l)+2)**2 + (mg_nh(l)+2) +  k), 
      $     k=1,mg_nh(l))
+        write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
+     $     (mg_work(k + l**ndim), k=1,mg_nh(l))
+#endif
 
+      if (if3d) then            ! extended array
+        !MJO - 3/15/17 Only put 3d on GPU
          call hsmg_schwarz_toext3d(mg_work,r,mg_nh(l))
       else
          call hsmg_schwarz_toext2d(mg_work,r,mg_nh(l))
       endif
-
 
       enx=mg_nh(l)+2
       eny=mg_nh(l)+2
@@ -647,6 +648,7 @@ c----------------------------------------------------------------------
       i = enx*eny*enz*nelv+1
       mg_work_size = enx*eny*enz*nelv
 
+#ifdef DEBUG
 !$ACC UPDATE HOST(mg_work)
         write(0,*), ''
         write(0,*), '**** AFTER hsmg_schwarz_toext3d ****'
@@ -656,11 +658,12 @@ c----------------------------------------------------------------------
      $     k=1,mg_nh(l))
         write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
      $     (mg_work(k + l**ndim), k=1,mg_nh(l))
+#endif
 
 c     exchange interior nodes
-
       call hsmg_extrude(mg_work,0,zero,mg_work,2,one,enx,eny,enz)
 
+#ifdef DEBUG
 !$ACC UPDATE HOST(mg_work)
         write(0,*), ''
         write(0,*), '**** AFTER hsmg_extrude, 1/5 ****'
@@ -670,9 +673,11 @@ c     exchange interior nodes
      $     k=1,mg_nh(l))
         write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
      $     (mg_work(k + l**ndim), k=1,mg_nh(l))
+#endif
 
       call hsmg_schwarz_dssum2(mg_work,l,mg_work_size)
 
+#ifdef DEBUG
 !$ACC UPDATE HOST(mg_work)
         write(0,*), ''
         write(0,*), '**** AFTER hsmg_schwarz_dssum2 ****'
@@ -682,9 +687,11 @@ c     exchange interior nodes
      $     k=1,mg_nh(l))
         write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
      $     (mg_work(k + l**ndim), k=1,mg_nh(l))
+#endif
 
       call hsmg_extrude(mg_work,0,one ,mg_work,2,onem,enx,eny,enz)
 
+#ifdef DEBUG
 !$ACC UPDATE HOST(mg_work)
         write(0,*), ''
         write(0,*), '**** AFTER hsmg_extrude, 2/5 ****'
@@ -694,9 +701,11 @@ c     exchange interior nodes
      $     k=1,mg_nh(l))
         write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
      $     (mg_work(k + l**ndim), k=1,mg_nh(l))
+#endif
 
       call hsmg_fdm(mg_work(i),mg_work,l) ! Do the local solves
 
+#ifdef DEBUG
 !$ACC UPDATE HOST(mg_work)
         write(0,*), ''
         write(0,*), '**** AFTER hsmg_fdm ****'
@@ -706,6 +715,7 @@ c     exchange interior nodes
      $     k=1,mg_nh(l))
         write(0,*), 'mg_work(1,1:mg_nh(l)', nl**ndim, ',1): ', 
      $     (mg_work(k + l**ndim), k=1,mg_nh(l))
+#endif
 
 c     Sum overlap region (border excluded)
       call hsmg_extrude(mg_work,0,zero,mg_work(i),0,one ,enx,eny,enz)

--- a/core/makenek.inc
+++ b/core/makenek.inc
@@ -16,6 +16,7 @@ if [ "$PPLIST" == "?" ]; then
   echo "  NEKNEK      activate overlapping mesh solver (experimental)"
   echo "  CMTNEK      activate DG compressible-flow solver (experimental)"
   echo "  ACC         compile with OpenACC (experimental)"
+  echo "  DEBUG       print debugging messages (severely limits performance)"
   exit 1
 fi
 

--- a/core/math.f
+++ b/core/math.f
@@ -1958,3 +1958,12 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
+      subroutine rzero_acc(a,n)
+      real  a(n)
+!$ACC PARALLEL LOOP PRESENT(a)
+      do i = 1, n
+         a(i ) = 0.0
+      enddo
+!$ACC END PARALLEL
+      return
+      end


### PR DESCRIPTION
In `hsmg_schwarz_toext3d()`, the call to `rzero()` had been inlined for OpenACC.  This was to avoid implementing a new `rzero_acc()` just for this purpose.  However, we inlined the subroutine incorrectly.  This PR fixes that issue.

I've also kept some debugging statements, which can be enabled with the "DEBUG" preprocessor symbol.  We will hopefully remove them once the OpenACC version is stable, but for now, they provide very useful debugging info when needed.  