### PR TITLE
Introducing luparam to define size of user runtime parameter space

### DIFF
--- a/core/INPUT
+++ b/core/INPUT
@@ -15,7 +15,7 @@ c
      $    ,cpfld(ldimt1,3)
      $    ,cpgrp(-5:10,ldimt1,3)
      $    ,qinteg(ldimt3,maxobj)
-     $    ,uparam(20)
+     $    ,uparam(luparam)
      $    ,atol(ldimt3)
       common /input1/ param,rstim,vnekton,cpfld,cpgrp,qinteg,uparam,
      $                atol

--- a/core/PARDICT
+++ b/core/PARDICT
@@ -3,7 +3,7 @@ c     Define all valid keys for .par file
 c     Note: Keys have to be in captial letters
 c
       integer PARDICT_NKEYS
-      parameter(PARDICT_NKEYS = 86)
+      parameter(PARDICT_NKEYS = 77)
 
       character*132 pardictkey(PARDICT_NKEYS)
       data
@@ -57,39 +57,30 @@ c
      &  pardictkey(48) / 'GENERAL:STARTFROM' /
      &  pardictkey(49) / 'PROBLEMTYPE' /
      &  pardictkey(50) / 'PROBLEMTYPE:STRESSFORMULATION' /
-     &  pardictkey(51) / 'GENERAL:USERPARAM01' /
-     &  pardictkey(52) / 'GENERAL:USERPARAM02' /
-     &  pardictkey(53) / 'GENERAL:USERPARAM03' /
-     &  pardictkey(54) / 'GENERAL:USERPARAM04' /
-     &  pardictkey(55) / 'GENERAL:USERPARAM05' /
-     &  pardictkey(56) / 'GENERAL:USERPARAM06' /
-     &  pardictkey(57) / 'GENERAL:USERPARAM07' /
-     &  pardictkey(58) / 'GENERAL:USERPARAM08' /
-     &  pardictkey(59) / 'GENERAL:USERPARAM09' /
-     &  pardictkey(60) / 'GENERAL:USERPARAM10' /
-     &  pardictkey(61) / 'SCALAR%%' /
-     &  pardictkey(62) / 'SCALAR%%:SOLVER' /
-     &  pardictkey(63) / 'SCALAR%%:RESIDUALTOL' /
-     &  pardictkey(64) / 'SCALAR%%:DENSITY' /
-     &  pardictkey(65) / 'SCALAR%%:DIFFUSIVITY' /
-     &  pardictkey(66) / 'SCALAR%%:WRITETOFIELDFILE' /
-     &  pardictkey(67) / 'SCALAR%%:ABSOLUTETOL' /
-     &  pardictkey(68) / 'SCALAR%%:CONJUGATEHEATTRANSFER' /
-     &  pardictkey(69) / 'TEMPERATURE:SOLVER' /
-     &  pardictkey(70) / 'TEMPERATURE:RESIDUALTOL' /
-     &  pardictkey(71) / 'TEMPERATURE:ABSOLUTETOL' /
-     &  pardictkey(72) / 'PROBLEMTYPE:DP0DT' /
-     &  pardictkey(73) / 'CVODE' /
-     &  pardictkey(74) / 'CVODE:ABSOLUTETOL' /
-     &  pardictkey(75) / 'CVODE:RELATIVETOL' /
-     &  pardictkey(76) / 'CVODE:STIFF' /
-     &  pardictkey(77) / 'CVODE:MODE' /
-     &  pardictkey(78) / 'CVODE:PRECONDITIONER' /
-     &  pardictkey(79) / 'CVODE:DTMAX' /
-     &  pardictkey(80) / 'CVODE:DQJINCREMENTFACTOR' /
-     &  pardictkey(81) / 'CVODE:RATIOLNLTOL' /
-     &  pardictkey(82) / ':PARVERSION' /
-     &  pardictkey(83) / 'MESH:NUMBEROFBCFIELDS' /
-     &  pardictkey(84) / 'GENERAL:OPTLEVEL' /
-     &  pardictkey(85) / 'GENERAL:LOGLEVEL' /
-     &  pardictkey(86) / 'PRESSURE:SOLVER' /
+     &  pardictkey(51) / 'SCALAR%%' /
+     &  pardictkey(52) / 'SCALAR%%:SOLVER' /
+     &  pardictkey(53) / 'SCALAR%%:RESIDUALTOL' /
+     &  pardictkey(54) / 'SCALAR%%:DENSITY' /
+     &  pardictkey(55) / 'SCALAR%%:DIFFUSIVITY' /
+     &  pardictkey(56) / 'SCALAR%%:WRITETOFIELDFILE' /
+     &  pardictkey(57) / 'SCALAR%%:ABSOLUTETOL' /
+     &  pardictkey(58) / 'SCALAR%%:CONJUGATEHEATTRANSFER' /
+     &  pardictkey(59) / 'TEMPERATURE:SOLVER' /
+     &  pardictkey(60) / 'TEMPERATURE:RESIDUALTOL' /
+     &  pardictkey(61) / 'TEMPERATURE:ABSOLUTETOL' /
+     &  pardictkey(62) / 'PROBLEMTYPE:DP0DT' /
+     &  pardictkey(63) / 'CVODE' /
+     &  pardictkey(64) / 'CVODE:ABSOLUTETOL' /
+     &  pardictkey(65) / 'CVODE:RELATIVETOL' /
+     &  pardictkey(66) / 'CVODE:STIFF' /
+     &  pardictkey(67) / 'CVODE:MODE' /
+     &  pardictkey(68) / 'CVODE:PRECONDITIONER' /
+     &  pardictkey(69) / 'CVODE:DTMAX' /
+     &  pardictkey(70) / 'CVODE:DQJINCREMENTFACTOR' /
+     &  pardictkey(71) / 'CVODE:RATIOLNLTOL' /
+     &  pardictkey(72) / ':PARVERSION' /
+     &  pardictkey(73) / 'MESH:NUMBEROFBCFIELDS' /
+     &  pardictkey(74) / 'GENERAL:OPTLEVEL' /
+     &  pardictkey(75) / 'GENERAL:LOGLEVEL' /
+     &  pardictkey(76) / 'PRESSURE:SOLVER' /
+     &  pardictkey(77) / 'GENERAL:USERPARAM%%' /

--- a/core/SIZE.inc
+++ b/core/SIZE.inc
@@ -91,6 +91,9 @@ c - - SIZE internals
       integer maxmbr
       parameter (maxmbr=lelt*6)
 
+      integer luparam ! size of user runtime parameter space
+      parameter (luparam = 20)
+
       ! cvode
       integer lcvx1,lcvy1,lcvz1
       parameter(lcvx1=lx1)


### PR DESCRIPTION
- added luparam to SIZE.inc and modified accordingly the rest of files
- check of upram names in par_verify
- pardictkey(77) / 'GENERAL:USERPARAM%%' / is kept in PARDICT for user to see the whole list of possible parameters even though it is not used in par_verify and could be removed