### PR TITLE
Faster local dprocmap cache lookup 

### DIFF
--- a/core/DPROCMAP
+++ b/core/DPROCMAP
@@ -7,7 +7,13 @@
       integer dProcmapWin 
       common /cbpmwd/ dProcmapWin(2*lelt)
 
-      parameter (lcr = lelt)                      ! remote elements
-      parameter (lc = lelt+lcr+8-mod(lelt+lcr,8)) ! multiple of 8
-      integer   cache
-      common /cbpmca/ cache(lc,3)
+      parameter (lur = 80)              ! unsorted size
+      parameter (lcu = 8*((lur+8)/8))   ! multiple of 8
+      parameter (ls1 = 8*lelt + 2*lcu)  ! larger than unsorted
+      parameter (ls2 = lelg   + 2*lcu)  ! larger than unsorted
+      parameter (lcs = min(ls1,ls2))    ! not much bigger than lelg
+      integer   ucache,cache            ! unsorted and sorted cache
+      common /cbpmca/ ucache(lcu,3),cache(lcs,3)
+
+
+

--- a/core/dprocmap.f
+++ b/core/dprocmap.f
@@ -37,21 +37,21 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine dProcmapPut(ibuf,lbuf,ioff,ieg)
+      subroutine dProcmapPut(ibuf,lbuf,ioff,eg)
 
       include 'mpif.h'
       include 'SIZE'
       include 'PARALLEL'
       include 'DPROCMAP'
 
-      integer ibuf(lbuf)
+      integer ibuf(lbuf),eg
       integer*8 disp
 
       if (lbuf.lt.1 .or. lbuf.gt.2)
      $   call exitti('invalid lbuf!',lbuf)
 
 #ifdef MPI
-      call dProcMapFind(iloc,nids,ieg)
+      call dProcMapFind(iloc,nids,eg)
       disp = 2*(iloc-1) + ioff
 
       call mpi_win_lock(MPI_LOCK_EXCLUSIVE,nids,0,dProcmapH,ierr)
@@ -59,79 +59,164 @@ c-----------------------------------------------------------------------
      $             dProcmapH,ierr)
       call mpi_win_unlock(nids,dProcmapH,ierr)
 #else
-      call icopy(dProcmapWin(2*(ieg-1) + ioff + 1),ibuf,lbuf)
+      call icopy(dProcmapWin(2*(eg-1) + ioff + 1),ibuf,lbuf)
 #endif
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine dProcmapGet(ibuf,ieg)
+      subroutine dProcmapGet(ibuf,eg)
 
       include 'mpif.h'
       include 'SIZE'
       include 'PARALLEL'
       include 'DPROCMAP'
 
-      integer ibuf(2)
+      integer ibuf(2),eg
 
       integer*8 disp
 
       save icalld
       data icalld /0/
 
-      save iran
-      parameter(im = 6075, ia = 106, ic = 1283)
+      integer ind(3*lcs+lcu)
+      common /ctmpx/ ind
+
+      integer n_in_sort,n_in_unsort
+      common  /mycache/ n_in_sort,n_in_unsort
 
       if (icalld .eq. 0) then
-         call ifill(cache,-1,size(cache))
          icalld = 1
+         call ifill( cache,-1,size( cache))
+         call ifill(ucache,-9,size(ucache))
+         n_in_sort   = 0
+         n_in_unsort = 0
       endif
 
-      ii = lsearch_ur(cache(1,3),lc,ieg)
-      if (ii.gt.lc) call exitti('lsearch_ur returns invalid index$',ii)
-      if (ii.gt.0 .and. ii.ne.lelt+lcr) then ! cache hit
-         !write(6,*) nid, 'cache hit ', 'ieg:', ieg
+      ii = ibsearch  (cache(1,3),n_in_sort  ,eg)
+      if (ii.gt.0) then  ! cache hit
+c        write(6,*) nid,'a cache hit ', 'eg:', eg, n_in_sort, lcs
          ibuf(1) = cache(ii,1)
          ibuf(2) = cache(ii,2)
-      else
+         return
+      endif
+
+      ii = lsearch_ur(ucache(1,3),n_in_unsort,eg)
+      if (ii.gt.lcu)call exitti('lsearch_ur returns invalid index$',nid)
+
+      if (ii.gt.0) then ! ucache hit
+c        write(6,*) nid,'Aucache hit ', 'eg:', eg, n_in_unsort, lcu
+         ibuf(1) = ucache(ii,1)
+         ibuf(2) = ucache(ii,2)
+         return
+      else                                   ! cache miss
+c       write(6,*) nid,'A cache miss eg:',eg,n_in_sort,n_in_unsort
 #ifdef MPI
-         call dProcmapFind(il,nidt,ieg)
+         call dProcmapFind(il,nidt,eg)
          disp = 2*(il-1)
          call mpi_win_lock(MPI_LOCK_SHARED,nidt,0,dProcmapH,ierr)
          call mpi_get(ibuf,2,MPI_INTEGER,nidt,disp,2,MPI_INTEGER,
      $                dProcmapH,ierr)
          call mpi_win_unlock(nidt,dProcmapH,ierr)
 #else
-         call icopy(ibuf,dProcmapWin(2*(ieg-1) + 1),2)
+         call icopy(ibuf,dProcmapWin(2*(eg-1) + 1),2)
 #endif
          if (dProcmapCache) then
-            if (ibuf(2).eq.nid) then
-               ii = ibuf(1)
-            else
-               iran = mod(iran*ia+ic,im)
-               ii = lelt + (lcr*iran)/im + 1 ! randomize array location 
+
+            n_in_unsort = n_in_unsort + 1      ! Add current ref to unsorted bin
+            ucache(n_in_unsort,1) = ibuf(1)
+            ucache(n_in_unsort,2) = ibuf(2)
+            ucache(n_in_unsort,3) = eg
+
+            if (n_in_unsort.eq.lcu) then ! merge with sorted list
+
+               if (n_in_sort.ge.lcs-lcu) then ! decimate cached data
+                  j=0
+                  do i=1,n_in_sort,2
+                     j=j+1
+                     cache(j,1) = cache(i,1)
+                     cache(j,2) = cache(i,2)
+                     cache(j,3) = cache(i,3)
+                  enddo
+                  n_in_sort = j
+               endif
+
+
+c              Sort unsorted part of cache
+
+               ipt = n_in_unsort+1
+               call isort(ucache(1,3),ind,n_in_unsort)
+               call iswap(ucache(1,2),ind,n_in_unsort,ind(ipt))
+               call iswap(ucache(1,1),ind,n_in_unsort,ind(ipt))
+
+c              Merge unsorted part of with sorted part
+
+               key = 3
+               call merge_tuple
+     $             (ind,lcs,mc,3,cache,lcs,n_in_sort
+     $                         ,ucache,lcu,n_in_unsort,key)
+
+               call icopy(cache(1,1),ind(1+0*lcs),mc)
+               call icopy(cache(1,2),ind(1+1*lcs),mc)
+               call icopy(cache(1,3),ind(1+2*lcs),mc)
+
+               n_in_sort   = mc      ! Update counters
+               n_in_unsort = 0
+
             endif
-            cache(ii,1) = ibuf(1)
-            cache(ii,2) = ibuf(2)
-            cache(ii,3) = ieg
+
          endif
       endif
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine dProcMapFind(il,nids,ieg)
+      subroutine dProcMapFind(il,nids,eg)
 
       include 'SIZE'
       include 'PARALLEL'
 
+      integer eg
+
       nstar = nelgt/np
-      nids = (ieg-1)/nstar
-      il = ieg - nids * nstar
-      if (ieg .gt. np*nstar) then
-         nids = mod(ieg,np) - 1
+      nids = (eg-1)/nstar
+      il = eg - nids * nstar
+      if (eg .gt. np*nstar) then
+         nids = mod(eg,np) - 1
          il = nstar + 1
       endif
+
+      return
+      end
+c-----------------------------------------------------------------------
+      integer function ibsearch(a,n,k)      !     P. 88-89, NUMERICAL RECIPES
+      include 'SIZE'
+      include 'PARALLEL'
+      integer a(n),n,k
+
+      ibsearch = 0
+
+      if (n.eq.0) return
+
+      ilo=1
+      ihi=n
+
+        lcount = 0
+    1   if ((ihi-ilo).gt.1) then
+           lcount = lcount + 1
+           i=(ihi+ilo)/2
+           if (a(i).eq.k) goto 10
+           if (a(i).gt.k) then
+              ihi=i
+           else
+              ilo=i
+           endif
+           goto 1
+        endif
+
+      return
+
+   10 ibsearch = i
 
       return
       end
@@ -142,59 +227,87 @@ c-----------------------------------------------------------------------
       parameter(lvec = 8) ! unroll factor
 
       lsearch_ur = 0
-      do i = 1,n,lvec
-         do j = 0,lvec-1
-            if (a(i+j).eq.k) lsearch_ur = i + j
+      ipt        = 0
+
+      if (n.eq.0) return
+
+      if (nvec.gt.4*lvect) then
+         do i = 1,n-lvec,lvec
+            do j = 0,lvec-1
+               ipt = i+j
+               if (a(ipt).eq.k) lsearch_ur = ipt
+            enddo
+            if (lsearch_ur.gt.0) return
          enddo
-         if (lsearch_ur.gt.0) goto 10
+      endif
+
+
+      do j = ipt+1,n
+         if (a(j).eq.k) lsearch_ur = j
+         if (lsearch_ur.gt.0) return
       enddo
 
-10    continue
+      return
       end
 c-----------------------------------------------------------------------
-      integer function gllnid(ieg)
+      integer function gllnid(eg)
 
+      include 'SIZE'
       include 'mpif.h'
 
-      integer iegl, nidl
-      save    iegl, nidl
-      data    iegl, nidl /0,0/
+      integer egl, nidl, icalld
+      save    egl, nidl, icalld
+      data    egl, nidl, icalld  /0,0,0/
 
-      integer ibuf(2)
+      integer ibuf(2),eg
 
-      if (ieg.eq.0) iegl = 0
+      include 'DPROCMAP'
 
-      if (ieg.eq.iegl) then
+      integer n_in_sort,n_in_unsort
+      common  /mycache/ n_in_sort,n_in_unsort
+
+
+      icalld = icalld+1
+
+      if (eg.eq.0) egl = 0
+
+      if (eg.eq.egl) then
          ibuf(2) = nidl
          goto 100
       endif
-      call dProcmapGet(ibuf,ieg)
+      call dProcmapGet(ibuf,eg)
 
- 100  iegl   = ieg
+c     iout = 60+nid
+c     write(iout,*) nid,'gllnid: ',icalld,eg,ibuf(2),ibuf(1)
+c     write(6,*)    nid,'gllnid: ',icalld,eg,ibuf(2),ibuf(1)
+c    $                            ,n_in_unsort,n_in_sort,lcu,lcs
+
+ 100  egl    = eg
       nidl   = ibuf(2)
       gllnid = ibuf(2)
 
+
       end
 c-----------------------------------------------------------------------
-      integer function gllel(ieg)
+      integer function gllel(eg)
 
       include 'mpif.h'
 
-      integer iegl, iell
-      save    iegl, iell
-      data    iegl, iell /0,0/
+      integer egl, iell, eg
+      save    egl, iell
+      data    egl, iell /0,0/
 
       integer ibuf(2)
 
-      if (ieg.eq.0) iegl = 0
+      if (eg.eq.0) egl = 0
 
-      if (ieg.eq.iegl) then
+      if (eg.eq.egl) then
          ibuf(1) = iell
          goto 100
       endif
-      call dProcmapGet(ibuf,ieg)
+      call dProcmapGet(ibuf,eg)
 
- 100  iegl  = ieg
+ 100  egl   = eg
       iell  = ibuf(1)
       gllel = ibuf(1)
 
@@ -206,11 +319,98 @@ c-----------------------------------------------------------------------
       include 'PARALLEL'
       include 'DPROCMAP'
 
-      call ifill(cache,-1,size(cache))
+      integer n_in_sort,n_in_unsort
+      common  /mycache/ n_in_sort,n_in_unsort
+
+c     write(6,*) nid,' Clearing dpcache:', n_in_sort,n_in_unsort
+
+      call ifill( cache,-1,size(cache) )
+      call ifill(ucache,-1,size(ucache))
+
       itmp = gllnid(0) ! reset last element cache
       itmp = gllel(0)  ! reset last element cache
 
+      n_in_sort   = 0
+      n_in_unsort = 0
+
       end
 c-----------------------------------------------------------------------
- 
+      subroutine merge_tuple(c,ldc,mc,nc,a,lda,ma,b,ldb,mb,key)
+
+      include 'SIZE'
+      include 'PARALLEL'
+
+c     c(mc,nc) = merge(a(ma,nc),b(mb,nc))
+
+      integer c(ldc,nc),a(lda,nc),b(ldb,nc)
+
+      mc = 0  ! Number of merged entries [ c ] = [ a ] + [ b ]
+
+      if (ma.eq.0.and.mb.eq.0) return
+
+      if (mb.eq.0) then
+         do k=1,nc
+         do i=1,ma
+            c(i,k) = a(i,k)
+         enddo
+         enddo
+         mc = ma
+         return
+      endif
+
+      if (ma.eq.0) then
+         do k=1,nc
+         do i=1,mb
+            c(i,k) = b(i,k)
+         enddo
+         enddo
+         mc = mb
+         return
+      endif
+
+
+      i=1
+      j=1
+      k=1
+      do while (i.le.ma.and.j.le.mb)
+         if (a(i,key).lt.b(j,key)) then
+            do l=1,nc
+               c(k,l) = a(i,l)
+            enddo
+            i=i+1
+         else
+            do l=1,nc
+               c(k,l) = b(j,l)
+            enddo
+            j=j+1
+         endif
+
+         if (k.eq.1) then
+            k=k+1
+         elseif (c(k,key).gt.c(k-1,key)) then ! Avoid repeats
+            k=k+1
+         endif
+      enddo
+
+      do while (i.le.ma)
+         do l=1,nc
+            c(k,l) = a(i,l)
+         enddo
+         i=i+1
+         k=k+1
+      enddo
+
+      do while (j.le.mb)
+         do l=1,nc
+            c(k,l) = b(j,l)
+         enddo
+         j=j+1
+         k=k+1
+      enddo
+
+      mc = k-1 ! Length of merged list
+
+      return
+      end
+c-----------------------------------------------------------------------
 #endif

--- a/core/reader_re2.f
+++ b/core/reader_re2.f
@@ -94,7 +94,9 @@ c-----------------------------------------------------------------------
 
       nrg       = nelgt
       nr        = nelt
+      etime0    = dnekclock_sync()
       irankoff  = igl_running_sum(nr) - nr
+      etime_s1  = dnekclock_sync() - etime0
       dtmp8     = irankoff
       re2off_b  = 84 ! set initial offset (hdr + endian)
       lre2off_b = re2off_b + dtmp8*lrs*wdsizi
@@ -103,7 +105,9 @@ c-----------------------------------------------------------------------
       ! read coordinates from file
       nwds4r = nr*lrs4
       call byte_set_view(lre2off_b,fh_re2)
+      etime0 = dnekclock_sync()
       call byte_read_mpi(bufr,nwds4r,-1,fh_re2,ierr)
+      etime_s2 = dnekclock_sync() - etime0
       re2off_b = re2off_b + nrg*4*lrs4
       if (ierr.gt.0) goto 100
 
@@ -112,6 +116,7 @@ c-----------------------------------------------------------------------
       if (nio.eq.0) write(6,*) 'reading mesh '
 
       ! pack buffer
+      etime0 = dnekclock_sync()
       do i = 1,nr
          jj      = (i-1)*lrs4 + 1
          ielg    = irankoff + i ! elements are stored in global order
@@ -119,12 +124,15 @@ c-----------------------------------------------------------------------
          vi(2,i) = ielg
          call icopy(vi(3,i),bufr(jj,1),lrs4)
       enddo
+      etime_t1 = dnekclock_sync() - etime0
 
       ! crystal route nr real items of size lrs to rank vi(key,1:nr)
       n   = nr
       key = 1 
+      etime0 = dnekclock_sync()
       call fgslib_crystal_tuple_transfer(cr_re2,n,nrmax,vi,li,
      &   vl,0,vr,0,key)
+      etime_t2 = dnekclock_sync() - etime0
 
       ! unpack buffer
       ierr = 0
@@ -133,11 +141,20 @@ c-----------------------------------------------------------------------
          goto 100
       endif
 
+      etime0 = dnekclock_sync()
       do i = 1,n
          iel = gllel(vi(2,i)) 
          call icopy     (bufr,vi(3,i),lrs4)
          call buf_to_xyz(bufr,iel,ifbswap,ierr)
       enddo
+      etime_t3 = dnekclock_sync() - etime0
+
+      if(nio.eq.0) write(6,1) etime_t1,etime_t2,etime_t3
+      if(nio.eq.0) write(6,2) etime_s1,etime_s2
+
+   1  format(3x,'readp_re2_mesh:pack/cr/unpack :',3(1e9.2))
+   2  format(3x,'readp_re2_mesh:running_sum/byte_read_mpi :',2(1e9.2))
+
 
  100  call err_chk(ierr,'Error reading .re2 mesh$')
 
@@ -174,7 +191,9 @@ c-----------------------------------------------------------------------
       nwds4r    = 1*wdsizi/4
       lre2off_b = re2off_b
       call byte_set_view(lre2off_b,fh_re2)
+      etime0 = dnekclock_sync()
       call byte_read_mpi(nrg4,nwds4r,-1,fh_re2,ierr)
+      etime_s1 = dnekclock_sync() - etime0
       if(ierr.gt.0) goto 100
 
       if(wdsizi.eq.8) then
@@ -195,7 +214,9 @@ c-----------------------------------------------------------------------
       do i = 0,mod(nrg,dtmp8)-1
          if(i.eq.nid) nr = nr + 1
       enddo
+      etime0 = dnekclock_sync()
       dtmp8     = i8gl_running_sum(int(nr,8)) - nr
+      etime_s2 = dnekclock_sync() - etime0
       lre2off_b = re2off_b + dtmp8*lrs*wdsizi
       lrs4      = lrs*wdsizi/4
 
@@ -206,10 +227,13 @@ c-----------------------------------------------------------------------
 
       nwds4r = nr*lrs4
       call byte_set_view(lre2off_b,fh_re2)
+      etime0 = dnekclock_sync()
       call byte_read_mpi(bufr,nwds4r,-1,fh_re2,ierr)
+      etime_s3 = dnekclock_sync() - etime0
       if(ierr.gt.0) goto 100
 
       ! pack buffer
+      etime0 = dnekclock_sync()
       do i = 1,nr
          jj = (i-1)*lrs4 + 1
 
@@ -227,19 +251,31 @@ c-----------------------------------------------------------------------
 
          call icopy (vi(2,i),bufr(jj,1),lrs4)
       enddo
+      etime_t1 = dnekclock_sync() - etime0
 
       ! crystal route nr real items of size lrs to rank vi(key,1:nr)
       n    = nr
       key  = 1
+      etime0 = dnekclock_sync()
       call fgslib_crystal_tuple_transfer(cr_re2,n,nrmax,vi,li,vl,0,vr,0,
      &                                   key)
+      etime_t2 = dnekclock_sync() - etime0
 
       ! unpack buffer
+      etime0 = dnekclock_sync()
       if(n.gt.nrmax) goto 100
       do i = 1,n
          call icopy       (bufr,vi(2,i),lrs4)
          call buf_to_curve(bufr)
       enddo
+      etime_t3 = dnekclock_sync() - etime0
+
+      if(nio.eq.0) write(6,1) etime_t1,etime_t2,etime_t3
+      if(nio.eq.0) write(6,2) etime_s1,etime_s2,etime_s3
+
+   1  format(3x,'readp_re2_curve:pack/cr/unpack :',3(1e9.2))
+   2  format(3x,'readp_re2_curve:byte_read_mpi/running_sum/byte_read_mpi
+     $ :',3(1e9.2))
 
       return
 
@@ -278,7 +314,9 @@ c-----------------------------------------------------------------------
       nwds4r    = 1*wdsizi/4
       lre2off_b = re2off_b
       call byte_set_view(lre2off_b,fh_re2)
+      etime0    = dnekclock_sync()
       call byte_read_mpi(nrg4,nwds4r,-1,fh_re2,ierr)
+      etime_s1  = dnekclock_sync() - etime0
       if(ierr.gt.0) goto 100
 
       if(wdsizi.eq.8) then
@@ -299,7 +337,9 @@ c-----------------------------------------------------------------------
       do i = 0,mod(nrg,dtmp8)-1
          if(i.eq.nid) nr = nr + 1
       enddo
+      etime0    = dnekclock_sync()
       dtmp8     = i8gl_running_sum(int(nr,8)) - nr
+      etime_s2  = dnekclock_sync() - etime0
       lre2off_b = re2off_b + dtmp8*lrs*wdsizi
       lrs4      = lrs*wdsizi/4
 
@@ -312,10 +352,13 @@ c-----------------------------------------------------------------------
 
       nwds4r = nr*lrs4
       call byte_set_view(lre2off_b,fh_re2)
+      etime0 = dnekclock_sync()
       call byte_read_mpi(bufr,nwds4r,-1,fh_re2,ierr)
+      etime_s3 = dnekclock_sync() - etime0
       if(ierr.gt.0) goto 100
 
       ! pack buffer
+      etime0 = dnekclock_sync()
       do i = 1,nr
          jj = (i-1)*lrs4 + 1
 
@@ -333,13 +376,16 @@ c-----------------------------------------------------------------------
 
          call icopy (vi(2,i),bufr(jj,1),lrs4)
       enddo
+      etime_t1 = dnekclock_sync() - etime0
 
       ! crystal route nr real items of size lrs to rank vi(key,1:nr)
       n    = nr
       key  = 1
 
+      etime0 = dnekclock_sync()
       call fgslib_crystal_tuple_transfer(cr_re2,n,nrmax,vi,li,vl,0,vr,0,
      &                                   key)
+      etime_t2 = dnekclock_sync() - etime0
 
       ! fill up with default
       do iel=1,nelt
@@ -350,10 +396,19 @@ c-----------------------------------------------------------------------
 
       ! unpack buffer
       if(n.gt.nrmax) goto 100
+      etime0 = dnekclock_sync()
       do i = 1,n
          call icopy    (bufr,vi(2,i),lrs4)
          call buf_to_bc(cbl,bl,bufr)
       enddo
+      etime_t3 = dnekclock_sync() - etime0
+
+      if(nio.eq.0) write(6,1) etime_t1,etime_t2,etime_t3
+      if(nio.eq.0) write(6,2) etime_s1,etime_s2,etime_s3
+
+   1  format(3x,'readp_re2_bc:pack/cr/unpack :',3(1e9.2))
+   2  format(3x,'readp_re2_bc:byte_read_mpi/running_sum/byte_read_mpi :'
+     $,3(1e9.2))
 
       return
 


### PR DESCRIPTION
* @fischer1: update dprocmap for faster mesh reading at large element counts
* @misunmin: add re2 timing breakdown and test up to 2B elements for nek5000/nekrs 