### PR TITLE
Corrected implicit reshaping of wt() in hmh_gmres

### DIFF
--- a/core/gmres.f
+++ b/core/gmres.f
@@ -324,9 +324,9 @@ c     GMRES iteration.
       common  /cprint/ ifprint
       logical          ifprint
       real             res  (lx1*ly1*lz1*lelv)
-      real             h1   (lx1,ly1,lz1,lelv)
-      real             h2   (lx1,ly1,lz1,lelv)
-      real             wt   (lx1,ly1,lz1,lelv)
+      real             h1   (lx1*ly1*lz1*lelv)
+      real             h2   (lx1*ly1*lz1*lelv)
+      real             wt   (lx1*ly1*lz1*lelv)
 
       common /scrcg/ d(lx1*ly1*lz1*lelv),wk(lx1*ly1*lz1*lelv)
 


### PR DESCRIPTION
This PR corrects implicit reshaping of several arrays in `hmh_gmres()`: `h1`, `h2`, `wt`