### PR TITLE
Write PARALLEL and mpif.h in CASEDIR

### DIFF
--- a/core/makefile.template
+++ b/core/makefile.template
@@ -75,10 +75,10 @@ else
    filters_cmt.o diagnostics.o artvisc.o
 endif
 
-DUMMY:= $(shell cp $S/PARALLEL.default $S/PARALLEL)
+DUMMY:= $(shell cp $S/PARALLEL.default $(CASEDIR)/PARALLEL)
 ifeq ($(DPROCMAP),1)
 	CORE := ${CORE} dprocmap.o
- 	DUMMY:= $(shell cp $S/PARALLEL.dprocmap $S/PARALLEL)
+ 	DUMMY:= $(shell cp $S/PARALLEL.dprocmap $(CASEDIR)/PARALLEL)
 endif
 
 ifneq ($(VISIT),0)
@@ -88,9 +88,9 @@ ifneq ($(VISIT),0)
 endif
 
 ifeq ($(MPI),0)
-	DUMMY:= $(shell cp $S/mpi_dummy.h $S/mpif.h) 
+	DUMMY:= $(shell cp $S/mpi_dummy.h $(CASEDIR)/mpif.h) 
 else
-	DUMMY:= $(shell rm -rf $S/mpif.h) 
+	DUMMY:= $(shell rm -rf $(CASEDIR)/mpif.h) 
 endif
 
 TMP1 = $(CORE) $(MXM) $(USR) $(COMM_MPI) $(VISITO)


### PR DESCRIPTION
Writing into the core directory triggers a race conditions when multiple
compilations are launched simultaneously. These essential include files
would vanish during compilation. As a fix, instead of copying "in-place"
within the ``core`` directory, the files are copied to CASEDIR.

This is the simplest approach I could think of. See also: https://github.com/exabl/snek5000/pull/117 where we discovered this. Note that this is not related to snek5000 in any sense, and can happen if we simply execute `makenek` simultaneously multiple times from different directories.