### PR TITLE
correct FFLAGS used in tools

### DIFF
--- a/tools/cgns2nek/makefile
+++ b/tools/cgns2nek/makefile
@@ -14,7 +14,7 @@ clean:
 	@cd ./cgns ; ./install clean
 
 lib:
-	@cd cgns; env CC="$(CC)" CFLAGS="$(BIGMEM)" FC="$(FC)" FFLAGS="$(BIGMEM)" ./install
+	@cd cgns; env CC="$(CC)" CFLAGS="$(CFLAGS)" FC="$(FC)" FFLAGS="$(FFLAGS)" ./install
 
 t.o  		 : t.F90			;  $(FC) -c $(FFLAGS) $(INC) t.F90 
 module_global.o  : module_global.f90		;  $(FC) -c $(FFLAGS) module_global.f90 

--- a/tools/exo2nek/makefile
+++ b/tools/exo2nek/makefile
@@ -16,7 +16,7 @@ clean:
 	@cd ./3rd_party ; rm -rf seacas-exodus netcdf
 
 lib:
-	@cd 3rd_party; env CC="$(CC)" CFLAGS="$(BIGMEM)" FC="$(FC)" FFLAGS="$(BIGMEM)" ./install
+	@cd 3rd_party; env CC="$(CC)" CFLAGS="$(CFLAGS)" FC="$(FC)" FFLAGS="$(FFLAGS)" ./install
 
 mod_SIZE.o      : mod_SIZE.f90			;  $(FC) -c $(FFLAGS) mod_SIZE.f90
 exo2nek.o	: exo2nek.f90			;  $(FC) -c $(FFLAGS) $(INC) exo2nek.f90

--- a/tools/maketools.inc
+++ b/tools/maketools.inc
@@ -203,6 +203,9 @@ else
      export CFLAGS="${NEK_CFLAGS}"
      export CFLAGS+=" ${US}"
      export CFLAGS+=" ${BIGMEM}"
+     if [ "$TOOL" == "cgns2nek" ]; then
+        export FFLAGS+=" -fallow-argument-mismatch"
+     fi
      if [ "$TOOL" == "exo2nek" ]; then
         export FFLAGS+=" ${R8}"
      fi

--- a/tools/nekamg_setup/makefile
+++ b/tools/nekamg_setup/makefile
@@ -10,7 +10,7 @@ nekamg_setup: amg_setup.o
 	$(CC) -DHAVE_CONFIG_H -DHYPRE_SEQUENTIAL -DHYPRE_TIMING $(CFLAGS) -I./hypre/include -c $<
 
 lib:
-	@cd hypre; env CC="$(CC)" CFLAGS="$(BIGMEM)" FC="$(FC)" FFLAGS="$(BIGMEM)" ./install
+	@cd hypre; env CC="$(CC)" CFLAGS="$(CFLAGS)" FC="$(FC)" FFLAGS="$(FFLAGS)" ./install
 
 clean:
 	@rm -rf amg_setup *.o hypre/lib hypre/include hypre/hypre*


### PR DESCRIPTION
- Use FFLAGS instead of BIGMEM    
  so the FFLAGS in maketools will be applied when compiling the tools.

- Ignore the argument-mismatch error in cgns2nek    
  The newer Fortran compiler turns this warning to error.