### PR TITLE
Add 'int' restart option for interpolation

### DIFF
--- a/core/RESTART
+++ b/core/RESTART
@@ -31,10 +31,10 @@ c
 
       logical ifgetx ,ifgetu ,ifgetp ,ifgett ,ifgtps (ldimt1),ifgtim
      $       ,ifgetxr,ifgetur,ifgetpr,ifgettr,ifgtpsr(ldimt1),ifgtimr
-     $       ,if_byte_sw,ifgetz,ifgetw,ifdiro
+     $       ,if_byte_sw,ifgetz,ifgetw,ifdiro,ifgfldr
       common /cmfi_l/ ifgetx,ifgetu,ifgetp,ifgett,ifgtps,ifgtim
      $       ,ifgetxr,ifgetur,ifgetpr,ifgettr,ifgtpsr,ifgtimr
-     $       ,if_byte_sw,ifgetz,ifgetw,ifdiro
+     $       ,if_byte_sw,ifgetz,ifgetw,ifdiro,ifgfldr
 
       integer         fid0,fid0r,pid0,pid1,pid0r,pid1r,pid00
       common /cmfi_p/ fid0,fid0r,pid0,pid1,pid0r,pid1r,pid00 

--- a/core/gfldr.f
+++ b/core/gfldr.f
@@ -321,4 +321,11 @@ c-----------------------------------------------------------------------
       return
       end
 
+#else
+
+      subroutine gfldr(sourcefld)
+
+      character sourcefld*(*)
+
+      call exitti("MPIIO needed for gfldr!$",0)
 #endif

--- a/core/gfldr.f
+++ b/core/gfldr.f
@@ -320,12 +320,14 @@ c-----------------------------------------------------------------------
 
       return
       end
-
+c-----------------------------------------------------------------------
 #else
-
       subroutine gfldr(sourcefld)
 
       character sourcefld*(*)
 
       call exitti("MPIIO needed for gfldr!$",0)
+
+      return
+      end
 #endif

--- a/core/ic.f
+++ b/core/ic.f
@@ -493,7 +493,7 @@ c use new reader (only binary support)
          do ifile=1,nfiles
             call sioflag(ndumps,fname,initc(ifile))
             if(ifgfldr) then
-              call gfldr(initc(ifile))
+              call gfldr(fname)
             else
               call mfi(fname,ifile)
             endif
@@ -1046,7 +1046,7 @@ C        Parse field specifications.
          IGO=INDX_CUT(RSOPT,'I',1)
          IF (IGO.NE.0) THEN
             ifdeft=.false.
-            IFGFLD=.TRUE.
+            ifgfldr=.TRUE.
          ENDIF
 
          IXO=INDX_CUT(RSOPT,'X',1)

--- a/core/ic.f
+++ b/core/ic.f
@@ -1043,7 +1043,7 @@ C           remove the user specified time from the RS options line.
 
 C        Parse field specifications.
 
-         IGO=INDX_CUT(RSOPT,'I',1)
+         IGO=INDX_CUT(RSOPT,'INT',3)
          IF (IGO.NE.0) THEN
             ifdeft=.false.
             ifgfldr=.TRUE.

--- a/core/ic.f
+++ b/core/ic.f
@@ -492,7 +492,11 @@ c use new reader (only binary support)
       if (p67.eq.6.0) then
          do ifile=1,nfiles
             call sioflag(ndumps,fname,initc(ifile))
-            call mfi(fname,ifile)
+            if(ifgfldr) then
+              call gfldr(initc(ifile))
+            else
+              call mfi(fname,ifile)
+            endif
          enddo
          call bcast(time,wdsize)! Sync time across processors
          return
@@ -1002,6 +1006,7 @@ C
   100 continue
       ifgtim=.true.
       ndumps=0
+      ifgfldr=.false.
 C
 C     Check for default case - just a filename given, no i/o options specified
 C
@@ -1037,6 +1042,12 @@ C           remove the user specified time from the RS options line.
          ENDIF
 
 C        Parse field specifications.
+
+         IGO=INDX_CUT(RSOPT,'I',1)
+         IF (IGO.NE.0) THEN
+            ifdeft=.false.
+            IFGFLD=.TRUE.
+         ENDIF
 
          IXO=INDX_CUT(RSOPT,'X',1)
          IF (IXO.NE.0) THEN

--- a/core/ic.f
+++ b/core/ic.f
@@ -497,6 +497,7 @@ c use new reader (only binary support)
             else
               call mfi(fname,ifile)
             endif
+            ifgfldr=.false. !avoid interfering with future gfldr calls
          enddo
          call bcast(time,wdsize)! Sync time across processors
          return
@@ -1045,7 +1046,6 @@ C        Parse field specifications.
 
          IGO=INDX_CUT(RSOPT,'INT',3)
          IF (IGO.NE.0) THEN
-            ifdeft=.false.
             ifgfldr=.TRUE.
          ENDIF
 
@@ -1091,8 +1091,10 @@ C        Get number of dumps from remainder of user supplied line.
 
 C     If no fields were explicitly specified, assume getting all fields. 
       if (ifdeft) then
-         IFGETX=.TRUE.
-         IF (IF3D) IFGETZ=.TRUE.
+         if(.not.ifgfldr) then
+           IFGETX=.TRUE.
+           IF (IF3D) IFGETZ=.TRUE.
+         endif
          IFANYC=.FALSE.
          DO 400 I=1,NFIELD
             IF (IFADVC(I)) IFANYC=.TRUE.
@@ -1107,6 +1109,9 @@ C     If no fields were explicitly specified, assume getting all fields.
             ifgtps(i)=.TRUE.
   410    continue
       endif
+
+      if(ifgfldr.and.ifgetx) 
+     & call exitti('"X" and "INT" restart options incompatible!$',0)
 
       return
       END


### PR DESCRIPTION
calls gfldr for restart when using
`startFrom = case0.f00001 I` 

addresses #415 

currently only supported if param(67) = 6