### PR TITLE
Fixes for gfortran and Travis tests

### DIFF
--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -3075,8 +3075,8 @@ C-------------------------------------------------------------------
       include 'MASS'
       include 'EIGEN'
 
-c     common  /cprint/ ifprint
-c     logical          ifprint
+      common  /cprint/ ifprint
+      logical          ifprint
 
       real w1   (lx1,ly1,lz1,lelt),
      $     w2   (lx1,ly1,lz1,lelt)
@@ -3364,9 +3364,9 @@ c
      $ ,             tmp2  (lx1*ly1*lz1*lelt)
      $ ,             tmp3  (lx1*ly1*lz1*lelt)
 
-      real           tm1   (lx1*ly1*lz1,lelt)
-      real           tm2   (lx1*ly1*lz1,lelt)
-      real           tm3   (lx1*ly1*lz1,lelt)
+      real           tm1   (lx1*ly1*lz1*lelt)
+      real           tm2   (lx1*ly1*lz1*lelt)
+      real           tm3   (lx1*ly1*lz1*lelt)
       real           duax  (lx1)
       real           ysm1  (lx1)
 

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -61,15 +61,15 @@ c     stop
 c!$acc update host(rhs)
 
       do i=1,lx1*ly1*lz1*nelv
-         write (6,*) 'rhs=',rhs(i,1,1,1)
+c        write (6,*) 'rhs=',rhs(i,1,1,1)
       enddo
       stop
 !$acc end data
 
       do i=1,lx1*ly1*lz1*nelv
-         write (6,*) 'rhs=',rhs(i,1,1,1)
+c        write (6,*) 'rhs=',rhs(i,1,1,1)
       enddo
-      write (6,*) 'after dssum'
+c     write (6,*) 'after dssum'
       stop
 
       call col2    (rhs,mask,ntot)
@@ -2807,7 +2807,7 @@ c     if (.not.iffdm) kfldfdm=-1
       call dssum(rhs,nx1,ny1,nz1)
 
       do i=1,lx1*ly1*lz1*nelv
-         write (6,*) 'rhs=',rhs(i,1,1,1)
+c        write (6,*) 'rhs=',rhs(i,1,1,1)
       enddo
       stop
 !$acc end data
@@ -2821,7 +2821,7 @@ c     $    write(6,*) param(22),' p22 ',istep,imsh
       if (tli.lt.0) tol=tli ! caller-specified relative tolerance
 
       do i=1,lx1*ly1*lz1*nelv
-         write (6,*) 'rhs=',rhs(i,1,1,1)
+c        write (6,*) 'rhs=',rhs(i,1,1,1)
       enddo
       stop
 


### PR DESCRIPTION
These are fixes for problems exposed by Travis CPU tests.  

As of e009caa34110624e5c496a3cc00d1be630bfecd1 , all tests were failing because of (somewhat) pedantic compile-time errors.  The language syntax was allowed by pgfortran (likely the compiler for  local OpenACC tests) but not by gfortran (the compiler for Travis CPU tests).  See further comments below.

Another issue in Travis was simply some debugging print statements.  These extended the length of stdout to the point that Travis was not able to handle the length of the resultant logfile.  This causes tests to fail.  

These allow the Travis tests to compile and run to completion.  A few still fail because of runtime errors, but this PR should help expose the reasons for those failures.  