### PR TITLE
[neknek] Add all outflow BC in fix_surface_flux

### DIFF
--- a/core/multimesh.f
+++ b/core/multimesh.f
@@ -544,7 +544,8 @@ c     velocity.
        itchk = 0
        do e=1,nelv
        do f=1,2*ldim
-         if (cbc(f,e,1).eq.'o  '.or.cbc(f,e,1).eq.'O  ') then
+         if (cbc(f,e,1).eq.'o  '.or.cbc(f,e,1).eq.'O  '.or.
+     $       cbc(f,e,1).eq.'on '.or.cbc(f,e,1).eq.'ON ') then
          if (intflag(f,e).eq.0) then
            itchk = 1
          endif


### PR DESCRIPTION
For SYM + Outflow + IFSTRS=T, ON is needed but it's not included in the `fix_surface_flux`