### PR TITLE
Write PARALLEL and mpif.h in OBJDIR

### DIFF
--- a/core/makefile.template
+++ b/core/makefile.template
@@ -64,10 +64,10 @@ ifeq ($(MPI),0)
   COMM_MPI := ${COMM_MPI} mpi_dummy.o
 endif
 
-DUMMY:= $(shell cp $S/core/PARALLEL.default $S/core/PARALLEL 2>/dev/null)
+DUMMY:= $(shell cp $S/core/PARALLEL.default $(CASEDIR)/PARALLEL 2>/dev/null)
 ifeq ($(DPROCMAP),1)
 	CORE := ${CORE} dprocmap.o
- 	DUMMY:= $(shell cp $S/core/PARALLEL.dprocmap $S/core/PARALLEL 2>/dev/null)
+	DUMMY:= $(shell cp $S/core/PARALLEL.dprocmap $(CASEDIR)/PARALLEL 2>/dev/null)
 endif
 
 ifneq ($(VISIT),0)
@@ -77,9 +77,9 @@ ifneq ($(VISIT),0)
 endif
 
 ifeq ($(MPI),0)
-	DUMMY:= $(shell cp $S/core/mpi_dummy.h $S/core/mpif.h) 
+	DUMMY:= $(shell cp $S/core/mpi_dummy.h $(CASEDIR)/mpif.h)
 else
-	DUMMY:= $(shell rm -rf $S/core/mpif.h) 
+	DUMMY:= $(shell rm -rf $(CASEDIR)/mpif.h)
 endif
 
 TMP1 = $(CORE) $(MXM) $(USR) $(COMM_MPI) $(VISITO)

--- a/core/makefile.template
+++ b/core/makefile.template
@@ -64,10 +64,10 @@ ifeq ($(MPI),0)
   COMM_MPI := ${COMM_MPI} mpi_dummy.o
 endif
 
-DUMMY:= $(shell cp $S/core/PARALLEL.default $(CASEDIR)/PARALLEL 2>/dev/null)
+DUMMY:= $(shell cp $S/core/PARALLEL.default $(OBJDIR)/PARALLEL 2>/dev/null)
 ifeq ($(DPROCMAP),1)
 	CORE := ${CORE} dprocmap.o
-	DUMMY:= $(shell cp $S/core/PARALLEL.dprocmap $(CASEDIR)/PARALLEL 2>/dev/null)
+	DUMMY:= $(shell cp $S/core/PARALLEL.dprocmap $(OBJDIR)/PARALLEL 2>/dev/null)
 endif
 
 ifneq ($(VISIT),0)
@@ -77,9 +77,9 @@ ifneq ($(VISIT),0)
 endif
 
 ifeq ($(MPI),0)
-	DUMMY:= $(shell cp $S/core/mpi_dummy.h $(CASEDIR)/mpif.h)
+	DUMMY:= $(shell cp $S/core/mpi_dummy.h $(OBJDIR)/mpif.h)
 else
-	DUMMY:= $(shell rm -rf $(CASEDIR)/mpif.h)
+	DUMMY:= $(shell rm -f $(OBJDIR)/mpif.h)
 endif
 
 TMP1 = $(CORE) $(MXM) $(USR) $(COMM_MPI) $(VISITO)

--- a/core/makefile.template
+++ b/core/makefile.template
@@ -93,9 +93,9 @@ L0 = $(G) -O0
 L2 = $(G) -O2
 L3 = $(G) -O3
 
-FL0   = $(L0) $(FFLAGS) $(PPS_F) -I$(CASEDIR) -I$S/core -I$(OPT_INCDIR) 
-FL2   = $(L2) $(FFLAGS) $(PPS_F) -I$(CASEDIR) -I$S/core -I$(OPT_INCDIR)
-FL3   = $(L3) $(FFLAGS) $(PPS_F) -I$(CASEDIR) -I$S/core -I$(OPT_INCDIR)
+FL0   = $(L0) $(FFLAGS) $(PPS_F) -I$(CASEDIR) -I$(OBJDIR) -I$S/core -I$(OPT_INCDIR) 
+FL2   = $(L2) $(FFLAGS) $(PPS_F) -I$(CASEDIR) -I$(OBJDIR) -I$S/core -I$(OPT_INCDIR)
+FL3   = $(L3) $(FFLAGS) $(PPS_F) -I$(CASEDIR) -I$(OBJDIR) -I$S/core -I$(OPT_INCDIR)
 
 cFL0   = $(L0) $(CFLAGS) $(PPS_C) -I$S/core -I$(OPT_INCDIR)
 cFL2   = $(L2) $(CFLAGS) $(PPS_C) -I$S/core -I$(OPT_INCDIR)


### PR DESCRIPTION
Writing into the core directory triggers a race conditions when multiple compilations are launched simultaneously. These essential include files would vanish during compilation. As a fix, instead of copying "in-place" within the core directory, the files are copied to CASEDIR.

This is the simplest approach I could think of. See also: exabl/snek5000#117 where we discovered this. Note that this is not related to snek5000 in any sense, and can happen if we simply execute makenek simultaneously multiple times from different directories.