### PR TITLE
Set nxmp and nxmt to nxmv for steady-state case

### DIFF
--- a/core/drive2.f
+++ b/core/drive2.f
@@ -190,9 +190,9 @@ C
       NMXV   = 1000
       if (iftran) NMXV = 200
       NMXH   =  NMXV ! not used anymore
-      NMXP   = 200
+      NMXP   = NMXV
       do ifield = 2,ldimt+1
-         NMXT(ifield-1) = 200 
+         NMXT(ifield-1) = NMXV
       enddo 
       NMXE   = 100
       NMXNL  = 10 


### PR DESCRIPTION
nxmp and nxmt are always 200, but some steady-state solutions do not converge in 200 iterations.