### PR TITLE
(restart) Fix int overflow in header

### DIFF
--- a/core/ic.f
+++ b/core/ic.f
@@ -2674,7 +2674,8 @@ c-----------------------------------------------------------------------
            if(i.eq.nid) nelr = nelr + 1
         enddo
         nelBr = igl_running_sum(nelr) - nelr 
-        offs = offs0 + nelBr*isize
+        offs = nelBr ! cast to int*8
+        offs = offs0 + offs*isize
 
         call addfid(hname,fid0r)
         call byte_open_mpi(hname,ifh_mbyte,.true.,ierr)

--- a/core/prepost.f
+++ b/core/prepost.f
@@ -2127,7 +2127,8 @@ c     check pressure format
       ! write global element numbering for this group
       if(nid.eq.pid0) then
         if(ifmpiio) then
-          ioff = iHeaderSize + 4 + nelB*isize
+          ioff = nelB ! cast to int*8
+          ioff = iHeaderSize + 4 + ioff*isize
           call byte_set_view (ioff,ifh_mbyte)
           call byte_write_mpi(lglist(1),lglist(0),-1,ifh_mbyte,ierr)
         else


### PR DESCRIPTION
This fix the int over flow for a case with huge number of elements per rank.