### PR TITLE
Fix perturb

### DIFF
--- a/core/SOLN
+++ b/core/SOLN
@@ -114,6 +114,7 @@ c
      $     ,prp    (lpx2*lpy2*lpz2*lpelv,lpert)
      $     ,tp     (lpx1*lpy1*lpz1*lpelt,ldimt,lpert)
      $     ,bqp    (lpx1*lpy1*lpz1*lpelt,ldimt,lpert)
+     $     ,adqp   (lpx1*lpy1*lpz1*lpelt,ldimt,lpert)
      $     ,bfxp   (lpx1*lpy1*lpz1*lpelv,lpert)  ! perturbation field rhs
      $     ,bfyp   (lpx1*lpy1*lpz1*lpelv,lpert)
      $     ,bfzp   (lpx1*lpy1*lpz1*lpelv,lpert)
@@ -133,7 +134,7 @@ c
       common /pvptsl/ vxp, vyp, vzp, prp, tp, bqp, bfxp, bfyp, bfzp,
      $     vxlagp, vylagp, vzlagp, prlagp, tlagp,
      $     exx1p, exy1p, exz1p, exx2p, exy2p, exz2p,
-     $     vgradt1p, vgradt2p
+     $     vgradt1p, vgradt2p, adqp
 
       integer jp
       common /ppointr/ jp

--- a/core/perturb.f
+++ b/core/perturb.f
@@ -635,6 +635,7 @@ C
          CALL SETHLM  (H1,H2,INTYPE)
          CALL BCNEUSC (TA,-1)
          CALL ADD2    (H2,TA,NTOT)
+         call add2    (h2,adqp(1,ifield-1,jp),ntot)
          CALL BCDIRSC (TP(1,IFIELD-1,jp))
          CALL AXHELM  (TA,TP (1,IFIELD-1,jp),H1,H2,IMESH,1)
          CALL SUB3    (TB,BQP(1,IFIELD-1,jp),TA,NTOT)
@@ -699,7 +700,7 @@ C
       time = time-dt                           ! time is tn
 c
       call rzero   ( bqp(1,ifield-1,jp) ,    ntot)
-      call setqvol ( bqp(1,ifield-1,jp)          )
+      call setqvol ( bqp(1,ifield-1,jp) , adqp(1,ifield-1,jp))
       call col2    ( bqp(1,ifield-1,jp) ,bm1,ntot)
 c
       time = time+dt                           ! restore time

--- a/core/reader_re2.f
+++ b/core/reader_re2.f
@@ -306,7 +306,7 @@ c-----------------------------------------------------------------------
       re2off_b = re2off_b + nrg*4*lrs4
 
       if (.not.ifread) return
-      if(nio.eq.0) write(6,'(A,I10,AI3)') 
+      if(nio.eq.0) write(6,'(A,I10,A,I3)') 
      $             ' reading boundary faces ', nrg, 
      $             ' for ifield ', ifield
 


### PR DESCRIPTION
fixes the segmentation fault with ifpert (issue #741) by incorporating the implicit scalar term in the perturbation solver.