### PR TITLE
Fix bug in makeq_aux

### DIFF
--- a/core/makeq_aux.f
+++ b/core/makeq_aux.f
@@ -12,7 +12,7 @@
 
       if (ifdp0dt .and.  ifield.eq.2 .and. .not.ifcvfld(ifield)) then
             dd = dp0thdt * (gamma0 - 1.)/gamma0
-            ntot = nxyz*nelv
+            ntot = nx1*ny1*nz1*nelv
             call add2s2 (bq(1,1,1,1,ifield-1),bm1,dd,ntot) 
       endif
 


### PR DESCRIPTION
When dp0dt=.true. and we solve for T using Helmholtz, the dp0dt term was not added correctly since nxyz was not defined.