### PR TITLE
Set nmxh to 1000 when setting IC with presolve solution

### DIFF
--- a/core/ic.f
+++ b/core/ic.f
@@ -1654,6 +1654,9 @@ C
 C
       CALL SETPROP
       CALL SETSOLV
+
+      mmxh = nmxh
+      nmxh = 1000
 C
       IF (NIO.EQ.0) WRITE (6,*) 'Steady Stokes problem'
       DO 100 IGEOM=1,2
@@ -1663,6 +1666,7 @@ C
 C     Set IFTRAN to true again
 C     Turn convection on again
 C
+      nmxh = mmxh
       IFTRAN = IFSAV1
       IFADVC(IFIELD) = IFSAV2
 C


### PR DESCRIPTION
nmxh is set to 100 or 1000 depending on iftran; but for the presolve option, it should be set to 1000 to be consistent with the behavior when iftran is false.