### PR TITLE
Patches for seacas-exodus build script

### DIFF
--- a/tools/exo2nek/3rd_party/install
+++ b/tools/exo2nek/3rd_party/install
@@ -54,6 +54,8 @@ if [ ! -f ./seacas-exodus/build/packages/seacas/libraries/exodus/libexodus.a ] |
   cd seacas-exodus
   sed -e "s:^NETCDF_PATH=.*:NETCDF_PATH=${NETCDFPATH} \\\:" \
       -e "s:CC=.*: CC=${CC}:" \
+      -e 's:CMAKE_C_FLAGS=\(.*\)\\:CMAKE_C_FLAGS="\1" \\:' \
+      -e 's:CMAKE_CXX_FLAGS=\(.*\)\\:CMAKE_CXX_FLAGS="\1" \\:' \
       -e "s:FC=.*: FC=${FC}:" cmake-exodus > cmake-exo
   chmod 755 cmake-exo
   rm -rf build


### PR DESCRIPTION
This adds additional patches to the `cmake-exodus` script to fix some improperly-quoted variables.  In particular, this command in the `cmake-exodus` should have quotes around the values for `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS`:

```
cmake -G "${GENERATOR}" \
-D CMAKE_CXX_COMPILER:FILEPATH=${CXX} \
-D CMAKE_C_COMPILER:FILEPATH=${CC} \
-D CMAKE_Fortran_COMPILER:FILEPATH=${FC} \
-D CMAKE_CXX_FLAGS=${CXXFLAGS} ${SANITIZER} \
-D CMAKE_C_FLAGS=${CFLAGS} ${SANITIZER} \
-D CMAKE_INSTALL_RPATH:PATH=${INSTALL_PATH}/lib \
-D BUILD_SHARED_LIBS:BOOL=${SHARED} \
-D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
-D SEACASProj_ENABLE_SEACASExodus=ON \
-D SEACASProj_ENABLE_SEACASExodus_for=${FORTRAN} \
-D SEACASProj_ENABLE_SEACASExoIIv2for32=${FORTRAN} \
-D SEACASProj_ENABLE_TESTS=ON \
-D SEACASExodus_ENABLE_STATIC:BOOL=${STATIC} \
-D CMAKE_INSTALL_PREFIX:PATH=${INSTALL_PATH} \
-D SEACASProj_SKIP_FORTRANCINTERFACE_VERIFY_TEST:BOOL=ON \
-D SEACASProj_HIDE_DEPRECATED_CODE:BOOL=${OMIT_DEPRECATED_CODE} \
\
-D PythonInterp_FIND_VERSION:STRING=${PYTHON_VER} \
-D SEACASProj_ENABLE_Fortran=${FORTRAN} \
-D TPL_ENABLE_Netcdf:BOOL=${HAVE_NETCDF} \
-D TPL_ENABLE_MPI:BOOL=${MPI} \
-D TPL_ENABLE_Pthread:BOOL=${THREADSAFE} \
${THREAD_SAFE_OPT} \
-D SEACASExodus_ENABLE_THREADSAFE:BOOL=${THREADSAFE} \
\
${MPI_SYMBOLS} \
${DARWIN_OPT} \
\
-D MPI_BIN_DIR:PATH=${MPI_BIN} \
-D NetCDF_ROOT:PATH=${NETCDF_PATH} \
-D HDF5_ROOT:PATH=${HDF5_PATH} \
-D HDF5_NO_SYSTEM_PATHS=ON \
-D PNetCDF_ROOT:PATH=${PNETCDF_PATH} \
\
$EXTRA_ARGS \
${ACCESS}
```