### PR TITLE
Fixed errors in OpenACC MPI collective calls

### DIFF
--- a/core/math.f
+++ b/core/math.f
@@ -1099,21 +1099,22 @@ C
 C     Perform inner-product in double precision
 C
       real a(n),b(n),mult(n)
-      real tmp,work(1)
+      real tmp(1),work(1)
 
-      tmp = 0.0
+!$ACC DATA CREATE(work) COPYOUT(tmp) PRESENT(a,b,mult)
 
-!$ACC KERNELS PRESENT(a,b,mult)
+!$ACC KERNELS
+      tmp(1) = 0.0
       do  i=1,n
-         tmp = tmp + a(i)*b(i)*mult(i)
+         tmp(1) = tmp(1) + a(i)*b(i)*mult(i)
       enddo
 !$ACC END KERNELS
 
-!$ACC ENTER DATA CREATE(work)
       call gop_acc(tmp,work,'+  ',1)
-!$ACC EXIT DATA DELETE(work)
 
-      glsc3_acc = tmp
+!$ACC END DATA
+
+      glsc3_acc = tmp(1)
       return
       end
 

--- a/core/math.f
+++ b/core/math.f
@@ -2007,14 +2007,17 @@ c-----------------------------------------------------------------------
       function glsum_acc (x,n)
       dimension x(n)
       dimension tmp(1),work(1)
-      tsum = 0.
-!$ACC KERNELS PRESENT(x)
+
+!$ACC DATA COPYOUT(tmp) CREATE(work) PRESENT(x)
+!$ACC KERNELS 
+      tmp(1) = 0.
       do i=1,n
-         tsum = tsum+x(i)
+         tmp(1) = tmp(1)+x(i)
       enddo
 !$ACC END KERNELS
-      tmp(1)=tsum
       call gop_acc(tmp,work,'+  ',1)
+!$ACC END DATA
+
       glsum = tmp(1)
       return
       END


### PR DESCRIPTION
This PR fixes a number of errors with MPI collective calls in OpenACC implementation.  In particular, `glsc3_acc` and `glsum_acc` did not handle host/device data movement properly.  