### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         test_case: [ 

--- a/core/comm_mpi.f
+++ b/core/comm_mpi.f
@@ -116,8 +116,10 @@ c-----------------------------------------------------------------------
          do n=0,nsessions-1
             npall=npall+npsess(n)
          enddo
-         if (npall.ne.np_global) 
-     &      call exitti('Number of ranks does not match!$',npall)
+         if (npall.ne.np_global) then
+           write(6,*) 'Number of ranks does not match!',npall,np_global
+           call exitt
+         endif
   
          ! Assign key for splitting into multiple groups
          nid_global_root_next=0

--- a/core/makenek.inc
+++ b/core/makenek.inc
@@ -552,6 +552,7 @@ if ! cat SIZE | grep -q 'SIZE.inc' ; then
   if ! cat SIZE | grep -qi 'lxo' ; then
      echo >>SIZE
      echo 'c automatically added by makenek' >>SIZE
+     echo '      integer lxo' >> SIZE
      echo '      parameter(lxo   = lx1) ! max output grid size (lxo>=lx1)' >>SIZE
   fi
   if ! cat SIZE | grep -qi 'ax1' ; then
@@ -564,6 +565,7 @@ if ! cat SIZE | grep -q 'SIZE.inc' ; then
      cat SIZE | grep -iv lxs > SIZE.x; mv SIZE.x SIZE  # Clean existing SIZE file of old version
      echo >>SIZE
      echo 'c automatically added by makenek' >>SIZE
+     echo '      integer lxs,lys,lzs' >> SIZE
      echo '      parameter (lxs=1,lys=lxs,lzs=(lxs-1)*(ldim-2)+1) !New Pressure Preconditioner' >> SIZE
 
   fi
@@ -576,33 +578,39 @@ if ! cat SIZE | grep -q 'SIZE.inc' ; then
   if ! cat SIZE | grep -qi 'lfdm' ; then
      echo >>SIZE
      echo 'c automatically added by makenek' >>SIZE
+     echo '      integer lfdm' >> SIZE
      echo '      parameter (lfdm=0)  ! == 1 for fast diagonalization method' >> SIZE
   fi
   if ! cat SIZE | grep -qi 'nsessmax' ; then
      echo >>SIZE
      echo 'c automatically added by makenek' >>SIZE
+     echo '      integer nsessmax' >> SIZE
      echo '      parameter (nsessmax=1)  ! max sessions to NEKNEK' >> SIZE
   fi
   if ! cat SIZE | grep -qi 'nmaxl_nn' ; then
      echo >>SIZE
      echo 'c automatically added by makenek' >>SIZE
+     echo '      integer nmaxl_nn' >> SIZE
      echo '      parameter (nmaxl_nn=' >> SIZE
      echo '     $          min(1+(nsessmax-1)*2*ldim*lxz*lelt,2*ldim*lxz*lelt))' >>SIZE
   fi
   if ! cat SIZE | grep -qi 'nfldmax_nn' ; then
      echo >>SIZE
      echo 'c automatically added by makenek' >>SIZE
+     echo '      integer nfldmax_nn' >> SIZE
      echo '      parameter (nfldmax_nn=' >> SIZE
      echo '     $          min(1+(nsessmax-1)*(ldim+1+ldimt),ldim+1+ldimt))' >>SIZE
   fi
   if ! cat SIZE | grep -qi 'nio' ; then
      echo >>SIZE
      echo 'c automatically added by makenek' >>SIZE
+     echo '      integer nio' >> SIZE
      echo '      common/IOFLAG/nio  ! for logfile verbosity control' >> SIZE
   fi
   if ! cat SIZE | grep -qi 'lhref' ; then
      echo >>SIZE
      echo 'c automatically added by makenek' >>SIZE
+     echo '      integer lhref' >> SIZE
      echo '      parameter (lhref=10)' >> SIZE
   fi
 fi

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -1891,7 +1891,7 @@ class IO_Test(NekTestCase):
         self.config_size()
 
         # read write tests
-        self.build_nek(usr_file="io_test")
+        self.build_nek(usr_file="io_test", opts={"FFLAGS": "-mcmodel=medium"})
         self.config_parfile({"MESH": {"hrefine": "1"}})
         self.run_nek(step_limit=None)
         phrase = self.get_phrase_from_log("All I/O tests PASSED")
@@ -1920,8 +1920,7 @@ class IO_Test(NekTestCase):
         self.assertDelayedFailures()
 
         # full restart
-        self.run_genmap(rea_file="io_test_rs")
-        self.build_nek(usr_file="io_test_rs")
+        self.build_nek(usr_file="io_test_rs", opts={"FFLAGS": "-mcmodel=medium"})
         self.config_parfile({"MESH": {"hrefine": "1"}})
 
         cls = self.__class__
@@ -1947,7 +1946,7 @@ class IO_Test(NekTestCase):
 
         self.size_params["lx2"] = "lx1-0"
         self.config_size()
-        self.build_nek(usr_file="io_test_rs")
+        self.build_nek(usr_file="io_test_rs", opts={"FFLAGS": "-mcmodel=medium"})
 
         self.config_parfile({"GENERAL": {"timestepper": "bdf3"}})
         self.config_parfile({"GENERAL": {"numsteps": "200"}})

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -1206,10 +1206,12 @@ class Ethier(NekTestCase):
         self.build_nek()
         self.run_nek(step_limit=1000)
 
-        np_err = self.get_value_from_log(label="Number of MPI ranks :", column=-1, row=0)
-        self.assertAlmostEqualDelayed(
-            np_err, target_val=self.parallel_procs, delta=0, label="np err"
+        np_err = int(
+            self.get_value_from_log(
+                label="Number of MPI ranks :", column=-1, row=0
+            )
         )
+        self.assertEqual(np_err, self.parallel_procs, "Number of MPI ranks mismatch")
 
         herr = self.get_value_from_log(label="hpts err", column=-1, row=-1)
         self.assertAlmostEqualDelayed(
@@ -1261,10 +1263,12 @@ class Ethier(NekTestCase):
 
         self.run_nek(step_limit=1000)
 
-        np_err = self.get_value_from_log(label="Number of MPI ranks :", column=-1, row=0)
-        self.assertAlmostEqualDelayed(
-            np_err, target_val=self.parallel_procs, delta=0, label="np err"
+        np_err = int(
+            self.get_value_from_log(
+                label="Number of MPI ranks :", column=-1, row=0
+            )
         )
+        self.assertEqual(np_err, self.parallel_procs, "Number of MPI ranks mismatch")
 
         gmres = self.get_value_from_log("gmres ", column=-7)
         self.assertAlmostEqualDelayed(

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -1206,6 +1206,11 @@ class Ethier(NekTestCase):
         self.build_nek()
         self.run_nek(step_limit=1000)
 
+        np_err = self.get_value_from_log(label="Number of MPI ranks :", column=-1, row=0)
+        self.assertAlmostEqualDelayed(
+            np_err, target_val=self.parallel_procs, delta=0, label="np err"
+        )
+
         herr = self.get_value_from_log(label="hpts err", column=-1, row=-1)
         self.assertAlmostEqualDelayed(
             herr, target_val=1.3776e-08, delta=1e-08, label="hpts err"
@@ -1255,6 +1260,11 @@ class Ethier(NekTestCase):
         self.config_parfile({"PRESSURE": {"preconditioner": "semg_amg"}})
 
         self.run_nek(step_limit=1000)
+
+        np_err = self.get_value_from_log(label="Number of MPI ranks :", column=-1, row=0)
+        self.assertAlmostEqualDelayed(
+            np_err, target_val=self.parallel_procs, delta=0, label="np err"
+        )
 
         gmres = self.get_value_from_log("gmres ", column=-7)
         self.assertAlmostEqualDelayed(

--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -1874,7 +1874,8 @@ class IO_Test(NekTestCase):
 
     def setUp(self):
         self.build_tools(["genmap"])
-        self.run_genmap()
+        self.run_genmap(rea_file="io_test")
+        self.run_genmap(rea_file="io_test_rs")
 
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):

--- a/short_tests/eddy/SIZE.legacy
+++ b/short_tests/eddy/SIZE.legacy
@@ -2,6 +2,8 @@ C     Dimension file to be included
 C
 C     HCUBE array dimensions
 C
+      integer ldim,lx1,ly1,lz1,lelt,lelv,lxd,lyd,lzd,lelx,lely,lelz,lzl
+     $      , lx2,ly2,lz2,lx3,ly3,lz3,lp,lelg
       parameter (ldim=2)
       parameter (lx1=8,ly1=lx1,lz1=1,lelt=300,lelv=lelt)
       parameter (lxd=12,lyd=lxd,lzd=1)
@@ -23,6 +25,7 @@ c     parameter (lpelv=lelv,lpelt=lelt,lpert=3)  ! perturbation
 c     parameter (lpx1=lx1,lpy1=ly1,lpz1=lz1)     ! array sizes
 c     parameter (lpx2=lx2,lpy2=ly2,lpz2=lz2)
 c
+      integer lpelv,lpelt,lpert,lpx1,lpy1,lpz1,lpx2,lpy2,lpz2
       parameter (lpelv=1,lpelt=1,lpert=1)        ! perturbation
       parameter (lpx1=1,lpy1=1,lpz1=1)           ! array sizes
       parameter (lpx2=1,lpy2=1,lpz2=1)
@@ -31,11 +34,13 @@ c     parameter (lbelv=lelv,lbelt=lelt)          ! MHD
 c     parameter (lbx1=lx1,lby1=ly1,lbz1=lz1)     ! array sizes
 c     parameter (lbx2=lx2,lby2=ly2,lbz2=lz2)
 c
+      integer lbelv,lbelt,lbx1,lby1,lbz1,lbx2,lby2,lbz2
       parameter (lbelv=1,lbelt=1)                ! MHD
       parameter (lbx1=1,lby1=1,lbz1=1)           ! array sizes
       parameter (lbx2=1,lby2=1,lbz2=1)
  
 C     LX1M=LX1 when there are moving meshes; =1 otherwise
+      integer lx1m,ly1m,lz1m,ldimt,ldimt1,ldimt3
       parameter (lx1m=1,ly1m=1,lz1m=1)
       parameter (ldimt= 2)                       ! 2 passive scalars + T
       parameter (ldimt1=ldimt+1)
@@ -43,6 +48,8 @@ C     LX1M=LX1 when there are moving meshes; =1 otherwise
 c
 c     Note:  In the new code, LELGEC should be about sqrt(LELG)
 c
+      INTEGER LELGEC,LXYZ2,LXZ21
+     $      , LMAXV,LMAXT,LMAXP,LXZ,LORDER,MAXOBJ,MAXMBR,lhis
       PARAMETER (LELGEC = 1)
       PARAMETER (LXYZ2  = 1)
       PARAMETER (LXZ21  = 1)
@@ -58,6 +65,7 @@ c
 C
 C     Common Block Dimensions
 C
+      INTEGER LCTMP0,LCTMP1
       PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)
       PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
 C
@@ -65,25 +73,31 @@ C     The parameter LVEC controls whether an additional 42 field arrays
 C     are required for Steady State Solutions.  If you are not using
 C     Steady State, it is recommended that LVEC=1.
 C
+      INTEGER LVEC
       PARAMETER (LVEC=1)
 C
 C     Uzawa projection array dimensions
 C
+      integer mxprev,lgmres
       parameter (mxprev = 20)
       parameter (lgmres = 30)
 C
 C     Split projection array dimensions
 C
+      integer lmvec,lsvec,lstore
       parameter(lmvec = 1)
       parameter(lsvec = 1)
       parameter(lstore=lmvec*lsvec)
 c
 c     NONCONFORMING STUFF
 c
+      integer maxmor
       parameter (maxmor = lelt)
 C
 C     Array dimensions
 C
+      INTEGER NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
+     $      , NX3,NY3,NZ3,NDIM,NFIELD,NPERT,NID,NXD,NYD,NZD
       COMMON/DIMN/NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
      $,NX3,NY3,NZ3,NDIM,NFIELD,NPERT,NID
      $,NXD,NYD,NZD

--- a/short_tests/io_test/io_test.usr
+++ b/short_tests/io_test/io_test.usr
@@ -1699,7 +1699,7 @@ c     fld binary
       param(66) = 4.0           ! file format
       time = time_test
       call fields_restore
-      call prepost (.true.,prefix)
+      call prepost (.true.,'   ')
       ifile = ifile +1
 
       if_full_pres = .false.    ! pressure writing format
@@ -1771,7 +1771,7 @@ c     fld ascii
       param(66) = -4.0          ! file format
       time = time_test
       call fields_restore
-      call prepost (.true.,prefix)
+      call prepost (.true.,'   ')
       ifile = ifile +1
 
       if_full_pres = .false.    ! pressure writing format

--- a/short_tests/lib/nekBinBuild.py
+++ b/short_tests/lib/nekBinBuild.py
@@ -67,6 +67,8 @@ def build_nek(source_root, usr_file, cwd=None, opts=None, verbose=False):
         my_env["CC"] = _opts.get("CC")
     if _opts.get("PPLIST"):
         my_env["PPLIST"] = _opts.get("PPLIST")
+    if _opts.get("FFLAGS"):
+        my_env["FFLAGS"] = _opts.get("FFLAGS")
 
     makenek_in = Path(source_root) / "bin" / "makenek"
     logfile = Path(cwd) / "build.log"

--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -63,7 +63,7 @@ def config_parfile(opts, infile, outfile):
     """
     import configparser
 
-    parfile = configparser.SafeConfigParser()
+    parfile = configparser.ConfigParser()
     parfile.read(infile)
 
     for section, name_vals in list(opts.items()):


### PR DESCRIPTION
- Address `IO_Test` issues:
  - Fix an uninitialized string.
  - Build `IO_Test` with `-mcmodel=medium`.
  - Add `genmap` support for `io_test_rs`.

- Replace deprecated `SafeConfigParser` with `ConfigParser`.
- Add missing implicit declarations to `makenek.inc` and `SIZE.legacy`.
- Switch GitHub workflow back to `ubuntu-22.04`.
- Add "Number of MPI" check to `Ethier`.

Action: https://github.com/yslan/Nek5000/actions/runs/19414952903