### PR TITLE
Fix mesh_metrics's spacing

### DIFF
--- a/core/genxyz.f
+++ b/core/genxyz.f
@@ -1496,7 +1496,7 @@ c-----------------------------------------------------------------------
       do ie = 1,nelt
          ddmin = min(ddmin,dxmin_e(ie)) 
          ddmax = max(ddmax,dxmax_e(ie))
-         dtmp  = vlsum(JACM1(1,1,1,ie),nxyz)**1./ldim
+         dtmp  = vlsum(bm1(1,1,1,ie),nxyz)**1./ldim
          ddavg = ddavg + dtmp/(lx1-1) 
       enddo 
       dxmin = glmin(ddmin,1)

--- a/core/genxyz.f
+++ b/core/genxyz.f
@@ -1496,7 +1496,7 @@ c-----------------------------------------------------------------------
       do ie = 1,nelt
          ddmin = min(ddmin,dxmin_e(ie)) 
          ddmax = max(ddmax,dxmax_e(ie))
-         dtmp  = vlsum(JACM1(1,1,1,ie),nxyz)**1./3
+         dtmp  = vlsum(JACM1(1,1,1,ie),nxyz)**1./ldim
          ddavg = ddavg + dtmp/(lx1-1) 
       enddo 
       dxmin = glmin(ddmin,1)

--- a/core/genxyz.f
+++ b/core/genxyz.f
@@ -1496,7 +1496,7 @@ c-----------------------------------------------------------------------
       do ie = 1,nelt
          ddmin = min(ddmin,dxmin_e(ie)) 
          ddmax = max(ddmax,dxmax_e(ie))
-         dtmp  = vlsum(bm1(1,1,1,ie),nxyz)**1./ldim
+         dtmp  = vlsum(bm1(1,1,1,ie),nxyz)**(1./ldim)
          ddavg = ddavg + dtmp/(lx1-1) 
       enddo 
       dxmin = glmin(ddmin,1)


### PR DESCRIPTION
My understanding is, we approximate each element with N^d uniform boxes with total volume = volume of the element.
Therefore, the 1D length scale should be square root for 2D. 