### PR TITLE
Add flow rate settings for par file

### DIFF
--- a/core/PARDICT
+++ b/core/PARDICT
@@ -4,7 +4,7 @@ c     Note: Keys have to be in captial letters
 c
       integer PARDICT_NKEYS
 
-      parameter(PARDICT_NKEYS = 104)
+      parameter(PARDICT_NKEYS = 107)
 
       character*132 pardictkey(PARDICT_NKEYS)
       data
@@ -109,3 +109,6 @@ c
      &  pardictkey(102)/ 'MESH:PARTITIONER' /
      &  pardictkey(103)/ 'MESH:CONNECTIVITYTOL' /
      &  pardictkey(104)/ 'SCALAR%%:ADVECTION' /     
+     &  pardictkey(105)/ 'GENERAL:CONSTFLOWRATE' /
+     &  pardictkey(106)/ 'GENERAL:MEANVELOCITY' /
+     &  pardictkey(107)/ 'GENERAL:MEANVOLUMETRICFLOW' /

--- a/core/reader_par.f
+++ b/core/reader_par.f
@@ -71,6 +71,9 @@ C
 
       param(47) = 0.4  ! viscosity for mesh elasticity solver
 
+      param(54) = 0    ! Direction of constant flow rate  
+      param(55) = 0    ! meanVelocity if param(55)<0 else meanVolumentricFlow
+
       param(59) = 1    ! No fast operator eval
 
       param(65) = 1    ! just one i/o node
@@ -552,6 +555,40 @@ c        stabilization type: none, explicit or hpfrt
          call finiparser_getDbl(d_out,txt,ifnd)
          if(ifnd .eq. 1) uparam(i) = d_out
       enddo
+
+c constant flow rate
+      call finiparser_getString(c_out,'general:constFlowRate',ifnd)
+      if (ifnd .eq. 1) then
+         call capit(c_out,132)
+
+         if (index(c_out,'X') .eq. 1) then
+            param(54) = 1 
+         else if (index(c_out,'Y') .eq. 1) then
+            param(54) = 2 
+         else if (index(c_out,'Z') .eq. 1) then
+            param(54) = 3 
+         else
+            write(6,*) 'value: ',trim(c_out)
+            write(6,*) 'is invalid for general:constFlowRate'
+            goto 999
+         endif
+         call finiparser_getDbl(d_out,'general:meanVelocity',ifnd)
+         if (ifnd .eq. 1) then
+            param(54) = - param(54)
+            param(55) = d_out
+            if (int(param(101)).eq.0) filterType = 0
+         else
+            call finiparser_getDbl
+     $           (d_out,'general:meanVolumetricFlow',ifnd)
+            if (ifnd .eq. 1) then
+              param(55) = d_out
+            else 
+              write(6,*) 'general:meanVelocity or meanVolumetricFlow'
+              write(6,*) 'is required for general:constFlowRate!'
+              goto 999
+            endif
+         endif
+      endif
 
 c set logical flags
       call finiparser_getString(c_out,'general:timeStepper',ifnd)


### PR DESCRIPTION
The flow rate settings in param(54) and param(55) were previously not available via the par file. 

The names of the parameters are derived from the corresponding settings for NekRS.

This PR adds those settings, as well as some validation on the parameters. Apart from the indices in PARDICT, the patch can be applied to v19.0 if someone needs it (already tested).

New syntax:
```
[GENERAL]
constFlowRate = <[XYZ]>
meanVolumetricFlow = <float>
OR
meanVelocity = <float>
```

Until then, the parameters can be set with a workaround: 

```
case.par:

[General]
userParam01 = -3        # fixed flow rate dir
userParam02 = 1         # vol flow rate (up05>0) or Ubar (up05<0)

case.usr, subroutine usrdat3:

param(54) = uparam(1)
param(55) = uparam(2)

```

Should I open a MR for the documentation repository as well, or only after this is released?

