### PR TITLE
Fix inconsitent data type for allreduce in printPartStat

### DIFF
--- a/core/partitioner.c
+++ b/core/partitioner.c
@@ -177,6 +177,7 @@ void printPartStat(long long *vtx, int nel, int nv, comm_ext ce)
 
   struct gs_data *gsh;
   int b;
+  long long b_long_long;
 
   int numPoints;
   long long *data;
@@ -223,7 +224,7 @@ void printPartStat(long long *vtx, int nel, int nv, comm_ext ce)
   nssSum = nsSum;
   comm_allreduce(&comm, gs_int, gs_max, &nssMax , 1, &b);
   comm_allreduce(&comm, gs_int, gs_min, &nssMin , 1, &b);
-  comm_allreduce(&comm, gs_long, gs_add, &nssSum , 1, &b);
+  comm_allreduce(&comm, gs_long_long, gs_add, &nssSum , 1, &b_long_long);
 
   nsSum = nsSum/Nmsg;
   comm_allreduce(&comm, gs_int, gs_add, &nsSum , 1, &b);


### PR DESCRIPTION
With `nssSum` changing types from `int` to `long long`, `gs_int` should technically have been changed to `gs_long_long` and `int b` needs to be replaced by an appropriate type. Before this PR, if you use MPICH configured with `HAVE_ERROR_CHECKING`, running any of the Nek5000 examples would give an error like this:

> Assertion failed in file src/mpi/misc/utils.c at line 55: FALSE
memcpy argument memory ranges overlap, dst_=0x7ffd5bd515ec src_=0x7ffd5bd515f0 len_=8

This PR fixes the cause of this error. Let me know if there is more to this fix than this PR - I don't think there should be, however, since a git bisect pointed to `13af156f4d776b7cc0f80ffe711da768cfffc9e1` as the culprit, which is quite a small commit.

Thanks @RonRahaman for the help in identifying this! 