### PR TITLE
bugfix:makefile

### DIFF
--- a/tools/makefile
+++ b/tools/makefile
@@ -17,7 +17,7 @@ all:
           export CFLAGS+=" ${BIGMEM}" ;          \
           if [ "$$i" == "exo2nek" ]; then        \
              export FFLAGS+=" ${R8}" ;           \
-             if [ ! -z $(DOALL) ]; then          \
+             if [ ${DOALL} -ne 1 ]; then          \
                 continue;                        \
              fi ;                                \
           fi ;                                   \


### PR DESCRIPTION
When using maketool all, the original makefile cannot compile exo2nek, so make changes to it.