### PR TITLE
Adding user parameters in PARDICT file

### DIFF
--- a/core/PARDICT
+++ b/core/PARDICT
@@ -65,57 +65,58 @@ c
      &  pardictkey(58) / 'GENERAL:USERPARAM08' /
      &  pardictkey(59) / 'GENERAL:USERPARAM09' /
      &  pardictkey(60) / 'GENERAL:USERPARAM10' /
-     &  pardictkey(61) / 'SCALAR%%' /
-     &  pardictkey(62) / 'SCALAR%%:SOLVER' /
-     &  pardictkey(63) / 'SCALAR%%:RESIDUALTOL' /
-     &  pardictkey(64) / 'SCALAR%%:DENSITY' /
-     &  pardictkey(65) / 'SCALAR%%:DIFFUSIVITY' /
-     &  pardictkey(66) / 'SCALAR%%:WRITETOFIELDFILE' /
-     &  pardictkey(67) / 'SCALAR%%:ABSOLUTETOL' /
-     &  pardictkey(68) / 'SCALAR%%:CONJUGATEHEATTRANSFER' /
-     &  pardictkey(69) / 'TEMPERATURE:SOLVER' /
-     &  pardictkey(70) / 'TEMPERATURE:RESIDUALTOL' /
-     &  pardictkey(71) / 'TEMPERATURE:ABSOLUTETOL' /
-     &  pardictkey(72) / 'PROBLEMTYPE:DP0DT' /
-     &  pardictkey(73) / 'CVODE' /
-     &  pardictkey(74) / 'CVODE:ABSOLUTETOL' /
-     &  pardictkey(75) / 'CVODE:RELATIVETOL' /
-     &  pardictkey(76) / 'CVODE:STIFF' /
-     &  pardictkey(77) / 'CVODE:MODE' /
-     &  pardictkey(78) / 'CVODE:PRECONDITIONER' /
-     &  pardictkey(79) / 'CVODE:DTMAX' /
-     &  pardictkey(80) / 'CVODE:DQJINCREMENTFACTOR' /
-     &  pardictkey(81) / 'CVODE:RATIOLNLTOL' /
-     &  pardictkey(82) / ':PARVERSION' /
-     &  pardictkey(83) / 'MESH:NUMBEROFBCFIELDS' /
-     &  pardictkey(84) / 'GENERAL:OPTLEVEL' /
-     &  pardictkey(85) / 'GENERAL:LOGLEVEL' /
-     &  pardictkey(86) / 'MESH:VISCOSITY' /
-     &  pardictkey(87) / 'MESH:RESIDUALTOL' /
-     &  pardictkey(88) / 'GENERAL:EXTRAPOLATION' /
-     &  pardictkey(89) / 'PROBLEMTYPE:EQUATION' /
-     &  pardictkey(90) / 'TEMPERATURE:RESIDUALPROJ' /
-     &  pardictkey(91) / 'SCALAR%%:RESIDUALPROJ' /
-     &  pardictkey(92) / 'MESH:FIRSTBCFIELDINDEX' /
-     &  pardictkey(93) / 'GENERAL:POLYNOMIALORDER' /
-     &  pardictkey(94) / 'GENERAL:POLYNOMIALORDERDEALIAS' /
-     &  pardictkey(95) / 'GENERAL:PNPNFORMULATION' /
-     &  pardictkey(96) / 'GENERAL:MINNUMPROCESSES' /
-     &  pardictkey(97) / 'GENERAL:MAXNUMSESSIONS' /
-     &  pardictkey(98) / 'GENERAL:MAXNUMELEMENTS' /
-     &  pardictkey(99) / 'GENERAL:MAXNUMHISTORYPOINTS' /
-     &  pardictkey(100)/ 'GENERAL:FILTERMODES' /
-     &  pardictkey(101)/ 'PRESSURE:SOLVER' /
-     &  pardictkey(102)/ 'MESH:PARTITIONER' /
-     &  pardictkey(103)/ 'MESH:CONNECTIVITYTOL' /
-     &  pardictkey(104)/ 'SCALAR%%:ADVECTION' /
-     &  pardictkey(105) / 'GENERAL:USERPARAM11' /
-     &  pardictkey(106) / 'GENERAL:USERPARAM12' /
-     &  pardictkey(107) / 'GENERAL:USERPARAM13' /
-     &  pardictkey(108) / 'GENERAL:USERPARAM14' /
-     &  pardictkey(109) / 'GENERAL:USERPARAM15' /
-     &  pardictkey(110) / 'GENERAL:USERPARAM16' /
-     &  pardictkey(111) / 'GENERAL:USERPARAM17' /
-     &  pardictkey(112) / 'GENERAL:USERPARAM18' /
-     &  pardictkey(113) / 'GENERAL:USERPARAM19' /
-     &  pardictkey(114) / 'GENERAL:USERPARAM20' /     
+     &  pardictkey(61) / 'GENERAL:USERPARAM11' /
+     &  pardictkey(62) / 'GENERAL:USERPARAM12' /
+     &  pardictkey(63) / 'GENERAL:USERPARAM13' /
+     &  pardictkey(64) / 'GENERAL:USERPARAM14' /
+     &  pardictkey(65) / 'GENERAL:USERPARAM15' /
+     &  pardictkey(66) / 'GENERAL:USERPARAM16' /
+     &  pardictkey(67) / 'GENERAL:USERPARAM17' /
+     &  pardictkey(68) / 'GENERAL:USERPARAM18' /
+     &  pardictkey(69) / 'GENERAL:USERPARAM19' /
+     &  pardictkey(70) / 'GENERAL:USERPARAM20' / 
+     &  pardictkey(71) / 'SCALAR%%' /
+     &  pardictkey(72) / 'SCALAR%%:SOLVER' /
+     &  pardictkey(73) / 'SCALAR%%:RESIDUALTOL' /
+     &  pardictkey(74) / 'SCALAR%%:DENSITY' /
+     &  pardictkey(75) / 'SCALAR%%:DIFFUSIVITY' /
+     &  pardictkey(76) / 'SCALAR%%:WRITETOFIELDFILE' /
+     &  pardictkey(77) / 'SCALAR%%:ABSOLUTETOL' /
+     &  pardictkey(78) / 'SCALAR%%:CONJUGATEHEATTRANSFER' /
+     &  pardictkey(79) / 'TEMPERATURE:SOLVER' /
+     &  pardictkey(80) / 'TEMPERATURE:RESIDUALTOL' /
+     &  pardictkey(81) / 'TEMPERATURE:ABSOLUTETOL' /
+     &  pardictkey(82) / 'PROBLEMTYPE:DP0DT' /
+     &  pardictkey(83) / 'CVODE' /
+     &  pardictkey(84) / 'CVODE:ABSOLUTETOL' /
+     &  pardictkey(85) / 'CVODE:RELATIVETOL' /
+     &  pardictkey(86) / 'CVODE:STIFF' /
+     &  pardictkey(87) / 'CVODE:MODE' /
+     &  pardictkey(88) / 'CVODE:PRECONDITIONER' /
+     &  pardictkey(89) / 'CVODE:DTMAX' /
+     &  pardictkey(90) / 'CVODE:DQJINCREMENTFACTOR' /
+     &  pardictkey(91) / 'CVODE:RATIOLNLTOL' /
+     &  pardictkey(92) / ':PARVERSION' /
+     &  pardictkey(93) / 'MESH:NUMBEROFBCFIELDS' /
+     &  pardictkey(94) / 'GENERAL:OPTLEVEL' /
+     &  pardictkey(95) / 'GENERAL:LOGLEVEL' /
+     &  pardictkey(96) / 'MESH:VISCOSITY' /
+     &  pardictkey(97) / 'MESH:RESIDUALTOL' /
+     &  pardictkey(98) / 'GENERAL:EXTRAPOLATION' /
+     &  pardictkey(99) / 'PROBLEMTYPE:EQUATION' /
+     &  pardictkey(100) / 'TEMPERATURE:RESIDUALPROJ' /
+     &  pardictkey(101) / 'SCALAR%%:RESIDUALPROJ' /
+     &  pardictkey(102) / 'MESH:FIRSTBCFIELDINDEX' /
+     &  pardictkey(103) / 'GENERAL:POLYNOMIALORDER' /
+     &  pardictkey(104) / 'GENERAL:POLYNOMIALORDERDEALIAS' /
+     &  pardictkey(105) / 'GENERAL:PNPNFORMULATION' /
+     &  pardictkey(106) / 'GENERAL:MINNUMPROCESSES' /
+     &  pardictkey(107) / 'GENERAL:MAXNUMSESSIONS' /
+     &  pardictkey(108) / 'GENERAL:MAXNUMELEMENTS' /
+     &  pardictkey(109) / 'GENERAL:MAXNUMHISTORYPOINTS' /
+     &  pardictkey(110)/ 'GENERAL:FILTERMODES' /
+     &  pardictkey(111)/ 'PRESSURE:SOLVER' /
+     &  pardictkey(112)/ 'MESH:PARTITIONER' /
+     &  pardictkey(113)/ 'MESH:CONNECTIVITYTOL' /
+     &  pardictkey(114)/ 'SCALAR%%:ADVECTION' /
+         

--- a/core/PARDICT
+++ b/core/PARDICT
@@ -4,7 +4,7 @@ c     Note: Keys have to be in captial letters
 c
       integer PARDICT_NKEYS
 
-      parameter(PARDICT_NKEYS = 104)
+      parameter(PARDICT_NKEYS = 114)
 
       character*132 pardictkey(PARDICT_NKEYS)
       data
@@ -108,4 +108,14 @@ c
      &  pardictkey(101)/ 'PRESSURE:SOLVER' /
      &  pardictkey(102)/ 'MESH:PARTITIONER' /
      &  pardictkey(103)/ 'MESH:CONNECTIVITYTOL' /
-     &  pardictkey(104)/ 'SCALAR%%:ADVECTION' /     
+     &  pardictkey(104)/ 'SCALAR%%:ADVECTION' /
+     &  pardictkey(105) / 'GENERAL:USERPARAM11' /
+     &  pardictkey(106) / 'GENERAL:USERPARAM12' /
+     &  pardictkey(107) / 'GENERAL:USERPARAM13' /
+     &  pardictkey(108) / 'GENERAL:USERPARAM14' /
+     &  pardictkey(109) / 'GENERAL:USERPARAM15' /
+     &  pardictkey(110) / 'GENERAL:USERPARAM16' /
+     &  pardictkey(111) / 'GENERAL:USERPARAM17' /
+     &  pardictkey(112) / 'GENERAL:USERPARAM18' /
+     &  pardictkey(113) / 'GENERAL:USERPARAM19' /
+     &  pardictkey(114) / 'GENERAL:USERPARAM20' /     

--- a/tools/postnek/PARDICT
+++ b/tools/postnek/PARDICT
@@ -4,7 +4,7 @@ c     Note: Keys have to be in captial letters
 c
       integer PARDICT_NKEYS
 
-      parameter(PARDICT_NKEYS = 85)
+      parameter(PARDICT_NKEYS = 95)
 
       character*132 pardictkey(PARDICT_NKEYS)
       data
@@ -68,29 +68,40 @@ c
      &  pardictkey(58) / 'GENERAL:USERPARAM08' /
      &  pardictkey(59) / 'GENERAL:USERPARAM09' /
      &  pardictkey(60) / 'GENERAL:USERPARAM10' /
-     &  pardictkey(61) / 'SCALAR%%' /
-     &  pardictkey(62) / 'SCALAR%%:SOLVER' /
-     &  pardictkey(63) / 'SCALAR%%:RESIDUALTOL' /
-     &  pardictkey(64) / 'SCALAR%%:DENSITY' /
-     &  pardictkey(65) / 'SCALAR%%:DIFFUSIVITY' /
-     &  pardictkey(66) / 'SCALAR%%:WRITETOFIELDFILE' /
-     &  pardictkey(67) / 'SCALAR%%:ABSOLUTETOL' /
-     &  pardictkey(68) / 'SCALAR%%:CONJUGATEHEATTRANSFER' /
-     &  pardictkey(69) / 'TEMPERATURE:SOLVER' /
-     &  pardictkey(70) / 'TEMPERATURE:RESIDUALTOL' /
-     &  pardictkey(71) / 'TEMPERATURE:ABSOLUTETOL' /
-     &  pardictkey(72) / 'PROBLEMTYPE:DP0DT' /
-     &  pardictkey(73) / 'CVODE' /
-     &  pardictkey(74) / 'CVODE:ABSOLUTETOL' /
-     &  pardictkey(75) / 'CVODE:RELATIVETOL' /
-     &  pardictkey(76) / 'CVODE:STIFF' /
-     &  pardictkey(77) / 'CVODE:MODE' /
-     &  pardictkey(78) / 'CVODE:PRECONDITIONER' /
-     &  pardictkey(79) / 'CVODE:DTMAX' /
-     &  pardictkey(80) / 'CVODE:DQJINCREMENTFACTOR' /
-     &  pardictkey(81) / 'CVODE:RATIOLNLTOL' /
-     &  pardictkey(82) / ':PARVERSION' /
-     &  pardictkey(83) / 'MESH:NUMBEROFBCFIELDS' /
-     &  pardictkey(84) / 'GENERAL:OPTLEVEL' /
-     &  pardictkey(85) / 'GENERAL:LOGLEVEL' /
+     &  pardictkey(61) / 'GENERAL:USERPARAM11' /
+     &  pardictkey(62) / 'GENERAL:USERPARAM12' /
+     &  pardictkey(63) / 'GENERAL:USERPARAM13' /
+     &  pardictkey(64) / 'GENERAL:USERPARAM14' /
+     &  pardictkey(65) / 'GENERAL:USERPARAM15' /
+     &  pardictkey(66) / 'GENERAL:USERPARAM16' /
+     &  pardictkey(67) / 'GENERAL:USERPARAM17' /
+     &  pardictkey(68) / 'GENERAL:USERPARAM18' /
+     &  pardictkey(69) / 'GENERAL:USERPARAM19' /
+     &  pardictkey(70) / 'GENERAL:USERPARAM20' / 
+     &  pardictkey(71) / 'SCALAR%%' /
+     &  pardictkey(72) / 'SCALAR%%:SOLVER' /
+     &  pardictkey(73) / 'SCALAR%%:RESIDUALTOL' /
+     &  pardictkey(74) / 'SCALAR%%:DENSITY' /
+     &  pardictkey(75) / 'SCALAR%%:DIFFUSIVITY' /
+     &  pardictkey(76) / 'SCALAR%%:WRITETOFIELDFILE' /
+     &  pardictkey(77) / 'SCALAR%%:ABSOLUTETOL' /
+     &  pardictkey(78) / 'SCALAR%%:CONJUGATEHEATTRANSFER' /
+     &  pardictkey(79) / 'TEMPERATURE:SOLVER' /
+     &  pardictkey(80) / 'TEMPERATURE:RESIDUALTOL' /
+     &  pardictkey(81) / 'TEMPERATURE:ABSOLUTETOL' /
+     &  pardictkey(82) / 'PROBLEMTYPE:DP0DT' /
+     &  pardictkey(83) / 'CVODE' /
+     &  pardictkey(84) / 'CVODE:ABSOLUTETOL' /
+     &  pardictkey(85) / 'CVODE:RELATIVETOL' /
+     &  pardictkey(86) / 'CVODE:STIFF' /
+     &  pardictkey(87) / 'CVODE:MODE' /
+     &  pardictkey(88) / 'CVODE:PRECONDITIONER' /
+     &  pardictkey(89) / 'CVODE:DTMAX' /
+     &  pardictkey(90) / 'CVODE:DQJINCREMENTFACTOR' /
+     &  pardictkey(91) / 'CVODE:RATIOLNLTOL' /
+     &  pardictkey(92) / ':PARVERSION' /
+     &  pardictkey(93) / 'MESH:NUMBEROFBCFIELDS' /
+     &  pardictkey(94) / 'GENERAL:OPTLEVEL' /
+     &  pardictkey(95) / 'GENERAL:LOGLEVEL' /
+
 


### PR DESCRIPTION
Hello,

In developing our solver with [snek5000](https://github.com/snek5000), we noticed that while it is thought of 20 user parameters inside the NEK, only 10 user parameters are defined in [PARDICT](https://github.com/snek5000/Nek5000/blob/140c4fd96c28df5f4d415e89be57424a7eba3691/core/PARDICT) file. I wonder if you could consider this pull request.

Kind regards.