### PR TITLE
PnPn-2 + restart : fix pressure field

### DIFF
--- a/core/prepost.f
+++ b/core/prepost.f
@@ -1382,6 +1382,9 @@ c-----------------------------------------------------------------------
 
       param(63) = 1 ! Enforce 64-bit output
       if_full_pres = .true. !Preserve mesh 2 pressure
+      if (lx1.ne.lx2) if_full_pres = .false. ! avoid unecessary zero pressure 
+                                             ! values to be published (and read)
+                                             ! in rs_* files.
 
       if (lastep.ne.1) call restart_save(iosave,nfld_save)
 


### PR DESCRIPTION
Using the PnPn-2 formulation, the subroutine now interpolate the pressure field onto the velocity mesh instead of copying it. It prevents zeros values on GLL points to be introduced in the simulation .