### PR TITLE
makenek resolves compiler aliases and symlinks

### DIFF
--- a/core/makenek.inc
+++ b/core/makenek.inc
@@ -209,6 +209,10 @@ fi
 \rm -f .tmp
 if [ $FCok -eq 0 ]; then
   FCcomp="unknown"
+else
+  # Resolve aliases and symlinks
+  FCcomp="`which $FCcomp`"
+  FCcomp="`realpath -e $FCcomp`"
 fi
 
 # assign FC compiler specific flags

--- a/tools/maketools.inc
+++ b/tools/maketools.inc
@@ -80,6 +80,10 @@ fi
 \rm -f .tmp
 if [ $FCok -eq 0 ]; then
   FCcomp="unknown"
+else
+  # Resolve aliases and symlinks
+  FCcomp="`which $FCcomp`"
+  FCcomp="`realpath -e $FCcomp`"
 fi
 
 PPPO=""


### PR DESCRIPTION
With these updates, makenek will resolve the aliases and symlinks of the Fortran compiler to discover the true executable.  

This update is necessitated by the mpich APT packages in the latest version of Ubuntu.  Apparantly, `mpif77` uses `f95` which, after resolving the aliases and symlinks, is in fact gfortran.  
```
$ /usr/bin/mpif77.mpich -show
f95 -Wl,-Bsymbolic-functions -Wl,-z,relro -I/usr/include/x86_64-linux-gnu/mpich -I/usr/include/x86_64-linux-gnu/mpich -L/usr/lib/x86_64-linux-gnu -lmpichfort -lmpich
$ which f95
/usr/bin/f95
$ realpath -e /usr/bin/f95
/usr/bin/x86_64-linux-gnu-gfortran-9
```

makenek doesn't recognize the vendor for `f95`, but resolving the aliases and symlinks allows makenek to proceed.  
