### PR TITLE
changed visit.f to run Nek examples with libsim on newer versions of …

### DIFF
--- a/core/3rd_party/visit.f
+++ b/core/3rd_party/visit.f
@@ -734,3 +734,15 @@ c---------------------------------------------------------------------
       visitgetdomainnesting = VISIT_INVALID_HANDLE
       end
 
+c---------------------------------------------------------------------
+c     visitgetmixedvariable
+c     This is needed to run with newer version of Visit (2.12.0 tested).
+c     TODO: The comment should be changed
+c---------------------------------------------------------------------
+      integer function visitgetmixedvariable(domain, name, lname)
+      implicit none
+      character*8 name
+      integer     domain, lname
+      include "visitfortransimV2interface.inc"
+      visitgetmixedvariable = VISIT_ERROR
+      end


### PR DESCRIPTION
Thanks to the help of my colleague finally I was able to run turboChannel with LibSim using this patch with Visit 2.12.3. otherwise, it won't compile.