### PR TITLE
Decreased host/device data movement in hmh_gmres (revised)

### DIFF
--- a/core/acc.f
+++ b/core/acc.f
@@ -29,6 +29,7 @@
 !$ACC ENTER DATA COPYIN(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC ENTER DATA COPYIN(h_gmres,w_gmres,v_gmres,z_gmres)
 !$ACC ENTER DATA COPYIN(c_gmres,s_gmres,x_gmres,gamma_gmres)
+!$ACC ENTER DATA COPYIN(r_gmres)
 !$ACC ENTER DATA COPYIN(ml_gmres,mu_gmres)
 !$ACC ENTER DATA COPYIN(h1,h2)
 
@@ -65,6 +66,7 @@
 !$ACC EXIT DATA DELETE(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC EXIT DATA COPYOUT(h_gmres,w_gmres,v_gmres,z_gmres)
 !$ACC EXIT DATA COPYOUT(c_gmres,s_gmres,x_gmres,gamma_gmres)
+!$ACC EXIT DATA COPYOUT(r_gmres)
 !$ACC EXIT DATA COPYOUT(ml_gmres,mu_gmres)
 !$ACC EXIT DATA COPYOUT(h1,h2)
 

--- a/core/acc.f
+++ b/core/acc.f
@@ -28,7 +28,7 @@
 !$ACC ENTER DATA COPYIN(mg_work,mg_fast_s,mg_fast_d)
 !$ACC ENTER DATA COPYIN(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC ENTER DATA COPYIN(h_gmres,w_gmres,v_gmres,z_gmres)
-!$ACC ENTER DATA COPYIN(c_gmres,s_gmres)
+!$ACC ENTER DATA COPYIN(c_gmres,s_gmres,gamma_gmres)
 !$ACC ENTER DATA COPYIN(ml_gmres,mu_gmres)
 !$ACC ENTER DATA COPYIN(h1,h2)
 
@@ -64,7 +64,7 @@
 !$ACC EXIT DATA DELETE(mg_work,mg_fast_s,mg_fast_d)
 !$ACC EXIT DATA DELETE(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC EXIT DATA COPYOUT(h_gmres,w_gmres,v_gmres,z_gmres)
-!$ACC EXIT DATA COPYOUT(c_gmres,s_gmres)
+!$ACC EXIT DATA COPYOUT(c_gmres,s_gmres,gamma_gmres)
 !$ACC EXIT DATA COPYOUT(ml_gmres,mu_gmres)
 !$ACC EXIT DATA COPYOUT(h1,h2)
 

--- a/core/acc.f
+++ b/core/acc.f
@@ -28,8 +28,11 @@
 !$ACC ENTER DATA COPYIN(mg_work,mg_fast_s,mg_fast_d)
 !$ACC ENTER DATA COPYIN(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC ENTER DATA COPYIN(h_gmres,w_gmres,v_gmres,z_gmres)
+!$ACC ENTER DATA COPYIN(c_gmres,s_gmres)
 !$ACC ENTER DATA COPYIN(ml_gmres,mu_gmres)
 !$ACC ENTER DATA COPYIN(h1,h2)
+
+
       return
       end
 
@@ -61,6 +64,7 @@
 !$ACC EXIT DATA DELETE(mg_work,mg_fast_s,mg_fast_d)
 !$ACC EXIT DATA DELETE(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC EXIT DATA COPYOUT(h_gmres,w_gmres,v_gmres,z_gmres)
+!$ACC EXIT DATA COPYOUT(c_gmres,s_gmres)
 !$ACC EXIT DATA COPYOUT(ml_gmres,mu_gmres)
 !$ACC EXIT DATA COPYOUT(h1,h2)
 

--- a/core/acc.f
+++ b/core/acc.f
@@ -28,7 +28,7 @@
 !$ACC ENTER DATA COPYIN(mg_work,mg_fast_s,mg_fast_d)
 !$ACC ENTER DATA COPYIN(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC ENTER DATA COPYIN(h_gmres,w_gmres,v_gmres,z_gmres)
-!$ACC ENTER DATA COPYIN(c_gmres,s_gmres,gamma_gmres)
+!$ACC ENTER DATA COPYIN(c_gmres,s_gmres,x_gmres,gamma_gmres)
 !$ACC ENTER DATA COPYIN(ml_gmres,mu_gmres)
 !$ACC ENTER DATA COPYIN(h1,h2)
 
@@ -64,7 +64,7 @@
 !$ACC EXIT DATA DELETE(mg_work,mg_fast_s,mg_fast_d)
 !$ACC EXIT DATA DELETE(g1m1,g2m1,g3m1,g4m1,g5m1,g6m1,dxm1,dxtm1)
 !$ACC EXIT DATA COPYOUT(h_gmres,w_gmres,v_gmres,z_gmres)
-!$ACC EXIT DATA COPYOUT(c_gmres,s_gmres,gamma_gmres)
+!$ACC EXIT DATA COPYOUT(c_gmres,s_gmres,x_gmres,gamma_gmres)
 !$ACC EXIT DATA COPYOUT(ml_gmres,mu_gmres)
 !$ACC EXIT DATA COPYOUT(h1,h2)
 

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -478,13 +478,16 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 !$ACC UPDATE DEVICE(h_gmres)
 
 #ifdef _OPENACC
-!$ACC KERNELS PRESENT(w_gmres, h_gmres, v_gmres)
-            do i=1,j
-               do k=1,n
-                  w_gmres(k) = w_gmres(k) - h_gmres(i,j) * v_gmres(k,i)
+!$ACC PARALLEL PRESENT(w_gmres, h_gmres, v_gmres)
+!$ACC LOOP PRIVATE(temp)
+            do k=1,n
+               temp = w_gmres(k)
+               do i=1,j
+                  temp = temp - h_gmres(i,j) * v_gmres(k,i)
                enddo
+               w_gmres(k) = temp
             enddo                                                !          i,j  i
-!$ACC END KERNELS
+!$ACC END PARALLEL
 #else
             do i=1,j
                call add2s2(w_gmres,v_gmres(1,i),-h_gmres(i,j),n) ! w = w - h    v

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -547,14 +547,18 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
          !back substitution
          !     -1
          !c = H   gamma
-         call acc_copy_all_out()
+!$ACC PARALLEL PRESENT(gamma_gmres, h_gmres, c_gmres)
+!$ACC LOOP SEQ
          do k=j,1,-1
             temp = gamma_gmres(k)
+!$ACC LOOP
             do i=j,k+1,-1
                temp = temp - h_gmres(k,i)*c_gmres(i)
             enddo
             c_gmres(k) = temp/h_gmres(k,k)
          enddo
+!$ACC END PARALLEL
+         call acc_copy_all_out()
          !sum up Arnoldi vectors
          do i=1,j
             call add2s2(x_gmres,z_gmres(1,i),c_gmres(i),n) ! x = x + c  z

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -456,23 +456,14 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 #ifdef _OPENACC
 
-c ROR, 05-12-2017: Though we attempted to implement vlsc3_acc() with an
-c ACC REDUCTION clause, it did not give the correct results (see
-c comments in vlsc3_acc).  This working implementation is based on
-c dependency analysis from the compiler.  
-
 !$ACC PARALLEL PRESENT(h_gmres, w_gmres, v_gmres, wt)
-!$ACC LOOP GANG, VECTOR
-            do i=1,j
-              h_gmres(i,j) = 0.0
-            enddo
-!$ACC LOOP SEQ
-            do k=1,n
-!$ACC LOOP GANG, VECTOR
-              do i=1,j
-                h_gmres(i,j) = h_gmres(i,j) + w_gmres(k) 
-     $            * v_gmres(k,i) *  wt(k)
-              enddo
+!$ACC LOOP PRIVATE(temp)
+            do i=1,j 
+               temp = 0.0
+               do k=1,n
+                  temp = temp + w_gmres(k) * v_gmres(k,i) *  wt(k)
+               enddo
+               h_gmres(i,j) = temp
             enddo                                            !  i,j       i
 !$ACC END PARALLEL
 

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -399,10 +399,10 @@ c           call copy(r,res,n)
          if(gamma_gmres(1) .eq. 0.) goto 9000
          temp = 1./gamma_gmres(1)
          call cmult2(v_gmres(1,1),r_gmres,temp,n) ! v  = r / gamma
+
+         call acc_copy_all_in()
                                                    !  1            1
          do j=1,m
-
-            call acc_copy_all_in()
 
             iter = iter+1
                                                        !       -1
@@ -538,8 +538,6 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
             temp = 1./alpha
             call cmult2(v_gmres(1,j+1),w_gmres,temp,n) ! v    = w / alpha
 #endif
-                                                       !  j+1
-         call acc_copy_all_out()
 
          enddo
   900    iconv = 1
@@ -575,8 +573,8 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
          enddo                                             !          i  i
 #endif
 c        if(iconv.eq.1) call dbg_write(x,nx1,ny1,nz1,nelv,'esol',3)
-         call acc_copy_all_out()
       enddo
+      call acc_copy_all_out()
  9000 continue
 
       divex = rnorm

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -460,6 +460,7 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 !$ACC LOOP PRIVATE(temp)
             do i=1,j 
                temp = 0.0
+!$ACC LOOP
                do k=1,n
                   temp = temp + w_gmres(k) * v_gmres(k,i) *  wt(k)
                enddo
@@ -479,13 +480,12 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 #ifdef _OPENACC
 !$ACC PARALLEL PRESENT(w_gmres, h_gmres, v_gmres)
-!$ACC LOOP PRIVATE(temp)
-            do k=1,n
-               temp = w_gmres(k)
-               do i=1,j
-                  temp = temp - h_gmres(i,j) * v_gmres(k,i)
+!$ACC LOOP SEQ
+            do i=1,j
+!$ACC LOOP
+               do k=1,n
+                  w_gmres(k) = w_gmres(k) - h_gmres(i,j) * v_gmres(k,i)
                enddo
-               w_gmres(k) = temp
             enddo                                                !          i,j  i
 !$ACC END PARALLEL
 #else

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -548,17 +548,15 @@ c . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
          !     -1
          !c = H   gamma
 
-!$ACC PARALLEL PRESENT(gamma_gmres, h_gmres, c_gmres)
-!$ACC LOOP SEQ
+!$ACC KERNELS PRESENT(gamma_gmres, h_gmres, c_gmres)
          do k=j,1,-1
             temp = gamma_gmres(k)
-!$ACC LOOP
             do i=j,k+1,-1
                temp = temp - h_gmres(k,i)*c_gmres(i)
             enddo
             c_gmres(k) = temp/h_gmres(k,k)
          enddo
-!$ACC END PARALLEL
+!$ACC END KERNELS
 
 ! Sum of Arnoldi vectors
 #ifdef _OPENACC

--- a/core/math.f
+++ b/core/math.f
@@ -1943,4 +1943,18 @@ c--------------------------------------------------------
          a(i) = a(i) * b(i)
       enddo
 !$ACC END PARALLEL LOOP
+      return
       end
+c-----------------------------------------------------------------------
+      subroutine col3_acc(a,b,c,n)
+      real a(n),b(n),c(n)
+
+!$ACC PARALLEL LOOP PRESENT(a,b,c)
+      do i=1,n
+         a(i)=b(i)*c(i)
+      enddo
+!$ACC END PARALLEL
+
+      return
+      end
+c-----------------------------------------------------------------------

--- a/core/math.f
+++ b/core/math.f
@@ -1938,11 +1938,11 @@ c--------------------------------------------------------
 !MJO - 3/15/17 - ACC version of col2
 !     a little hack to make dsavg work easily
 
-!$ACC PARALLEL LOOP GANG VECTOR PRESENT(a,b)
+!$ACC PARALLEL LOOP PRESENT(a,b)
       do i=1,n
          a(i) = a(i) * b(i)
       enddo
-!$ACC END PARALLEL LOOP
+!$ACC END PARALLEL
       return
       end
 c-----------------------------------------------------------------------
@@ -1957,4 +1957,29 @@ c-----------------------------------------------------------------------
 
       return
       end
+c-----------------------------------------------------------------------
+      subroutine copy_acc(a,b,n)
+      real a(n),b(n)
+
+!$ACC PARALLEL LOOP PRESENT(a,b)
+      do i=1,n
+         a(i)=b(i)
+      enddo
+!$ACC END PARALLEL
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine add2s2_acc(a,b,c1,n)
+      real a(1),b(1)
+
+!$ACC PARALLEL LOOP PRESENT(a,b)
+      do i=1,n
+        a(i)=a(i)+c1*b(i)
+      enddo
+!$ACC END PARALLEL
+
+      return
+      end
+
 c-----------------------------------------------------------------------

--- a/core/subs2.f
+++ b/core/subs2.f
@@ -2310,3 +2310,12 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
+      subroutine cmult2_acc (a,b,const,n)
+      dimension a(n),b(n)
+!$ACC PARALLEL LOOP
+      do i=1,n
+         a(i)=b(i)*const
+      enddo
+!$ACC END PARALLEL
+      return
+      end


### PR DESCRIPTION
This is a working revision of PR #284.  The OpenACC data regions are now moved outside the outer convergence loop in `hmh_gmres()`.   Bugfixes from PR #290 and #291 have now been included, so CPU and GPU versions now match.  