### PR TITLE
Began implementing gop_acc

### DIFF
--- a/core/comm_mpi.f
+++ b/core/comm_mpi.f
@@ -157,6 +157,8 @@ c-----------------------------------------------------------------------
 
 c     Global vector commutative operation
 
+      include 'CTIMER'
+
       include 'mpif.h'
       common /nekmpi/ nid,np,nekcomm,nekgroup,nekreal
 
@@ -164,6 +166,16 @@ c     Global vector commutative operation
       character*3 op
 
       if (ifsync) call nekgsync()
+
+#ifdef TIMER
+      if (icalld.eq.0) then
+        tgop =0.0d0
+        ngop =0
+        icalld=1
+      endif
+      ngop = ngop + 1
+      etime1=dnekclock()
+#endif
 
 #ifdef MPI
 

--- a/core/comm_mpi.f
+++ b/core/comm_mpi.f
@@ -153,6 +153,55 @@ c
       return
       end
 c-----------------------------------------------------------------------
+      subroutine gop_acc( x, w, op, n)
+
+c     Global vector commutative operation
+
+      include 'mpif.h'
+      common /nekmpi/ nid,np,nekcomm,nekgroup,nekreal
+
+      real x(n), w(n)
+      character*3 op
+
+      if (ifsync) call nekgsync()
+
+#ifdef MPI
+
+c     ROR: 2017-06-03: This implementation updates host and does
+c     communication through host.  
+
+c     It may be possible to use the HOST_DATA clause so that
+c     mpi_allreduce will (if I understand correctly) be able to use GPU
+c     direct, if available.  However, I have not tested it.  This is
+c     based on demonstrations from:
+c     https://www.olcf.ornl.gov/tutorials/gpudirect-mpich-enabled-cuda/#OpenACC_Fortran
+
+!$ACC UPDATE HOST(x)
+      if (op.eq.'+  ') then
+         call mpi_allreduce (x,w,n,nekreal,mpi_sum ,nekcomm,ierr)
+      elseif (op.EQ.'M  ') then
+         call mpi_allreduce (x,w,n,nekreal,mpi_max ,nekcomm,ierr)
+      elseif (op.EQ.'m  ') then
+         call mpi_allreduce (x,w,n,nekreal,mpi_min ,nekcomm,ierr)
+      elseif (op.EQ.'*  ') then
+         call mpi_allreduce (x,w,n,nekreal,mpi_prod,nekcomm,ierr)
+      else
+         write(6,*) nid,' OP ',op,' not supported.  ABORT in GOP.'
+         call exitt
+      endif
+!$ACC UPDATE DEVICE(w)
+
+      call copy_acc(x,w,n)
+
+#else
+
+c     ROR: 2017-06-03:  On a single-node, allreduce is a null op.
+
+#endif
+
+      return
+      end
+c-----------------------------------------------------------------------
       subroutine igop( x, w, op, n)
 c
 c     Global vector commutative operation

--- a/core/math.f
+++ b/core/math.f
@@ -1090,6 +1090,33 @@ C
       GLSC3 = TMP
       return
       END
+
+C----------------------------------------------------------------------------
+
+
+      function glsc3_acc(a,b,mult,n)
+C
+C     Perform inner-product in double precision
+C
+      real a(n),b(n),mult(n)
+      real tmp,work(1)
+
+      tmp = 0.0
+
+!$ACC KERNELS PRESENT(a,b,mult)
+      do  i=1,n
+         tmp = tmp + a(i)*b(i)*mult(i)
+      enddo
+!$ACC END KERNELS
+
+!$ACC ENTER DATA CREATE(work)
+      call gop_acc(tmp,work,'+  ',1)
+!$ACC EXIT DATA DELETE(work)
+
+      glsc3_acc = tmp
+      return
+      end
+
 c-----------------------------------------------------------------------
       function glsc2(x,y,n)
 C


### PR DESCRIPTION
This PR implements collectives in `gop_acc()`.  It handles allreduce in two ways
* Without MPI, the allreduce is simply a null op.
* With MPI, the allreduce is surrounded by host/device updates and done on the CPU.  However, it leaves the opportunity to use GPU-aware MPI by substituting the host/device updates with host_data pointers (which will be done in a future PR).  

This PR also introduces `glsc3_acc()`, which uses `gop_acc()`.

Overall, this PR elminates many host/device updates without MPI.  With MPI, we still have the opportunity to introduce GPU-aware MPI in a future PR.   