### PR TITLE
Update PARDICT

### DIFF
--- a/core/PARDICT
+++ b/core/PARDICT
@@ -4,7 +4,7 @@ c     Note: Keys have to be in captial letters
 c
       integer PARDICT_NKEYS
 
-      parameter(PARDICT_NKEYS = 103)
+      parameter(PARDICT_NKEYS = 104)
 
       character*132 pardictkey(PARDICT_NKEYS)
       data
@@ -108,3 +108,4 @@ c
      &  pardictkey(101)/ 'PRESSURE:SOLVER' /
      &  pardictkey(102)/ 'MESH:PARTITIONER' /
      &  pardictkey(103)/ 'MESH:CONNECTIVITYTOL' /
+     &  pardictkey(104)/ 'SCALAR%%:ADVECTION' /     


### PR DESCRIPTION
ADVECTION key was missing for scalars, so that advection could not be turned off/on when using .par file instead of .rea file.