### PR TITLE
quick fix  to ms_glsc2 declaration in PARALLEL

### DIFF
--- a/core/PARALLEL
+++ b/core/PARALLEL
@@ -48,6 +48,3 @@ c     Maximum number of elements (limited to 2**31/12, at least for now)
 
       integer               nsessions
       common /session_info/ nsessions
-
-      real ms_glmin,ms_glmax,ms_glamin,ms_glamax,ms_glsum,ms_glsc3
-     $     ,ms_glsc2

--- a/core/PARALLEL
+++ b/core/PARALLEL
@@ -50,4 +50,4 @@ c     Maximum number of elements (limited to 2**31/12, at least for now)
       common /session_info/ nsessions
 
       real ms_glmin,ms_glmax,ms_glamin,ms_glamax,ms_glsum,ms_glsc3
-     $     ms_glsc2
+     $     ,ms_glsc2

--- a/core/SIZE.inc
+++ b/core/SIZE.inc
@@ -111,3 +111,6 @@ c - - SIZE internals
      $ ,nx1,ny1,nz1,nx2,ny2,nz2,nx3,ny3,nz3,nxd,nyd,nzd,ndim,ldimr
       common/dimn/  nelv,nelt,nfield,npert,nid,idsess
      $ ,nx1,ny1,nz1,nx2,ny2,nz2,nx3,ny3,nz3,nxd,nyd,nzd,ndim,ldimr
+
+      real ms_glmin,ms_glmax,ms_glamin,ms_glamax,ms_glsum,ms_glsc3,
+     $     ms_glsc2


### PR DESCRIPTION
just a quick fix in PARALLEL.. don't need to change function declaration in math.f because each function includes PARALLEL through TOTAL.