### PR TITLE
PR to address issue #649 - max GLL spacing broken for 2D

### DIFF
--- a/core/genxyz.f
+++ b/core/genxyz.f
@@ -1626,12 +1626,12 @@ c-----------------------------------------------------------------------
             dx = xm1(i+1,j,1,e) - xm1(i,j,1,e)
             dy = ym1(i+1,j,1,e) - ym1(i,j,1,e)
             d2 = dx*dx + dy*dy
-            d2m = min(d2m,d2)
+            d2m = max(d2m,d2)
 
             dx = xm1(i,j+1,1,e) - xm1(i,j,1,e)
             dy = ym1(i,j+1,1,e) - ym1(i,j,1,e)
             d2 = dx*dx + dy*dy
-            d2m = min(d2m,d2)
+            d2m = max(d2m,d2)
          enddo
          enddo
       endif


### PR DESCRIPTION
This PR should resolve #649 by replacing the min function with max function as desired in the PR. 

I tested it was baseline Nek5000 for the eddy_uv NekExample:
GLL grid spacing min/max    : 2.52E-02-1.00E+00

After changing the min to max function for eddy_uv NekExample:
GLL grid spacing min/max    : 2.52E-02 8.22E-02

I didn't test further, but not sure what y'all would like to see.