### PR TITLE
Modify .f file header to add pressure mesh flag

### DIFF
--- a/core/ic.f
+++ b/core/ic.f
@@ -2329,17 +2329,28 @@ c-----------------------------------------------------------------------
       include 'SOLN'
       include 'PARALLEL'
       include 'RESTART'
+      include 'TSTEP'
 
       character*132 hdr
       character*4 dummy
+      logical if_press_mesh
 
       p0thr = -1
+      if_press_mesh = .false.
 
       read(hdr,*,iostat=ierr) dummy
      $         ,  wdsizr,nxr,nyr,nzr,nelr,nelgr,timer,istpr
      $         ,  ifiler,nfiler
      $         ,  rdcode      ! 74+20=94
+     $         ,  p0thr, if_press_mesh
+
+      if (ierr.gt.0) then ! try again without pressure format flag
+        read(hdr,*,iostat=ierr) dummy
+     $         ,  wdsizr,nxr,nyr,nzr,nelr,nelgr,timer,istpr
+     $         ,  ifiler,nfiler
+     $         ,  rdcode      ! 74+20=94
      $         ,  p0thr
+      endif
 
       if (ierr.gt.0) then ! try again without mean pressure
         read(hdr,*,err=99) dummy
@@ -2347,6 +2358,10 @@ c-----------------------------------------------------------------------
      $         ,  ifiler,nfiler
      $         ,  rdcode      ! 74+20=94
       endif
+
+c     set if_full_pres flag
+      if_full_pres = .false.
+      if (.not.ifsplit) if_full_pres = if_press_mesh
 
       ifgtim  = .true.  ! always get time
       ifgetxr = .false.

--- a/core/prepost.f
+++ b/core/prepost.f
@@ -1858,6 +1858,7 @@ c-----------------------------------------------------------------------
 
       character*132 hdr
       integer*8 ioff
+      logical if_press_mesh
 
       call nekgsync()
       idum = 1
@@ -1915,11 +1916,15 @@ c-----------------------------------------------------------------------
             WRITE(rdcode1(i+2),'(I1)') NPSCALO-(NPSCALO/10)*10
          ENDIF
       ENDIF
+
+c     check pressure format
+      if_press_mesh = .false.
+      if (.not.ifsplit.and.if_full_pres) if_press_mesh = .true.
  
       write(hdr,1) wdsizo,nxo,nyo,nzo,nelo,nelgt,time,istep,fid0,nfileoo
-     $            ,(rdcode1(i),i=1,10),p0th
+     $            ,(rdcode1(i),i=1,10),p0th,if_press_mesh
     1 format('#std',1x,i1,1x,i2,1x,i2,1x,i2,1x,i10,1x,i10,1x,e20.13,
-     &       1x,i9,1x,i6,1x,i6,1x,10a,1pe15.7)
+     &       1x,i9,1x,i6,1x,i6,1x,10a,1pe15.7,1x,l1)
 
       ! if we want to switch the bytes for output
       ! switch it again because the hdr is in ASCII


### PR DESCRIPTION
Currently pressure for p_n-p_n-2 can be written in .f files on velocity or pressure meshes depending on if_full_press flag. Unfortunately this is not consistent between writing and reading routines as writing does not assume anything (up to user) and reading assumes single and double precision to have pressure on velocity and pressure meshes respectively. Adding flag to the header could clarify this issue. In the future it could be used as well in visualization software to properly plot pressure from restart files.