### PR TITLE
Add interpolation as a restart option

### DIFF
--- a/core/PARDICT
+++ b/core/PARDICT
@@ -4,7 +4,7 @@ c     Note: Keys have to be in captial letters
 c
       integer PARDICT_NKEYS
 
-      parameter(PARDICT_NKEYS = 103)
+      parameter(PARDICT_NKEYS = 104)
 
       character*132 pardictkey(PARDICT_NKEYS)
       data
@@ -108,3 +108,4 @@ c
      &  pardictkey(101)/ 'PRESSURE:SOLVER' /
      &  pardictkey(102)/ 'MESH:PARTITIONER' /
      &  pardictkey(103)/ 'MESH:CONNECTIVITYTOL' /
+     &  pardictkey(104)/ 'GENERAL:INTERPOLATEFROM' /

--- a/core/ic.f
+++ b/core/ic.f
@@ -115,6 +115,7 @@ C     If any pre-solv, do pre-solv for all temperatur/passive scalar fields
 
       call nekgsync()
       if(irstt.eq.1) call restart(nfiles) !  Check restart files
+      write(*,*) nid, irstt
       if(irstt.eq.2) call gfldr(initc(1)) ! use interpolation for restart
       call nekgsync()
 

--- a/core/ic.f
+++ b/core/ic.f
@@ -115,7 +115,6 @@ C     If any pre-solv, do pre-solv for all temperatur/passive scalar fields
 
       call nekgsync()
       if(irstt.eq.1) call restart(nfiles) !  Check restart files
-      write(*,*) nid, irstt
       if(irstt.eq.2) call gfldr(initc(1)) ! use interpolation for restart
       call nekgsync()
 

--- a/core/ic.f
+++ b/core/ic.f
@@ -114,7 +114,8 @@ C     If any pre-solv, do pre-solv for all temperatur/passive scalar fields
      
 
       call nekgsync()
-      call restart(nfiles) !  Check restart files
+      if(irstt.eq.1) call restart(nfiles) !  Check restart files
+      if(irstt.eq.2) call gfldr(initc(1)) ! use interpolation for restart
       call nekgsync()
 
 

--- a/core/reader_par.f
+++ b/core/reader_par.f
@@ -818,6 +818,13 @@ c set restart options
       do i = 1,min(ifnd,15)
          call finiparser_getToken(initc(i),i)
          if(index(initc(i),'0') .eq. 1) call blank(initc(i),132)
+         irstt=1
+      enddo
+      call finiparser_findTokens('general:interpolateFrom', ',' , ifnd)
+      do i = 1,min(ifnd,15)
+         call finiparser_getToken(initc(i),i)
+         if(index(initc(i),'0') .eq. 1) call blank(initc(i),132)
+         irstt=2
       enddo
 
 c set partitioner options

--- a/core/reader_par.f
+++ b/core/reader_par.f
@@ -918,6 +918,7 @@ C
       call bcast(ifto  , lsize)
       call bcast(ifpsco, ldimt1*lsize)
 
+      call bcast(irstt, isize)
       call bcast(initc, 15*132*csize) 
 
       call bcast(timeioe,sizeof(timeioe))


### PR DESCRIPTION
Adds a simple parameter for setics to call gfldr instead of restart.