### PR TITLE
Fix typo: vr_ifaxis -> chk_axis in drive1.f

### DIFF
--- a/core/drive1.f
+++ b/core/drive1.f
@@ -110,7 +110,7 @@ c      COMMON /SCRCG/ DUMM10(LX1,LY1,LZ1,LELT,1)
       call count_bdry   ! count the number of faces with assigned BCs
       call fix_geom
 
-      call vr_ifaxis        ! verify axisymmetric mesh/BC requirements
+      call chk_axis         ! verify axisymmetric mesh/BC requirements
       call vrdsmsh          ! verify mesh topology
       call mesh_metrics     ! print some metrics
 


### PR DESCRIPTION
Commit f99f4b5 introduced a call to vr_ifaxis in drive1.f:113, but the subroutine is defined as chk_axis in bdry.f:2235. This causes undefined symbol errors when building with ifaxis=true.