### PR TITLE
Fix batch size and RMA size

### DIFF
--- a/core/ic.f
+++ b/core/ic.f
@@ -2002,7 +2002,7 @@ c-----------------------------------------------------------------------
             endif
 
 #ifdef MPI
-            nbatch = (nelrr - 1) / lbrst + 1
+            nbatch = (nelgt - 1) / lbrst + 1
             nbatch = iglmax(nbatch, 1)
 
             do ibatch = 1,nbatch
@@ -2213,7 +2213,7 @@ c-----------------------------------------------------------------------
             endif
 
 #ifdef MPI
-            nbatch = (nelrr - 1) / lbrst + 1
+            nbatch = (nelgt - 1) / lbrst + 1
             nbatch = iglmax(nbatch, 1)
 
             do ibatch = 1,nbatch
@@ -2582,7 +2582,7 @@ c
         disp_unit = 4
         win_size = int(disp_unit,8)*size(wk)
         if (lbrst.lt.nelt) then
-          win_size = int(disp_unit,8) * (7*lx1*ly1*lz1*lbrst)
+          win_size = int(disp_unit,8)*(7*lx1*ly1*lz1*lbrst)*(wdsize/4)
         endif
 
         if (commrs .eq. MPI_COMM_NULL) then


### PR DESCRIPTION
1. For batched restart, the "batch" is defined by the partition of global element id at destination. Therefore, it should use `nelgt` to determine the batch, not `nelrr`.

2. When batched RMA is used, the allocated shared memory should match the type of real, which is `real*8` by default. This require extra multiply of `(wdsize/4)`.

The first error will make the read incomplete and missing some elements. 
The second error cause an MPI error complaining MPI_PUT has invalid address. 

This is more likely to happen when using h-refine restart.