### PR TITLE
[WIP] Separate MHD pressure solver from MHD

### DIFF
--- a/core/fast3d.f
+++ b/core/fast3d.f
@@ -850,6 +850,9 @@ c     ibc = 2  <==>  Neumann,
          if (cbc(ied,e,ifield).eq.'s  ') ibc = 2
          if (cbc(ied,e,ifield).eq.'J  ') ibc = 0
          if (cbc(ied,e,ifield).eq.'SP ') ibc = 0
+         if (cbc(ied,e,ifield).eq.'t  ') ibc = 2
+         if (cbc(ied,e,ifield).eq.'T  ') ibc = 2
+         if (cbc(ied,e,ifield).eq.'I  ') ibc = 1
 
          fbc(iface) = ibc
 
@@ -1639,10 +1642,9 @@ c
       ied = eface(face)	! symmetric -> preprocessor notation
       nfc = face+1
       nfc = nfc/2	! = 1,2,3 for face 1 & 2,3 & 4,5 & 6
+      if (indx2(cbc(ied,e,ifield),3,'d',1).gt.0)   ibc=2
 
-      if (indx1(cbc(ied,e,ifield),'d',1).gt.0)   ibc=2
-
-      if (indx1(cbc(ied,e,ifield),'n',1).gt.nfc) ibc=1 ! 'n' for V_n
+      if (indx2(cbc(ied,e,ifield),3,'n',1).gt.nfc) ibc=1 ! 'n' for V_n
 
       return
       end

--- a/core/hsmg.f
+++ b/core/hsmg.f
@@ -1880,6 +1880,8 @@ c     if_hybrid = .true.    ! Control this from gmres, according
 c     if_hybrid = .false.   ! to convergence efficiency
 
       nel   = nelfld(ifield)
+      mg_fld = 1
+      if (ifield.gt.1) mg_fld = 2
 
       op    =  1.                                     ! Coefficients for h1mg_ax
       om    = -1.
@@ -2243,6 +2245,8 @@ c----------------------------------------------------------------------
       integer p_h1,p_h2,p_g,p_b,p_msk
 
 
+      mg_fld = 1
+      if (ifield.gt.1) mg_fld = 2
       param(59) = 1
       call geom_reset(1)  ! Recompute g1m1 etc. with deformed only
 

--- a/core/induct.f
+++ b/core/induct.f
@@ -1106,6 +1106,8 @@ c     include 'TSTEP'   ! ifield?
          cb = cbc(ifc,iel,ifield)
          if  (cb.eq.'ndd' .or. cb.eq.'dnd' .or. cb.eq.'ddn')
      $           ifbcor = .false.
+         if  (cb.eq.'O  ' .or. cb.eq.'o  ')
+     $           ifbcor = .false.
       enddo
       enddo
 

--- a/core/navier8.f
+++ b/core/navier8.f
@@ -166,7 +166,9 @@ c     ifield=1			!c? avo: set in set_overlap through 'TSTEP'?
          do iface=1,nfaces
             cb=cbc(iface,ie,ifield)
             if (cb.eq.'ndd'  .or.  cb.eq.'dnd'  .or.  cb.eq.'ddn')
-     $          call facev(mask,ie,iface,z,nxc,nxc,nzc)
+     $           call facev(mask,ie,iface,z,nxc,nxc,nzc)
+            if (cb.eq.'O  '  .or.  cb.eq.'o ')
+     $           call facev(mask,ie,iface,z,nxc,nxc,nzc) ! 'S* ' & 's* ' ?avo?
          enddo
          enddo
       endif
@@ -225,6 +227,7 @@ c      endif
       t0 = dnekclock()-t0
       if (nio.eq.0) then
          write(6,*) 'done :: setup h1 coarse grid ',t0, ' sec'
+     $            ,  ifield,xxth(ifield)
          write(6,*) ' '
       endif
 


### PR DESCRIPTION
This allow user to solve Poisson via semg-gmres with the crs solve stored in ifield=ifldmhd.
So, users can run Fluid solver + an additional Poisson solver.

- Support 'O' BC
- pass mask to hmh_gmres, so bpmask can be active