### PR TITLE
Removed velocity projection form vol_flow

### DIFF
--- a/core/drive2.f
+++ b/core/drive2.f
@@ -1548,7 +1548,7 @@ C
 c
       intype = -1
       call sethlm   (h1,h2,intype)
-      call ophinv   (vxc,vyc,vzc,resv1,resv2,resv3,h1,h2,tolhv,nmxv)
+      call ophinv_nopr (vxc,vyc,vzc,resv1,resv2,resv3,h1,h2,tolhv,nmxv)
 C
       return
       end
@@ -1601,7 +1601,7 @@ c
       endif
       intype = -1
       call sethlm   (h1,h2,intype)
-      call ophinv   (vxc,vyc,vzc,rw1,rw2,rw3,h1,h2,tolhv,nmxv)
+      call ophinv_nopr (vxc,vyc,vzc,rw1,rw2,rw3,h1,h2,tolhv,nmxv)
       call ssnormd  (vxc,vyc,vzc)
 c
 c     Compute pressure  (from "incompr")
@@ -1689,7 +1689,7 @@ C     Compute velocity
 
       intype = -1
       call sethlm   (h1,h2,intype)
-      call ophinv   (vxc,vyc,vzc,resv1,resv2,resv3,h1,h2,tolhv,nmxv)
+      call ophinv_nopr (vxc,vyc,vzc,resv1,resv2,resv3,h1,h2,tolhv,nmxv)
 
       if (ifexplvis) call redo_split_vis ! restore vdiff
 

--- a/core/induct.f
+++ b/core/induct.f
@@ -1088,6 +1088,67 @@ C
       return
       end
 c--------------------------------------------------------------------
+c     ophinv version without projection; required by vol_flow
+      subroutine ophinv_nopr (out1,out2,out3,inp1,inp2,inp3,h1,h2,
+     $                                                     tolh,nmxi)
+
+c     OUT = (H1*A+H2*B)-1 * INP  (implicit)
+
+      include 'SIZE'
+      include 'INPUT'
+      include 'SOLN'
+      include 'TSTEP'
+
+      real out1(1),out2(1),out3(1),inp1(1),inp2(1),inp3(1),h1(1),h2(1)
+
+      imesh = 1
+
+
+      if (ifstrs) then
+         matmod = 0
+         if (ifield.eq.ifldmhd) then
+            call hmhzsf  ('NOMG',out1,out2,out3,inp1,inp2,inp3,h1,h2,
+     $                     b1mask,b2mask,b3mask,vmult,
+     $                     tolh,nmxi,matmod)
+         else
+            call hmhzsf  ('NOMG',out1,out2,out3,inp1,inp2,inp3,h1,h2,
+     $                     v1mask,v2mask,v3mask,vmult,
+     $                     tolh,nmxi,matmod)
+         endif
+      elseif (ifcyclic) then
+         matmod = 0
+         if (ifield.eq.ifldmhd) then
+            call hmhzsf  ('BXYZ',out1,out2,out3,inp1,inp2,inp3,h1,h2,
+     $                     b1mask,b2mask,b3mask,vmult,
+     $                     tolh,nmxi,matmod)
+         else
+            call hmhzsf  ('VXYZ',out1,out2,out3,inp1,inp2,inp3,h1,h2,
+     $                     v1mask,v2mask,v3mask,vmult,
+     $                     tolh,nmxi,matmod)
+         endif
+      else
+         if (ifield.eq.ifldmhd) then
+            call hmholtz ('BX  ',out1,inp1,h1,h2,b1mask,vmult,
+     $                                      imesh,tolh,nmxi,1)
+            call hmholtz ('BY  ',out2,inp2,h1,h2,b2mask,vmult,
+     $                                      imesh,tolh,nmxi,2)
+            if (ldim.eq.3)
+     $      call hmholtz ('BZ  ',out3,inp3,h1,h2,b3mask,vmult,
+     $                                      imesh,tolh,nmxi,3)
+         else
+            call hmholtz ('VELX',out1,inp1,h1,h2,v1mask,vmult,
+     $                                      imesh,tolh,nmxi,1)
+            call hmholtz ('VELY',out2,inp2,h1,h2,v2mask,vmult,
+     $                                      imesh,tolh,nmxi,2)
+            if (ldim.eq.3)
+     $      call hmholtz ('VELZ',out3,inp3,h1,h2,v3mask,vmult,
+     $                                      imesh,tolh,nmxi,3)
+         endif
+      endif
+C
+      return
+      end
+c--------------------------------------------------------------------
       subroutine set_ifbcor
       include 'SIZE'
       include 'GEOM'

--- a/core/multimesh.f
+++ b/core/multimesh.f
@@ -900,7 +900,7 @@ c
         if (ictr.eq.1) then
           intype = -1
           call sethlm   (h1,h2,intype)
-          call ophinv   (vxc,vyc,vzc,rw1,rw2,rw3,h1,h2,tolhv,nmxh)
+          call ophinv_nopr (vxc,vyc,vzc,rw1,rw2,rw3,h1,h2,tolhv,nmxh)
           call ssnormd  (vxc,vyc,vzc)
         else
           intype = -1
@@ -919,7 +919,7 @@ c
           call sub2(rw1,resbc(1,1),ntot1)
           call sub2(rw2,resbc(1,2),ntot1)
           if (ldim.eq.3) call sub2(rw3,resbc(1,3),ntot1)
-          call ophinv   (vxc,vyc,vzc,rw1,rw2,rw3,h1,h2,tolhv,nmxh)
+          call ophinv_nopr (vxc,vyc,vzc,rw1,rw2,rw3,h1,h2,tolhv,nmxh)
           call opadd2(vxc,vyc,vzc,vxcbc,vycbc,vzcbc)
           call ssnormd  (vxc,vyc,vzc)
         endif
@@ -1099,7 +1099,7 @@ ccccc
         call sub2(resv1,resbc(1,1),n)
         call sub2(resv2,resbc(1,2),n)
         if (ldim.eq.3) call sub2(resv3,resbc(1,3),n)
-        call ophinv   (vxc,vyc,vzc,resv1,resv2,resv3,h1,h2,tolhv,nmxh)
+        call ophinv_nopr(vxc,vyc,vzc,resv1,resv2,resv3,h1,h2,tolhv,nmxh)
         call opadd2(vxc,vyc,vzc,vxcbc,vycbc,vzcbc)
 
         call sub3(dvxc,vxcp,vxc,n)


### PR DESCRIPTION
In v17 there were two versions of ophinv routine with and without a velocity projection. The second one was removed in v19, however this causes a problem in vol_flow calculations. It is not visible with constant dt, as a volume flow calculation is executed only once, but with a variable time step vol_flow is recalculated each time dt changes giving scary looking NaN in a log. This is caused by an attempt to enlarge projection space for inconsistent operator. Although this vector is rejected, the log is full of the error messages. This commit adds ophinv without projections for vol_flow only. Neknek version (multimesh.f) is not tested.