### PR TITLE
Using Hypre v2.11.1 for AMG setup

### DIFF
--- a/tools/amg_hypre/hypre/install
+++ b/tools/amg_hypre/hypre/install
@@ -1,5 +1,5 @@
 #!/bin/bash
-wget https://github.com/LLNL/hypre/archive/v2.11.2.tar.gz 
+wget https://github.com/LLNL/hypre/archive/v2.11.1.tar.gz 
 tar -zxvf *.tar.gz
 cd hypre*/src
 ./configure --prefix=`pwd`/../.. CC=gcc FC=gfortran --without-MPI


### PR DESCRIPTION
Hypre v2.11.2 is producing wrong results during the AMG setup in some cases. Therefore, it is replaced by v2.11.1 (originally used when developing the setup).