### PR TITLE
Support for HEX20/QUAD8 elements

### DIFF
--- a/tools/exo2nek/README.md
+++ b/tools/exo2nek/README.md
@@ -1,11 +1,11 @@
-Reads a exodus II (.exo) file and generates a .re2 file containing the grid,
-curved sides and sideset ids. 
+Reads an exodus II (.exo) file and generates a .re2 file containing the grid,
+curved sides and sideset IDs. 
 
-   - Requires the 3rd-party Exodus library (and NetCDF with modifications see below) 
-   - So far tested with Cubit, but any other package exporting exodusII should work, too
-   - Supported are HEX27 (3D) and QUAD9 (2D)
-   - For 2d meshes use z=0
-   - Sideset ids are stored in the 5th argument of the fluid bc array
-   - The "real" BC's have to be specified in the .usr file using the sideset ids 
+   - Requires the 3rd-party Exodus library (and NetCDF with the suggested modifications by Exodus) 
+   - Supported element types are HEX20 (3D) and QUAD8 (2D)
+   - HEX27/QUAD9 elements may also work but this is not guaranteed, since there is no standard for this element type in the Exodus library.
+   - 2D meshes must be constructed on the z=0 plane
+   - Sideset IDs are stored in the 5th argument of the fluid bc array
+   - The "real" BC's have to be specified in the .usr file using the sideset IDs 
    - Periodic BC's are not supported yet
    - Conjugate heat transfer (v and t-mesh) is not supported

--- a/tools/exo2nek/SIZE
+++ b/tools/exo2nek/SIZE
@@ -23,7 +23,7 @@ c
       integer side_list          (2*ldim*max_num_elem, max_num_sidesets)
       integer num_sides_in_set   (max_num_sidesets)
       integer idss               (max_num_sidesets)
-      integer num_dim, num_elem, num_elem_blk, num_side_sets
+      integer num_dim, num_elem, num_elem_blk, num_side_sets, nvert
 c
 c
 c NEK CORE variables:
@@ -56,6 +56,6 @@ c
       common /INPUT3/ num_dim,           num_elem,         num_elem_blk,
      &                num_side_sets,     num_sides_in_set, idss,
      &                elem_list,         side_list,        connect,
-     &                num_elem_in_block
+     &                num_elem_in_block, nvert
 
       common /INPUT4/ cbc, ccurve, exoname, re2name

--- a/tools/exo2nek/exo2nek.f
+++ b/tools/exo2nek/exo2nek.f
@@ -122,18 +122,56 @@ c
      &              "num_nodes_per_elem = ", i8)')
      &              idblk(i), typ, num_elem_in_block(i),
      &              num_nodes_per_elem(i)
-        if (num_dim.eq.3.and.num_nodes_per_elem(i).ne.27) then
-          write(6,'(a)')
-     &     "ERROR: Only HEX27 elements are allowed in a 3D mesh!"
-          write(6,'(a,i3)') "num_nodes_per_elem= ",num_nodes_per_elem(i)
+
+        if (i.eq.1) then
+          nvert=num_nodes_per_elem(i)
+          if (num_dim.eq.2) then
+            if (nvert.ne.8) then
+              if (nvert.eq.9) then
+                write(6,*)
+                write(6,'(a)')
+     &          "WARNING: QUAD9 elements are not officially supported"
+                write(6,'(a)')
+     &          "as there is no exodus standard for this element type."
+                write(6,*)
+              else
+                write(6,*)
+                write(6,'(a)')
+     &          "ERROR: Only QUAD8 elements are allowed in a 2D mesh!"
+                STOP
+              endif
+            endif      
+          elseif (num_dim.eq.3) then
+            if (nvert.ne.20) then
+              if (nvert.eq.27) then
+                write(6,*)
+                write(6,'(a)')
+     &          "WARNING: HEX27 elements are not officially supported"
+                write(6,'(a)')
+     &          "as there is no exodus standard for this element type."
+                write(6,*)
+              else
+                write(6,*)
+                write(6,'(a)')
+     &          "ERROR: Only HEX20 elements are allowed in a 3D mesh!"
+                STOP
+              endif
+            endif      
+          else
+          write(6,'(a,i3)')  
+     &     "ERROR: Unknown number of dimensions! num_dim= ",num_dim
           STOP
-        elseif (num_dim.eq.2.and.num_nodes_per_elem(i).ne.9) then
-          write(6,'(a)')
-     &      "ERROR: Only QUAD9 elements are allowed in a 2D mesh!"
+          endif
+        endif
+
+        if (num_nodes_per_elem(i).ne.nvert) then
+          write(6,*)
+          write(6,'(a)') 
+     &     "ERROR: All blocks should contain elements of the same type!"
           write(6,'(a,i3)') "num_nodes_per_elem= ",num_nodes_per_elem(i)
+          write(6,'(a,i3)') "num_nodes_per_elem of block 1 ",nvert
           STOP
         endif
-        write (6,*)
       enddo
 c
 c read nodal coordinates values from database
@@ -243,8 +281,6 @@ c node and face conversion (it works at least for cubit):
 
       integer exo_to_nek_face2D(4)
       data    exo_to_nek_face2D  / 1, 2, 3, 4 /          ! symmetric face numbering
-
-      nvert = 3**num_dim
 
       write(6,'(A)') ' '
       write(6,'(A)') 'Converting elements ... '


### PR DESCRIPTION
This update sets HEX20 and QUAD8 the default element types for exo2nek to make it compliant with the ExodusII standard and in accordance to the current .re2 file capabilities. HEX27 and QUAD9 are still supported to maintain backward compatibility (a warning is issued).