### PR TITLE
In hmh_gmres, running chktcg1_acc on GPU

### DIFF
--- a/core/acc.f
+++ b/core/acc.f
@@ -20,6 +20,8 @@
       common /scrmg/ e(2*lt),w(lt),r(lt)
       parameter (lwk=(lx1+2)*(ly1+2)*(lz1+2))
       common /hsmgw/ work(0:lwk-1),work2(0:lwk-1)
+      common /ctmp0/ w1   (lx1,ly1,lz1,lelt)
+     $ ,             w2   (lx1,ly1,lz1,lelt)
 !$ACC ENTER DATA COPYIN(work,work2)
 !$ACC ENTER DATA COPYIN(mg_mask,mg_imask,pmask)
 !$ACC ENTER DATA COPYIN(tmult,vmult)
@@ -32,6 +34,8 @@
 !$ACC ENTER DATA COPYIN(r_gmres)
 !$ACC ENTER DATA COPYIN(ml_gmres,mu_gmres)
 !$ACC ENTER DATA COPYIN(h1,h2)
+!$ACC ENTER DATA COPYIN(bm1,binvm1,bintm1)
+!$ACC ENTER DATA CREATE(w1,w2)
 
 
       return
@@ -58,6 +62,8 @@
       common /scrmg/ e(2*lt),w(lt),r(lt)
       parameter (lwk=(lx1+2)*(ly1+2)*(lz1+2))
       common /hsmgw/ work(0:lwk-1),work2(0:lwk-1)
+      common /ctmp0/ w1   (lx1,ly1,lz1,lelt)
+     $ ,             w2   (lx1,ly1,lz1,lelt)
 !$ACC EXIT DATA DELETE(work,work2)
 !$ACC EXIT DATA DELETE(mg_mask,mg_imask,pmask)
 !$ACC EXIT DATA DELETE(e,w,r)
@@ -69,6 +75,8 @@
 !$ACC EXIT DATA COPYOUT(r_gmres)
 !$ACC EXIT DATA COPYOUT(ml_gmres,mu_gmres)
 !$ACC EXIT DATA COPYOUT(h1,h2)
+!$ACC EXIT DATA COPYOUT(binvm1,bintm1)
+!$ACC EXIT DATA DELETE(w1,w2)
 
       return
       end

--- a/core/math.f
+++ b/core/math.f
@@ -1938,27 +1938,6 @@ c
       enddo
       return
       end
-c-----------------------------------------------------------------------
-      function glsum_acc (x,n)
-      DIMENSION X(n)
-      DIMENSION TMP(1),WORK(1)
-
-      TSUM = 0.
-
-!$ACC KERNELS
-      DO I=1,N
-         TSUM = TSUM+X(I)
-      ENDDO
-!$ACC END KERNELS
-
-      TMP(1)=TSUM
-
-      CALL GOP(TMP,WORK,'+  ',1)
-
-      GLSUM = TMP(1)
-
-      return
-      END
 c--------------------------------------------------------
       subroutine col2_acc(a,b,n)
       real a(n),b(n)
@@ -1987,28 +1966,23 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
       subroutine copy_acc(a,b,n)
       real a(n),b(n)
-
 !$ACC PARALLEL LOOP PRESENT(a,b)
       do i=1,n
          a(i)=b(i)
       enddo
 !$ACC END PARALLEL
-
       return
       end
 c-----------------------------------------------------------------------
       subroutine add2s2_acc(a,b,c1,n)
       real a(1),b(1)
-
 !$ACC PARALLEL LOOP PRESENT(a,b)
       do i=1,n
         a(i)=a(i)+c1*b(i)
       enddo
 !$ACC END PARALLEL
-
       return
       end
-
 c-----------------------------------------------------------------------
       subroutine rzero_acc(a,n)
       real  a(n)
@@ -2019,3 +1993,27 @@ c-----------------------------------------------------------------------
 !$ACC END PARALLEL
       return
       end
+c-----------------------------------------------------------------------
+      subroutine rone_acc(a,n)
+      dimension  a(n)
+!$ACC PARALLEL LOOP PRESENT(a)
+      do i = 1, n
+         a(i) = 1.0
+      enddo
+!$ACC END PARALLEL
+      END
+c-----------------------------------------------------------------------
+      function glsum_acc (x,n)
+      dimension x(n)
+      dimension tmp(1),work(1)
+      tsum = 0.
+!$ACC KERNELS PRESENT(x)
+      do i=1,n
+         tsum = tsum+x(i)
+      enddo
+!$ACC END KERNELS
+      tmp(1)=tsum
+      call gop_acc(tmp,work,'+  ',1)
+      glsum = tmp(1)
+      return
+      END


### PR DESCRIPTION
This PR implements `chktcg1_acc` to run on GPU.  To do so, we also had to implement `glsum_acc`, which uses the already-implemented `gop_acc`.  