### PR TITLE
Adjusting to a change of variables names in makenek

### DIFF
--- a/short_tests/README.md
+++ b/short_tests/README.md
@@ -9,7 +9,7 @@ Python 2.7 or higher.
 
 Before running the tests, several environment variables may be optionally defined.
 
-* `SOURCE_ROOT`: Points to the top-level Nek5000 repository (default: this repository).
+* `NEK_SOURCE_ROOT`: Points to the top-level Nek5000 repository (default: this repository).
 * `FC`: The Fortran 77 compiler (default mpif77).
 * `CC`: The C compiler (default: mpicc).
 * `PPLIST`: List of pre-processor symbols (default: none)

--- a/short_tests/lib/nekBinBuild.py
+++ b/short_tests/lib/nekBinBuild.py
@@ -46,7 +46,7 @@ def build_nek(source_root, usr_file, cwd=None, opts=None, verbose=False):
         _opts = {}
     else:
         _opts = opts.copy()
-    _opts.update(SOURCE_ROOT=source_root)
+    _opts.update(NEK_SOURCE_ROOT=source_root)
 
     print('Compiling nek5000...')
     print('    Using source directory "{0}"'.format(source_root))
@@ -56,7 +56,7 @@ def build_nek(source_root, usr_file, cwd=None, opts=None, verbose=False):
         print('    Using {0}="{1}"'.format(key, val))
 
     my_env = os.environ.copy()
-    if source_root      : my_env["SOURCE_ROOT"] = source_root
+    if source_root      : my_env["NEK_SOURCE_ROOT"] = source_root
     if _opts.get('F77')   : my_env["FC"] = _opts.get('F77') 
     if _opts.get('CC')    : my_env["CC"] = _opts.get('CC')
     if _opts.get('PPLIST') : my_env["PPLIST"] = _opts.get('PPLIST') 

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -79,7 +79,7 @@ class NekTestCase(unittest.TestCase):
         f77 (str):            The Fortran 77 compiler to use     [default: 'gfortran']
         cc (str):             The C compiler to use              [default: 'gcc']
         ifmpi (bool):         Perform compilation/tests with MPI [default: False]
-        source_root (str):    Path to Nek source directory;overridden by $SOURCE_ROOT env variable
+        source_root (str):    Path to Nek source directory;overridden by $NEK_SOURCE_ROOT env variable
                               [default: '$HOME/nek5_svn/trunk/nek']
         tools_root (str):     Path to Nek tools directory; overridden by $TOOLS_ROOT env variable
                               [default: '$HOME/nek5_svn/trunk/tools']
@@ -182,7 +182,7 @@ class NekTestCase(unittest.TestCase):
 
         # Get paths from env
         try:
-            self.source_root = os.path.abspath(os.environ['SOURCE_ROOT'])
+            self.source_root = os.path.abspath(os.environ['NEK_SOURCE_ROOT'])
         except KeyError:
             pass
         else:
@@ -209,7 +209,7 @@ class NekTestCase(unittest.TestCase):
                 ('PPLIST', self.pplist),
                 ('USR_LFLAGS', self.usr_lflags),
                 ('IFMPI', self.ifmpi),
-                ('SOURCE_ROOT', self.source_root),
+                ('NEK_SOURCE_ROOT', self.source_root),
                 ('EXAMPLES_ROOT', self.examples_root),
                 ('LOG_ROOT', self.log_root),
                 ('TOOLS_ROOT', self.tools_root),
@@ -222,7 +222,7 @@ class NekTestCase(unittest.TestCase):
 
         # Verify that pathnames are valid
         for varname, varval in (
-                ('SOURCE_ROOT', self.source_root),
+                ('NEK_SOURCE_ROOT', self.source_root),
                 ('EXAMPLES_ROOT', self.examples_root),
                 ('LOG_ROOT', self.log_root),
                 ('TOOLS_ROOT', self.tools_root),


### PR DESCRIPTION
Different variable names in makenek and jenkins script caused failures of all the tests