### PR TITLE
Expose nopen file counter via common block

### DIFF
--- a/core/prepost.f
+++ b/core/prepost.f
@@ -1154,7 +1154,7 @@ c-----------------------------------------------------------------------
       data        slash,dot  / '/' , '.' /
 
       integer nopen(1000,2)
-      save    nopen
+      common /nopenf2/ nopen
       data    nopen  / 2000*0 /
 
       call blank(fname,132)


### PR DESCRIPTION
The nopen array in mfo_open_files tracks output file numbering but is inaccessible to user routines due to the save statement.

This change exposes it via common /nopenf2/, following the existing pattern at line 282 where common /nopenf/ exposes a similar counter.

Use case: User code that needs to coordinate custom output file numbering with Nek5000's internal restart/output counter.