### PR TITLE
Fix projection always being turned on for velocity

### DIFF
--- a/core/induct.f
+++ b/core/induct.f
@@ -1036,7 +1036,6 @@ C
       real h1 (lx1,ly1,lz1,1) , h2 (lx1,ly1,lz1,1)
  
       ifproj = .false.
-      if (param(94).gt.0)    ifproj = .true.
       if (ifprojfld(ifield)) ifproj = .true.
  
       if (.not.ifproj) then


### PR DESCRIPTION
The modification fixes the fact that velocity projection is always being turned on when using PnPn-2. Projection is turned on only if variable `residualProj=yes` in .par file, irrespectively of the value of param(94).