### PR TITLE
Update gencon.f for a E120M mesh

### DIFF
--- a/tools/gencon/gencon.f
+++ b/tools/gencon/gencon.f
@@ -205,7 +205,8 @@ c
       real dx(1)
       real x(8),y(8),z(8)
       integer e,buf(50)
-
+      integer*8 l
+      
       integer h2s(8) ! hypercube to strange ordering
       save    h2s
       data    h2s / 1,2,4,3,5,6,8,7 /


### PR DESCRIPTION
After adding this line (from genmap), I can generate co2 for a E120M mesh. 

https://github.com/Nek5000/Nek5000/blob/43a7a8142004c85fdca073aae444ff487c1dafa5/tools/genmap/genmap.f#L358