### PR TITLE
Fix IO issue when alphad < 0

### DIFF
--- a/core/navier4.f
+++ b/core/navier4.f
@@ -253,7 +253,8 @@ C
 C    .Normalize new element in P~
 C
       if (ALPHAd.le.0.0) then
-         write(6,*) 'ERROR:  alphad .le. 0 in econj',alphad,Kprev
+         if (nio.eq.0)
+     $   write(6,*) 'ERROR:  alphad .le. 0 in econj',alphad,Kprev
          ierr = 1
          return
       endif


### PR DESCRIPTION
Fixes the issue of all the mpi ranks writing to disk when alphad < 0.