### PR TITLE
Updates for latest parRSB

### DIFF
--- a/core/INPUT
+++ b/core/INPUT
@@ -31,10 +31,10 @@ c
      $       ,nktonv,nhis,lochis(4,lhis+maxobj)
      $       ,ipscal,npscal,ipsco, ifldmhd
      $       ,irstv,irstt,irstim,nmember(maxobj),nobj
-     $       ,ngeom,idpss(ldimt),meshPartitioner
+     $       ,ngeom,idpss(ldimt),fluid_partitioner,solid_partitioner
       common /input2/ matype,nktonv,nhis,lochis,ipscal,npscal,ipsco
      $               ,ifldmhd,irstv,irstt,irstim,nmember,nobj
-     $               ,ngeom,idpss,meshPartitioner
+     $               ,ngeom,idpss,fluid_partitioner,solid_partitioner
 
       logical         if3d,ifflow,ifheat,iftran,ifaxis,ifstrs,ifsplit
      $               ,ifmgrid

--- a/core/PARDICT
+++ b/core/PARDICT
@@ -4,7 +4,7 @@ c     Note: Keys have to be in captial letters
 c
       integer PARDICT_NKEYS
 
-      parameter(PARDICT_NKEYS = 122)
+      parameter(PARDICT_NKEYS = 124)
 
       character*132 pardictkey(PARDICT_NKEYS)
       data
@@ -127,3 +127,5 @@ c
      &  pardictkey(120) / 'TEMPERATURE:BOUNDARYTYPEMAP' /
      &  pardictkey(121) / 'SCALAR%%:BOUNDARYTYPEMAP' /
      &  pardictkey(122) / 'MESH:BOUNDARYIDMAP' /
+     &  pardictkey(123) / 'MESH:FLUIDPARTITIONER' /
+     &  pardictkey(124) / 'MESH:SOLIDPARTITIONER' /

--- a/core/map2.f
+++ b/core/map2.f
@@ -229,7 +229,7 @@ c fluid elements
       neliv = j
 
       nel = neliv
-      call fpartMesh(eid8,vtx8,xyz,lelt,nel,nlv,nekcomm,
+      call fpartMesh(nel,eid8,vtx8,xyz,lelt,nlv,nekcomm,
      $  fluid_partitioner,0,loglevel,ierr)
       call err_chk(ierr,'partMesh fluid failed!$')
 
@@ -282,7 +282,7 @@ c solid elements
          nelit = j
 
          nel = nelit
-         call fpartMesh(eid8,vtx8,xyz,lelt,nel,nlv,nekcomm,
+         call fpartMesh(nel,eid8,vtx8,xyz,lelt,nlv,nekcomm,
      $                  solid_partitioner,0,loglevel,ierr)
          call err_chk(ierr,'partMesh solid failed!$')
 

--- a/core/map2.f
+++ b/core/map2.f
@@ -230,7 +230,7 @@ c fluid elements
 
       nel = neliv
       call fpartMesh(eid8,vtx8,xyz,lelt,nel,nlv,nekcomm,
-     $  meshPartitioner,0,loglevel,ierr)
+     $  fluid_partitioner,0,loglevel,ierr)
       call err_chk(ierr,'partMesh fluid failed!$')
 
       nelv = nel
@@ -283,7 +283,7 @@ c solid elements
 
          nel = nelit
          call fpartMesh(eid8,vtx8,xyz,lelt,nel,nlv,nekcomm,
-     $                  0,0,loglevel,ierr)
+     $                  solid_partitioner,0,loglevel,ierr)
          call err_chk(ierr,'partMesh solid failed!$')
 
          nelt = nelv + nel

--- a/core/partitioner.c
+++ b/core/partitioner.c
@@ -5,20 +5,20 @@
 #endif
 
 #define MAXNV 8 /* maximum number of vertices per element */
-typedef struct{
+
+typedef struct {
   long long vtx[MAXNV];
-  long long eid;
+  ulong eid;
   int proc;
-  uint seq;
 } edata;
 
 #ifdef PARMETIS
 
-#include "parmetis.h"
 #include "defs.h"
+#include "parmetis.h"
 
-int parMETIS_partMesh(int *part, long long *vl, int nel, int nv, int *opt, comm_ext ce)
-{
+int parMETIS_partMesh(int *part, long long *vl, int nel, int nv, int *opt,
+                      comm_ext ce) {
   int i, j;
   int ierrm;
   double time, time0;
@@ -59,48 +59,51 @@ int parMETIS_partMesh(int *part, long long *vl, int nel, int nv, int *opt, comm_
   elmwgt = NULL; /* no weights */
   ncommonnodes = 2;
 
-  part_ = (idx_t*) malloc(nel*sizeof(idx_t));
+  part_ = (idx_t *)malloc(nel * sizeof(idx_t));
 
-  if (sizeof(idx_t) != sizeof(long long)){
+  if (sizeof(idx_t) != sizeof(long long)) {
     printf("ERROR: invalid sizeof(idx_t)!\n");
     goto err;
   }
-  if (nv != 4 && nv != 8){
+  if (nv != 4 && nv != 8) {
     printf("ERROR: nv is %d but only 4 and 8 are supported!\n", nv);
     goto err;
   }
 
   color = MPI_UNDEFINED;
-  if (nel > 0) color = 1;
+  if (nel > 0)
+    color = 1;
   MPI_Comm_split(ce, color, 0, &comms);
   if (color == MPI_UNDEFINED)
     goto end;
 
-  comm_init(&comm,comms);
+  comm_init(&comm, comms);
   if (comm.id == 0)
     printf("Running parMETIS ... "), fflush(stdout);
 
-  nelarray = (long long*) malloc(comm.np*sizeof(long long));
-  MPI_Allgather(&nell, 1, MPI_LONG_LONG_INT, nelarray, 1, MPI_LONG_LONG_INT, comm.c);
-  elmdist = (idx_t*) malloc((comm.np+1)*sizeof(idx_t));
+  nelarray = (long long *)malloc(comm.np * sizeof(long long));
+  MPI_Allgather(&nell, 1, MPI_LONG_LONG_INT, nelarray, 1, MPI_LONG_LONG_INT,
+                comm.c);
+  elmdist = (idx_t *)malloc((comm.np + 1) * sizeof(idx_t));
   elmdist[0] = 0;
-  for (i=0; i<comm.np; ++i)
-    elmdist[i+1] = elmdist[i] + (idx_t)nelarray[i];
+  for (i = 0; i < comm.np; ++i)
+    elmdist[i + 1] = elmdist[i] + (idx_t)nelarray[i];
   free(nelarray);
 
-  evlptr = (idx_t*) malloc((nel+1)*sizeof(idx_t));
+  evlptr = (idx_t *)malloc((nel + 1) * sizeof(idx_t));
   evlptr[0] = 0;
-  for (i=0; i<nel; ++i)
-    evlptr[i+1] = evlptr[i] + nv;
-  nelsm = elmdist[comm.id+1] - elmdist[comm.id];
+  for (i = 0; i < nel; ++i)
+    evlptr[i + 1] = evlptr[i] + nv;
+  nelsm = elmdist[comm.id + 1] - elmdist[comm.id];
   evlptr[nelsm]--;
 
-  if (nv == 8) ncommonnodes = 4;
+  if (nv == 8)
+    ncommonnodes = 4;
   nparts = comm.np;
 
   options[0] = 1;
   options[PMV3_OPTION_DBGLVL] = 0;
-  options[PMV3_OPTION_SEED]   = 0;
+  options[PMV3_OPTION_SEED] = 0;
   if (opt[0] != 0) {
     options[PMV3_OPTION_DBGLVL] = opt[1];
     if (opt[2] != 0) {
@@ -109,37 +112,26 @@ int parMETIS_partMesh(int *part, long long *vl, int nel, int nv, int *opt, comm_
     }
   }
 
-  tpwgts = (real_t*) malloc(ncon*nparts*sizeof(real_t));
-  for (i=0; i<ncon*nparts; ++i)
-    tpwgts[i] = 1./(real_t)nparts;
+  tpwgts = (real_t *)malloc(ncon * nparts * sizeof(real_t));
+  for (i = 0; i < ncon * nparts; ++i)
+    tpwgts[i] = 1. / (real_t)nparts;
 
   if (options[3] == PARMETIS_PSR_UNCOUPLED)
-    for (i=0; i<nel; ++i)
+    for (i = 0; i < nel; ++i)
       part_[i] = comm.id;
 
   comm_barrier(&comm);
   time0 = comm_time();
-  ierrm = ParMETIS_V3_PartMeshKway(elmdist,
-                                   evlptr,
-                                   (idx_t*)vl,
-                                   elmwgt,
-                                   &wgtflag,
-                                   &numflag,
-                                   &ncon,
-                                   &ncommonnodes,
-                                   &nparts,
-                                   tpwgts,
-                                   &ubvec,
-                                   options,
-                                   &edgecut,
-                                   part_,
-                                   &comm.c);
+  ierrm =
+      ParMETIS_V3_PartMeshKway(elmdist, evlptr, (idx_t *)vl, elmwgt, &wgtflag,
+                               &numflag, &ncon, &ncommonnodes, &nparts, tpwgts,
+                               &ubvec, options, &edgecut, part_, &comm.c);
 
   time = comm_time() - time0;
   if (comm.id == 0)
     printf("%lf sec\n", time), fflush(stdout);
 
-  for (i=0; i<nel; ++i)
+  for (i = 0; i < nel; ++i)
     part[i] = part_[i];
 
   free(elmdist);
@@ -149,9 +141,10 @@ int parMETIS_partMesh(int *part, long long *vl, int nel, int nv, int *opt, comm_
   comm_free(&comm);
 
 end:
-  comm_init(&comm,ce);
+  comm_init(&comm, ce);
   comm_allreduce(&comm, gs_int, gs_min, &ierrm, 1, &ibuf);
-  if (ierrm != METIS_OK) goto err;
+  if (ierrm != METIS_OK)
+    goto err;
   return 0;
 
 err:
@@ -159,9 +152,8 @@ err:
 }
 #endif
 
-void printPartStat(long long *vtx, int nel, int nv, comm_ext ce)
-{
-  int i,j;
+void print_part_stat(long long *vtx, int nel, int nv, comm_ext ce) {
+  int i, j;
 
   struct comm comm;
   int np, id;
@@ -182,20 +174,22 @@ void printPartStat(long long *vtx, int nel, int nv, comm_ext ce)
   int numPoints;
   long long *data;
 
-  comm_init(&comm,ce);
+  comm_init(&comm, ce);
   np = comm.np;
   id = comm.id;
 
-  if (np == 1) return;
+  if (np == 1)
+    return;
 
-  numPoints = nel*nv;
-  data = (long long*) malloc(numPoints*sizeof(long long));
-  for(i = 0; i < numPoints; i++) data[i] = vtx[i];
+  numPoints = nel * nv;
+  data = (long long *)malloc(numPoints * sizeof(long long));
+  for (i = 0; i < numPoints; i++)
+    data[i] = vtx[i];
 
   gsh = gs_setup(data, numPoints, &comm, 0, gs_pairwise, 0);
 
   pw_data_nmsg(gsh, &Nmsg);
-  Ncomm = (int *) malloc(Nmsg*sizeof(int));
+  Ncomm = (int *)malloc(Nmsg * sizeof(int));
   pw_data_size(gsh, Ncomm);
 
   gs_free(gsh);
@@ -204,30 +198,30 @@ void printPartStat(long long *vtx, int nel, int nv, comm_ext ce)
   ncMax = Nmsg;
   ncMin = Nmsg;
   ncSum = Nmsg;
-  comm_allreduce(&comm, gs_int, gs_max, &ncMax , 1, &b);
-  comm_allreduce(&comm, gs_int, gs_min, &ncMin , 1, &b);
-  comm_allreduce(&comm, gs_int, gs_add, &ncSum , 1, &b);
+  comm_allreduce(&comm, gs_int, gs_max, &ncMax, 1, &b);
+  comm_allreduce(&comm, gs_int, gs_min, &ncMin, 1, &b);
+  comm_allreduce(&comm, gs_int, gs_add, &ncSum, 1, &b);
 
   nsMax = Ncomm[0];
   nsMin = Ncomm[0];
   nsSum = Ncomm[0];
-  for (i=1; i<Nmsg; ++i){
-    nsMax = Ncomm[i] > Ncomm[i-1] ? Ncomm[i] : Ncomm[i-1];
-    nsMin = Ncomm[i] < Ncomm[i-1] ? Ncomm[i] : Ncomm[i-1];
+  for (i = 1; i < Nmsg; ++i) {
+    nsMax = Ncomm[i] > Ncomm[i - 1] ? Ncomm[i] : Ncomm[i - 1];
+    nsMin = Ncomm[i] < Ncomm[i - 1] ? Ncomm[i] : Ncomm[i - 1];
     nsSum += Ncomm[i];
   }
-  comm_allreduce(&comm, gs_int, gs_max, &nsMax , 1, &b);
-  comm_allreduce(&comm, gs_int, gs_min, &nsMin , 1, &b);
+  comm_allreduce(&comm, gs_int, gs_max, &nsMax, 1, &b);
+  comm_allreduce(&comm, gs_int, gs_min, &nsMin, 1, &b);
 
   nssMin = nsSum;
   nssMax = nsSum;
   nssSum = nsSum;
-  comm_allreduce(&comm, gs_int, gs_max, &nssMax , 1, &b);
-  comm_allreduce(&comm, gs_int, gs_min, &nssMin , 1, &b);
-  comm_allreduce(&comm, gs_long_long, gs_add, &nssSum , 1, &b_long_long);
+  comm_allreduce(&comm, gs_int, gs_max, &nssMax, 1, &b);
+  comm_allreduce(&comm, gs_int, gs_min, &nssMin, 1, &b);
+  comm_allreduce(&comm, gs_long_long, gs_add, &nssSum, 1, &b_long_long);
 
-  nsSum = nsSum/Nmsg;
-  comm_allreduce(&comm, gs_int, gs_add, &nsSum , 1, &b);
+  nsSum = nsSum / Nmsg;
+  comm_allreduce(&comm, gs_int, gs_add, &nsSum, 1, &b);
 
   nelMax = nel;
   nelMin = nel;
@@ -235,57 +229,53 @@ void printPartStat(long long *vtx, int nel, int nv, comm_ext ce)
   comm_allreduce(&comm, gs_int, gs_min, &nelMin, 1, &b);
 
   if (id == 0) {
-    printf(
-      " nElements   max/min/bal: %d %d %.2f\n",
-      nelMax, nelMin, (double)nelMax/nelMin);
-    printf(
-      " nMessages   max/min/avg: %d %d %.2f\n",
-      ncMax, ncMin, (double)ncSum/np);
-    printf(
-      " msgSize     max/min/avg: %d %d %.2f\n",
-      nsMax, nsMin, (double)nsSum/np);
-    printf(
-      " msgSizeSum  max/min/avg: %d %d %.2f\n",
-      nssMax, nssMin, (double)nssSum/np);
+    printf(" nElements   max/min/bal: %d %d %.2f\n", nelMax, nelMin,
+           (double)nelMax / nelMin);
+    printf(" nMessages   max/min/avg: %d %d %.2f\n", ncMax, ncMin,
+           (double)ncSum / np);
+    printf(" msgSize     max/min/avg: %d %d %.2f\n", nsMax, nsMin,
+           (double)nsSum / np);
+    printf(" msgSizeSum  max/min/avg: %d %d %.2f\n", nssMax, nssMin,
+           (double)nssSum / np);
     fflush(stdout);
   }
 
   comm_free(&comm);
 }
 
-int redistributeData(int *nel_, long long *vl, long long *el, int *part, int *seq, int nv, int lelt,
-                     struct comm *comm) {
-  int nel=*nel_;
+int redistribute_data(int *nel_, long long *vl, long long *el, int *part,
+                      int nv, int lelt, struct comm *comm) {
+  int nel = *nel_;
 
   struct crystal cr;
   struct array eList;
   edata *data;
 
-  int count,e,n,ibuf;
+  int count, e, n, ibuf;
 
   /* redistribute data */
   array_init(edata, &eList, nel), eList.n = nel;
-  for(data = eList.ptr, e = 0; e < nel; ++e) {
-    data[e].proc= part[e];
+  for (data = eList.ptr, e = 0; e < nel; ++e) {
+    data[e].proc = part[e];
     data[e].eid = el[e];
-    for(n = 0; n < nv; ++n) {
-      data[e].vtx[n] = vl[e*nv + n];
+    for (n = 0; n < nv; ++n) {
+      data[e].vtx[n] = vl[e * nv + n];
     }
   }
 
-  if(seq!=NULL){
-    for(data=eList.ptr, e=0; e<nel; ++e)
-      data[e].seq=seq[e];
-  }
-
-  crystal_init(&cr,comm);
+  crystal_init(&cr, comm);
   sarray_transfer(edata, &eList, proc, 0, &cr);
   crystal_free(&cr);
 
-  *nel_=nel=eList.n;
+  buffer bfr;
+  buffer_init(&bfr, 1024);
+  sarray_sort(edata, eList.ptr, eList.n, eid, 1, &bfr);
+  buffer_free(&bfr);
 
+  *nel_ = nel = eList.n;
   count = 0;
-  if (nel > lelt) count = 1;
+  if (nel > lelt)
+    count = 1;
   comm_allreduce(comm, gs_int, gs_add, &count, 1, &ibuf);
   if (count > 0) {
     count = nel;
@@ -295,17 +285,10 @@ int redistributeData(int *nel_, long long *vl, long long *el, int *part, int *se
     return 1;
   }
 
-  //TODO: sort by seq
-  if(seq!=NULL){
-    buffer bfr; buffer_init(&bfr,1024);
-    sarray_sort(edata,eList.ptr,eList.n,seq,0,&bfr);
-    buffer_free(&bfr);
-  }
-
-  for(data = eList.ptr, e = 0; e < nel; ++e) {
+  for (data = eList.ptr, e = 0; e < nel; ++e) {
     el[e] = data[e].eid;
-    for(n = 0; n < nv; ++n) {
-      vl[e*nv + n] = data[e].vtx[n];
+    for (n = 0; n < nv; ++n) {
+      vl[e * nv + n] = data[e].vtx[n];
     }
   }
 
@@ -314,22 +297,25 @@ int redistributeData(int *nel_, long long *vl, long long *el, int *part, int *se
   return 0;
 }
 
-#define fpartMesh FORTRAN_UNPREFIXED(fpartmesh,FPARTMESH)
-void fpartMesh(long long *el, long long *vl, double *xyz, const int *lelt, int *nell, const int *nve,
-               int *fcomm, int *fpartitioner, int *falgo, int *loglevel, int *rtval)
-{
+#define fpartmesh FORTRAN_UNPREFIXED(fpartmesh, FPARTMESH)
+
+void fpartmesh(int *nell, long long *el, long long *vl, double *xyz,
+               const int *const lelm, const int *const nve,
+               const int *const fcomm, const int *const fpartitioner,
+               const int *const falgo, const int *const loglevel, int *rtval) {
   struct comm comm;
 
-  int nel, nv, partitioner, algo;
+  int nel, nv, lelt, partitioner, algo;
   int e, n;
   int count, ierr, ibuf;
-  int *part,*seq;
+  int *part;
   int opt[3];
 
-  nel  = *nell;
-  nv   = *nve;
+  lelt = *lelm;
+  nel = *nell;
+  nv = *nve;
   partitioner = *fpartitioner;
-  algo = *falgo; // 0 - Lanczos, 1 - MG (Used only when partitioner = 1)
+  algo = *falgo;
 
 #if defined(MPI)
   comm_ext cext = MPI_Comm_f2c(*fcomm);
@@ -338,75 +324,45 @@ void fpartMesh(long long *el, long long *vl, double *xyz, const int *lelt, int *
 #endif
   comm_init(&comm, cext);
 
-  part = (int *)malloc(*lelt * sizeof(int));
-  seq  = (int *)malloc(*lelt * sizeof(int));
-
   ierr = 1;
+  part = (int *)malloc(lelt * sizeof(int));
 #if defined(PARRSB)
-  // General options
-  //   partitioner: Partition algo: 0 - RSB, 1 - RCB, 2 - RIB (Default: 0)
-  //   verbose_level: Verbose level: 0, 1, 2, .. etc (Default: 1)
-  //   profile_level: Profile level: 0, 1, 2, .. etc (Default: 1)
-  //   two_level: Use two level partitioning algo (Default: 0)
-  //   repair: Repair disconnected components: 0 - No, 1 - Yes (Default: 0)
-  // RSB specific
-  //   rsb_algo: RSB algo: 0 - Lanczos, 1 - RQI (Default: 0)
-  //   rsb_pre: RSB pre-partition algo: 0 - None, 1 - RCB , 2 - RIB (Default: 1)
-  //   rsb_max_iter: Maximum iterations in Lanczos or RQI (Default: 50)
-  //   rsb_tol: Tolerance for Lanczos or RQI (Default: 1e-3)
-  // RSB-MG specific
-  //   rsb_mg_grammian: MG Grammian: 0 or 1 (Default: 0)
-  //   rsb_mg_factor: MG Coarsening factor (Default: 2, should be > 1)
-  // RSB-Lanczos specific
-  //   rsb_lanczos_max_restarts: Maximum restarts in Lanczos (Default: 50)
-
   parrsb_options options = parrsb_default_options;
-  if (partitioner & 1)
-    options.partitioner = 0;
-  else if (partitioner & 2)
-    options.partitioner = 1;
-
-  if (partitioner & 1)
+  options.partitioner = partitioner;
+  if (partitioner == 0) // RSB
     options.rsb_algo = algo;
 
   if (*loglevel > 2)
-    printPartStat(vl, nel, nv, cext);
+    print_part_stat(vl, nel, nv, cext);
 
-  ierr = parrsb_part_mesh(part, seq, vl, xyz, nel, nv, options, comm.c);
+  ierr = parrsb_part_mesh(part, vl, xyz, NULL, nel, nv, &options, comm.c);
   if (ierr != 0)
     goto err;
 
-  ierr = redistributeData(&nel, vl, el, part, seq, nv, *lelt, &comm);
+  ierr = redistribute_data(&nel, vl, el, part, nv, lelt, &comm);
   if (ierr != 0)
     goto err;
 
   if (*loglevel > 2)
-    printPartStat(vl, nel, nv, cext);
+    print_part_stat(vl, nel, nv, cext);
 
 #elif defined(PARMETIS)
-  int metis;
-  metis = partitioner & 4;
-
-  if (metis) {
+  if (partitioner == 8) {
     opt[0] = 1;
     opt[1] = 0; /* verbosity */
     opt[2] = comm.np;
 
-    ierr = parMETIS_partMesh(part,vl,nel,nv,opt,comm.c);
-
-    ierr = redistributeData(&nel,vl,el,part,NULL,nv,*lelt,&comm);
+    ierr = parMETIS_partMesh(part, vl, nel, nv, opt, comm.c);
+    ierr = redistribute_data(&nel, vl, el, part, NULL, nv, lelt, &comm);
     if (ierr != 0)
       goto err;
   }
 #endif
-
   free(part);
-  free(seq);
+  comm_free(&comm);
 
   *nell = nel;
   *rtval = 0;
-  if (comm.id == 0) printf("\n");
-  fflush(stdout);
   return;
 
 err:
@@ -414,9 +370,45 @@ err:
   *rtval = 1;
 }
 
-#define fprintPartStat FORTRAN_UNPREFIXED(printpartstat,PRINTPARTSTAT)
-void fprintPartStat(long long *vtx, int *nel, int *nv, int *comm)
-{
+#define fpartmesh_greedy FORTRAN_UNPREFIXED(fpartmesh_greedy, FPARTMESH_GRREDY)
+
+void fpartmesh_greedy(int *const nel2, long long *const el2,
+                      long long *const vl2, const int *const nel1,
+                      const long long *const vl1, const int *const lelm_,
+                      const int *const nv, const int *const fcomm,
+                      int *const rtval) {
+#if defined(PARRSB)
+  const int lelm = *lelm_;
+
+  struct comm comm;
+#if defined(MPI)
+  comm_ext cext = MPI_Comm_f2c(*fcomm);
+#else
+  comm_ext cext = 0;
+#endif
+  comm_init(&comm, cext);
+
+  int *const part = (int *)malloc(lelm * sizeof(int));
+  parrsb_part_solid(part, vl2, *nel2, vl1, *nel1, *nv, comm.c);
+
+  int ierr = redistribute_data(nel2, vl2, el2, part, *nv, lelm, &comm);
+  if (ierr != 0)
+    goto err;
+  *rtval = 0;
+
+  free(part);
+  comm_free(&comm);
+  return;
+
+err:
+  fflush(stdout);
+  *rtval = 1;
+#endif
+}
+
+#define fprintpartstat FORTRAN_UNPREFIXED(printpartstat, PRINTPARTSTAT)
+
+void fprintpartstat(long long *vtx, int *nel, int *nv, int *comm) {
 
 #if defined(MPI)
   comm_ext c = MPI_Comm_f2c(*comm);
@@ -424,5 +416,5 @@ void fprintPartStat(long long *vtx, int *nel, int *nv, int *comm)
   comm_ext c = 0;
 #endif
 
-  printPartStat(vtx, *nel, *nv, c);
+  print_part_stat(vtx, *nel, *nv, c);
 }

--- a/core/reader_par.f
+++ b/core/reader_par.f
@@ -152,7 +152,8 @@ C
          idpss(i) = -1
       enddo 
 
-      meshPartitioner=3 ! HYBRID (RSB+RCB)
+      fluid_partitioner=0 ! RSB
+      solid_partitioner=1 ! RCB
       connectivityTol=0.2
 
       ifprojfld(0) = .false. 
@@ -885,13 +886,35 @@ c set partitioner options
       call finiparser_getString(c_out,'mesh:partitioner',ifnd)
       call capit(c_out,132)
       if(index(c_out,'RSB').eq.1) then
-         meshPartitioner=1
-      else if (index(c_out,'RCBRSB').eq.1) then
-         meshPartitioner=3
-      else if(index(c_out,'RCB').eq.1) then
-         meshPartitioner=2
+         fluid_partitioner=0
+         solid_partitioner=0
+      else if (index(c_out,'RCB').eq.1) then
+         fluid_partitioner=1
+         solid_partitioner=1
       else if (index(c_out,'METIS').eq.1) then
-         meshPartitioner=4
+         fluid_partitioner=8
+      endif
+
+c set partitioner options
+      call finiparser_getString(c_out,'mesh:fluidpartitioner',ifnd)
+      call capit(c_out,132)
+      if(index(c_out,'RSB').eq.1) then
+         fluid_partitioner=0
+      else if (index(c_out,'RCB').eq.1) then
+         fluid_partitioner=1
+      else if (index(c_out,'METIS').eq.1) then
+         fluid_partitioner=8
+      endif
+
+c set partitioner options
+      call finiparser_getString(c_out,'mesh:solidpartitioner',ifnd)
+      call capit(c_out,132)
+      if(index(c_out,'RSB').eq.1) then
+         solid_partitioner=0
+      else if (index(c_out,'RCB').eq.1) then
+         solid_partitioner=1
+      else if (index(c_out,'METIS').eq.1) then
+         solid_partitioner=8
       endif
 
 c set connectivity tolerance
@@ -1099,7 +1122,8 @@ C
 
       call bcast(idpss    ,  ldimt*isize)
 
-      call bcast(meshPartitioner,isize)
+      call bcast(fluid_partitioner,isize)
+      call bcast(solid_partitioner,isize)
       call bcast(connectivityTol,wdsize)
 
       call bcast(iftmsh   , (ldimt1+1)*lsize)

--- a/core/reader_rea.f
+++ b/core/reader_rea.f
@@ -48,7 +48,8 @@ C
 
 c     Set default values for parCon and parRSB
       connectivityTol=0.2
-      meshPartitioner=3 ! HYBRID (RSB+RCB)
+      fluid_partitioner=0 ! RSB
+      solid_partitioner=1 ! RCB
 
 c     Use same tolerances for all fields 
       restol(0) = param(22) ! mesh


### PR DESCRIPTION
This PR also adds two `.par` file options to control fluid and solid partitioner separately.
- mesh:fluidPartitioner (defaults to RSB)
- mesh:solidPartitioner (defaults to RCB)