### PR TITLE
only initialize bx in nekuic if ifmhd=.true.

### DIFF
--- a/core/ic.f
+++ b/core/ic.f
@@ -1686,7 +1686,7 @@ c-----------------------------------------------------------------------
                vx(i,j,k,e) = ux
                vy(i,j,k,e) = uy
                vz(i,j,k,e) = uz
-             elseif (ifield.eq.ifldmhd) then
+             elseif (ifield.eq.ifldmhd .and. ifmhd) then
                bx(i,j,k,e) = ux
                by(i,j,k,e) = uy
                bz(i,j,k,e) = uz


### PR DESCRIPTION
This avoids initializing bx in non-MHD cases where ldimt>npscal+3. We do this to allow diagnostic use of the T array and to make it easier to visualize diagnostic quantities (like the artificial viscosity fields in CMT-nek). This also avoids breaching the bounds of BX if ldimt>npscal+3 and lbelt=1