### PR TITLE
ortho res in esolve to make sure it is orthogonal to null space

### DIFF
--- a/core/navier0.f
+++ b/core/navier0.f
@@ -20,6 +20,9 @@ C
       real kwave2
 
       if (icalld.eq.0) teslv=0.0
+
+      call ortho(res) !Ensure that residual is orthogonal to null space
+
       icalld=icalld+1
       neslv=icalld
       etime1=dnekclock()


### PR DESCRIPTION
A fix to ensure that the residual is orthogonal to the null space when solving for pressure.
cc: @fischer1 