### PR TITLE
Update MPI_Type_extent dummy with MPI_Type_get_extent dummy

### DIFF
--- a/core/mpi_dummy.f
+++ b/core/mpi_dummy.f
@@ -1109,10 +1109,11 @@ c
       return
       end
 c-----------------------------------------------------------------------
-      subroutine mpi_type_extent(ikey,isize,ierr)
+      subroutine mpi_type_get_extent(ikey,lb,isize,ierr)
 
       include "mpi_dummy.h"
 
+      lb = 0
       if (ikey.eq.MPI_DOUBLE_PRECISION) isize = 8 
       if (ikey.eq.MPI_INTEGER)  isize = 4 
       if (ikey.eq.MPI_INTEGER8) isize = 8 

--- a/core/mpi_dummy.f
+++ b/core/mpi_dummy.f
@@ -1109,6 +1109,19 @@ c
       return
       end
 c-----------------------------------------------------------------------
+      subroutine mpi_type_extent(ikey,isize,ierr)
+
+      include "mpi_dummy.h"
+
+      if (ikey.eq.MPI_DOUBLE_PRECISION) isize = 8 
+      if (ikey.eq.MPI_INTEGER)  isize = 4 
+      if (ikey.eq.MPI_INTEGER8) isize = 8 
+
+      ierr = 0
+
+      return
+      end
+c-----------------------------------------------------------------------
       subroutine mpi_type_get_extent(ikey,lb,isize,ierr)
 
       include "mpi_dummy.h"


### PR DESCRIPTION
The libCEED CI pipeline is failing, and I think its because d7b18dd3a64674acac751fd68841ba1456b36e77 didn't update `mpi_dummy.f`.

See: https://travis-ci.com/github/CEED/libCEED/jobs/351063664

Not sure if `0` is a reasonable lower bound dummy value, but `lb` does not seem to be used at this time?