### PR TITLE
Allow initial bad mesh without abort

### DIFF
--- a/core/INPUT
+++ b/core/INPUT
@@ -51,7 +51,7 @@ c
      $               ,ifxyo_,ifaziv,ifneknek,ifneknekm,ifneknekc
      $               ,ifcvfld(ldimt1),ifdp0dt
      $               ,ifmpiio,ifcrrs,ifrich,ifvvisp
-     $               ,ifbmap(ldimt1)
+     $               ,ifbmap(ldimt1),ifjac0_abort
 
       common /input3/ if3d,ifflow,ifheat,iftran,ifaxis,ifstrs,ifsplit
      $               ,ifmgrid 
@@ -67,7 +67,7 @@ c
      $               ,ifcyclic,ifmoab,ifcoup, ifvcoup, ifusermv,ifreguo
      $               ,ifxyo_,ifaziv,ifneknek,ifneknekm,ifneknekc
      $               ,ifcvfld,ifdp0dt
-     $               ,ifmpiio,ifcrrs,ifrich,ifvvisp,ifbmap
+     $               ,ifmpiio,ifcrrs,ifrich,ifvvisp,ifbmap,ifjac0_abort
 
       logical         ifnav
       equivalence    (ifnav, ifadvc(1))

--- a/core/coef.f
+++ b/core/coef.f
@@ -530,7 +530,6 @@ C
       ENDIF
 C
       kerr = 0
-      ifprint = .true.
       DO 400 ie=1,NELT
          CALL MAP31 (RXM1(1,1,1,ie),RXM3(1,1,1,ie),ie)
          CALL MAP31 (RYM1(1,1,1,ie),RYM3(1,1,1,ie),ie)

--- a/core/coef.f
+++ b/core/coef.f
@@ -529,7 +529,6 @@ C
          CALL RONE  (TZM1,NTOT1)
       ENDIF
 C
-      kerr = 0
       DO 400 ie=1,NELT
          CALL MAP31 (RXM1(1,1,1,ie),RXM3(1,1,1,ie),ie)
          CALL MAP31 (RYM1(1,1,1,ie),RYM3(1,1,1,ie),ie)

--- a/core/coef.f
+++ b/core/coef.f
@@ -547,7 +547,7 @@ C
          CALL MAP31 (ZM1(1,1,1,ie),ZM3(1,1,1,ie),ie)
  400  CONTINUE
 
-      call mesh_check(ifjac0_abort,1)
+      call mesh_check(.false.,0,0)
       call invers2(jacmi,jacm1,ntot1)
 
       RETURN
@@ -625,7 +625,7 @@ C
          CALL ASCOL5  (TZM1,XRM1,YSM1,XSM1,YRM1,NTOT1)
       ENDIF
 C
-      call mesh_check(.false.,0)
+      call mesh_check(.false.,0,0)
       call invers2(jacmi,jacm1,ntot1)
 
       RETURN
@@ -966,22 +966,101 @@ c
       RETURN
       END
 c-----------------------------------------------------------------------
-      subroutine mesh_check(ifabort,imetric)
+      subroutine xm1toxc
+      include 'SIZE'
+      include 'GEOM'  ! xm1
+      include 'INPUT' ! xc
+
+      do ie = 1,nelt
+         ! x
+         xc(1,ie) = XM1(1  ,1  ,1  ,ie)
+         xc(2,ie) = XM1(lx1,1  ,1  ,ie)
+         xc(3,ie) = XM1(lx1,ly1,1  ,ie)
+         xc(4,ie) = XM1(1  ,ly1,1  ,ie)
+         xc(5,ie) = XM1(1  ,1  ,lz1,ie)
+         xc(6,ie) = XM1(lx1,1  ,lz1,ie)
+         xc(7,ie) = XM1(lx1,ly1,lz1,ie)
+         xc(8,ie) = XM1(1  ,ly1,lz1,ie)
+         ! y
+         yc(1,ie) = YM1(1  ,1  ,1  ,ie)
+         yc(2,ie) = YM1(lx1,1  ,1  ,ie)
+         yc(3,ie) = YM1(lx1,ly1,1  ,ie)
+         yc(4,ie) = YM1(1  ,ly1,1  ,ie)
+         yc(5,ie) = YM1(1  ,1  ,lz1,ie)
+         yc(6,ie) = YM1(lx1,1  ,lz1,ie)
+         yc(7,ie) = YM1(lx1,ly1,lz1,ie)
+         yc(8,ie) = YM1(1  ,ly1,lz1,ie)
+         ! z
+         zc(1,ie) = ZM1(1  ,1  ,1  ,ie)
+         zc(2,ie) = ZM1(lx1,1  ,1  ,ie)
+         zc(3,ie) = ZM1(lx1,ly1,1  ,ie)
+         zc(4,ie) = ZM1(1  ,ly1,1  ,ie)
+         zc(5,ie) = ZM1(1  ,1  ,lz1,ie)
+         zc(6,ie) = ZM1(lx1,1  ,lz1,ie)
+         zc(7,ie) = ZM1(lx1,ly1,lz1,ie)
+         zc(8,ie) = ZM1(1  ,ly1,lz1,ie)
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine xctoxyz
+      include 'SIZE'
+      include 'INPUT' ! xc
+      include 'SCRCT' ! xyz
+
+      integer indx(8)
+      data indx /1,2,4,3,5,6,8,7/
+
+      if (ldim.eq.2) then
+        do ie=1,nelt
+          do j=1,8
+            ivtx = indx(j)
+            xyz(1,ivtx,ie) = xc(j,ie)
+            xyz(2,ivtx,ie) = yc(j,ie)
+            xyz(3,ivtx,ie) = zc(j,ie)
+          enddo
+        enddo
+      else
+        do ie=1,nelt
+          do j=1,4
+            ivtx = indx(j)
+            xyz(1,ivtx,ie) = xc(j,ie)
+            xyz(2,ivtx,ie) = yc(j,ie)
+            xyz(3,ivtx,ie) = 0.0
+          enddo
+        enddo
+      endif
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine mesh_check(ifabort,iverb,idbg)
 c
-c     Check mesh consistency after fix_geom (or any geom_reset).
+c     Check mesh 1 consistency after fix_geom (or any geom_reset).
 c
 c     ifabort : .true.     abort run if an error is detected
 c               .false.    report error and continue
-c     imetric : 0          do not compute/print metrics
-c               1          compute and always print metrics
-c               2          compute but only print when metrics change
+c
+c     iverb   : 0          do not print unless an error occurs (then use idbg)
+c               1          short summary; print metrics only when they change
+c               2          summary + always print mesh metrics
+c
+c     When bad elements detected:
+c     idbg    : 0          only print summarized results
+c             : 1          also dump xyz file
+c                             pr = err type (0=ok, 1=rhs, 2=jac, 3=both)
+c                             temp = jacobian
+c             : 2          print all bad elements and dump xyz file
 c
       include 'SIZE'
+      include 'PARALLEL'
       include 'INPUT'
       include 'GEOM'
       include 'SOLN'
+      include 'SCRCT'! xyz
 
-      logical ifabort, ifprint
+      logical ifabort, print_bad_e
+      integer bad_elem(lelt)
 
       real elem_metric
       common /msh_metrics/ elem_metric(3,3)
@@ -990,39 +1069,68 @@ c
       save elem_metric_prev
 
       nxyz = lx1*ly1*lz1
+      nxyz2 = lx2*ly2*lz2
+
+      print_bad_e = .false.
+      if (idbg.eq.2) print_bad_e = .true. ! this can print a lot
+
+c     Check right-handedness
+      call xm1toxc
+      call xctoxyz
+      call verrhe(print_bad_e,bad_elem) ! tag LHS e with bad_elem(ie) = 1
+      kerr1 = iglsum(bad_elem,nelt)
 
 c     Check Jacobians
-      kerr = 0
-      ifprint = .true.
+      kerr2 = 0
       do ie=1,nelt
         call chkjac(jacm1(1,1,1,ie),nxyz,ie,xm1(1,1,1,ie)
-     $             ,ym1(1,1,1,ie),zm1(1,1,1,ie),ldim,ifprint,ierr)
+     $             ,ym1(1,1,1,ie),zm1(1,1,1,ie),ldim,print_bad_e,ierr)
         if (ierr.ne.0) then
-          kerr    = kerr+1
-          ifprint = .false. ! only prints first element per rank
+          kerr2 = kerr2 + 1
+          bad_elem(ie) = bad_elem(ie) + 2 ! add 2 for neg-jac, so 2 or 3
         endif
       enddo
-      kerr = iglsum(kerr,1)
+      kerr2 = iglsum(kerr2,1)
 
-      if (kerr.gt.0) then
-        ifxyo = .true.
-        ifvo  = .false.
-        ifpo  = .false.
-        ifto  = .true.
-        param(66) = 4
-        call outpost(vx,vy,vz,pr,jacm1,'xyz')
-        if (nid.eq.0) write(6,1) kerr
-        if (ifabort) call exitt
+c     Short summary
+      kerr = max(kerr1,kerr2)
+      if (nid.eq.0) then
+        if (kerr1.gt.0) write(6,2001) kerr1
+        if (kerr2.gt.0) write(6,2002) kerr2
+        if (iverb.gt.0.AND.kerr.eq.0) write(6,2003) nelgt
       endif
-    1 format('Jac error mesh 1 in ', I2,' elements, dump jac in temp')
+ 2001 format('Right-handed check failed for',I12,' elements.')
+ 2002 format('Neg-Jacobian check failed for',I12,' elements.')
+ 2003 format('Mesh check complete for',I12,' elements. OK.')
+
+c     Error behavior
+      if (kerr.ne.0) then
+
+        if (idbg.gt.0) then ! dump xyz
+          if (nid.eq.0) write(6,2004)
+          ifxyo = .true.
+          ifvo  = .false.
+          ifpo  = .true.    ! 0=ok, 1=lhs, 2=neg-jac, 3=both (pr)
+          ifto  = .true.    ! pointwise jacobian (temp)
+          call rzero(pr,nxyz2*nelt)
+          do ie=1,nelt
+            call cfill(pr(1,1,1,ie),1.0*bad_elem(ie),nxyz2)
+          enddo
+          call outpost(vx,vy,vz,pr,jacm1,'xyz')
+        endif
+
+        if (ifabort) then
+          if (nid.eq.0) write(6,2005)
+          call exitt
+        endif
+
+      endif
+
+ 2004 format('Dump xyz: pr = error type, temp = Jacobian')
+ 2005 format('Mesh check failed. Abort!')
 
 c     Compute mesh metrics
-      if (imetric.eq.1) then
-
-        call mesh_metrics(.true.) ! compute and print
-        call copy(elem_metric_prev,elem_metric,9)
-
-      elseif (imetric.eq.2) then
+      if (iverb.eq.1) then
 
         call mesh_metrics(.false.) ! compute silently
         call sub3(tmp,elem_metric_prev,elem_metric,9)
@@ -1041,6 +1149,12 @@ c     Compute mesh metrics
             write(6,*)
           endif
         endif
+
+      elseif (iverb.eq.2) then
+
+        call mesh_metrics(.true.) ! compute and print
+        call copy(elem_metric_prev,elem_metric,9)
+
       endif
 
       return

--- a/core/coef.f
+++ b/core/coef.f
@@ -1004,17 +1004,19 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine xctoxyz
+      subroutine xctoxyz(xyz)
       include 'SIZE'
       include 'INPUT' ! xc
-      include 'SCRCT' ! xyz
 
+      real xyz(3,8,1)
       integer indx(8)
       data indx /1,2,4,3,5,6,8,7/
 
-      if (ldim.eq.2) then
+      call rzero(xyz,24*nelt)
+
+      if (ldim.eq.3) then
         do ie=1,nelt
-          do j=1,4
+          do j=1,8
             ivtx = indx(j)
             xyz(1,ivtx,ie) = xc(j,ie)
             xyz(2,ivtx,ie) = yc(j,ie)
@@ -1023,7 +1025,7 @@ c-----------------------------------------------------------------------
         enddo
       else
         do ie=1,nelt
-          do j=1,8
+          do j=1,4
             ivtx = indx(j)
             xyz(1,ivtx,ie) = xc(j,ie)
             xyz(2,ivtx,ie) = yc(j,ie)
@@ -1031,6 +1033,7 @@ c-----------------------------------------------------------------------
           enddo
         enddo
       endif
+
       return
       end
 c-----------------------------------------------------------------------
@@ -1057,10 +1060,11 @@ c
       include 'INPUT'
       include 'GEOM'
       include 'SOLN'
-      include 'SCRCT'! xyz
 
       logical ifabort, print_bad_e
       integer bad_elem(lelt)
+
+      real xyz(3,8,lelt)
 
       real elem_metric
       common /msh_metrics/ elem_metric(3,3)
@@ -1078,8 +1082,8 @@ c
       if (idbg.eq.2) print_bad_e = .true. ! this can print a lot
 
 c     Check right-handedness
-      call xctoxyz
-      call verrhe(print_bad_e,bad_elem) ! tag LHS e with bad_elem(ie) = 1
+      call xctoxyz(xyz)
+      call verrhe(xyz,print_bad_e,bad_elem) ! tag LHS e with bad_elem(ie) = 1
       kerr1 = iglsum(bad_elem,nelt)
 
 c     Check Jacobians

--- a/core/coef.f
+++ b/core/coef.f
@@ -431,8 +431,6 @@ C
       DIMENSION XM3(LX3,LY3,LZ3,1)
      $        , YM3(LX3,LY3,LZ3,1)
      $        , ZM3(LX3,LY3,LZ3,1)
-      logical ifprint
-C
 C
       NXY3  = lx3*ly3
       NYZ3  = ly3*lz3
@@ -534,15 +532,6 @@ C
       kerr = 0
       ifprint = .true.
       DO 400 ie=1,NELT
-
-c        write(6,*) 'chkj1'
-c        call outxm3j(xm3,ym3,jacm3)
-         CALL CHKJAC(JACM3(1,1,1,ie),NXYZ3,ie,xm3(1,1,1,ie),
-     $ ym3(1,1,1,ie),zm3(1,1,1,ie),ldim,ifprint,ierr)
-         if (ierr.eq.1) then
-            kerr = kerr+1
-            ifprint = .false.
-         endif
          CALL MAP31 (RXM1(1,1,1,ie),RXM3(1,1,1,ie),ie)
          CALL MAP31 (RYM1(1,1,1,ie),RYM3(1,1,1,ie),ie)
          CALL MAP31 (SXM1(1,1,1,ie),SXM3(1,1,1,ie),ie)
@@ -559,19 +548,8 @@ c        call outxm3j(xm3,ym3,jacm3)
          CALL MAP31 (YM1(1,1,1,ie),YM3(1,1,1,ie),ie)
          CALL MAP31 (ZM1(1,1,1,ie),ZM3(1,1,1,ie),ie)
  400  CONTINUE
-      kerr = iglsum(kerr,1)
-      if (kerr.gt.0.AND.ifjac0_abort) then
-         ifxyo = .true.
-         ifvo  = .false.
-         ifpo  = .false.
-         ifto  = .true.
-         param(66) = 4
-         call outpost(vx,vy,vz,pr,jacm3,'xyz')
-         if (nid.eq.0) write(6,*)
-     &     'Jac error 3 in ',kerr,' elements, setting p66=4, ifxyo=t'
-         call exitt
-      endif
 
+      call mesh_check(ifjac0_abort,1)
       call invers2(jacmi,jacm1,ntot1)
 
       RETURN

--- a/core/coef.f
+++ b/core/coef.f
@@ -565,9 +565,9 @@ c        call outxm3j(xm3,ym3,jacm3)
          ifxyo = .true.
          ifvo  = .false.
          ifpo  = .false.
-         ifto  = .false.
+         ifto  = .true.
          param(66) = 4
-         call outpost(vx,vy,vz,pr,t,'xyz')
+         call outpost(vx,vy,vz,pr,jacm3,'xyz')
          if (nid.eq.0) write(6,*) 
      &     'Jac error 3 in ',kerr,' elements, setting p66=4, ifxyo=t'
          call exitt
@@ -667,9 +667,9 @@ C
          ifxyo = .true.
          ifvo  = .false.
          ifpo  = .false.
-         ifto  = .false.
+         ifto  = .true.
          param(66) = 4
-         call outpost(vx,vy,vz,pr,t,'xyz')
+         call outpost(vx,vy,vz,pr,jacm1,'xyz')
          if (nid.eq.0) write(6,*) 
      &     'Jac error 1 in ',kerr,' elements, setting p66=4, ifxyo=t'
          call exitt
@@ -1038,9 +1038,9 @@ c
          ifxyo = .true.
          ifvo  = .false.
          ifpo  = .false.
-         ifto  = .false.
+         ifto  = .true.
          param(66) = 4
-         call outpost(vx,vy,vz,pr,t,'xyz')
+         call outpost(vx,vy,vz,pr,jacm1,'xyz')
          if (nid.eq.0) write(6,*)
      &     'Jac error 1 in ',kerr,' elements, setting p66=4, ifxyo=t'
          call exitt

--- a/core/coef.f
+++ b/core/coef.f
@@ -537,8 +537,8 @@ C
 
 c        write(6,*) 'chkj1'
 c        call outxm3j(xm3,ym3,jacm3)
-         CALL CHKJAC(JACM3(1,1,1,ie),NXYZ3,ie,xm3(1,1,1,ie)
-     $              ,ym3(1,1,1,ie),zm3(1,1,1,ie),ldim,ierr)
+         CALL CHKJAC(JACM3(1,1,1,ie),NXYZ3,ie,xm3(1,1,1,ie),
+     $ ym3(1,1,1,ie),zm3(1,1,1,ie),ldim,ifprint,ierr)
          if (ierr.eq.1) then
             kerr = kerr+1
             ifprint = .false.

--- a/core/coef.f
+++ b/core/coef.f
@@ -1014,7 +1014,7 @@ c-----------------------------------------------------------------------
 
       if (ldim.eq.2) then
         do ie=1,nelt
-          do j=1,8
+          do j=1,4
             ivtx = indx(j)
             xyz(1,ivtx,ie) = xc(j,ie)
             xyz(2,ivtx,ie) = yc(j,ie)
@@ -1023,7 +1023,7 @@ c-----------------------------------------------------------------------
         enddo
       else
         do ie=1,nelt
-          do j=1,4
+          do j=1,8
             ivtx = indx(j)
             xyz(1,ivtx,ie) = xc(j,ie)
             xyz(2,ivtx,ie) = yc(j,ie)
@@ -1034,7 +1034,7 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine mesh_check(ifabort,iverb,idbg)
+      subroutine mesh_check(ifabort,iverb,idbg_in)
 c
 c     Check mesh 1 consistency after fix_geom (or any geom_reset).
 c
@@ -1071,11 +1071,13 @@ c
       nxyz = lx1*ly1*lz1
       nxyz2 = lx2*ly2*lz2
 
+      idbg = idbg_in
+      if (ifabort) idbg = max(1,idbg_in)
+
       print_bad_e = .false.
       if (idbg.eq.2) print_bad_e = .true. ! this can print a lot
 
 c     Check right-handedness
-      call xm1toxc
       call xctoxyz
       call verrhe(print_bad_e,bad_elem) ! tag LHS e with bad_elem(ie) = 1
       kerr1 = iglsum(bad_elem,nelt)

--- a/core/coef.f
+++ b/core/coef.f
@@ -559,7 +559,7 @@ c        call outxm3j(xm3,ym3,jacm3)
          CALL MAP31 (YM1(1,1,1,ie),YM3(1,1,1,ie),ie)
          CALL MAP31 (ZM1(1,1,1,ie),ZM3(1,1,1,ie),ie)
  400  CONTINUE
-
+      kerr = iglsum(kerr,1)
       if (kerr.gt.0.AND.ifjac0_abort) then
          ifxyo = .true.
          ifvo  = .false.

--- a/core/connect1.f
+++ b/core/connect1.f
@@ -893,6 +893,7 @@ C
       LOGICAL IFYES,IFCSTT
 C
       IFCSTT=.TRUE.
+      nnr = 0
       IF (.NOT.IF3D) THEN
       DO 1000 IE=1,NELT
 C
@@ -907,8 +908,9 @@ C
      $       C3.LE.0.0.OR.C4.LE.0.0 ) THEN
 C
             ieg=lglel(ie)
+            nnr = nnr+1
             WRITE(6,800) IEG,C1,C2,C3,C4
-  800       FORMAT(/,2X,'WARNINGa: Detected non-right-handed element.',
+  800       FORMAT(/,2X,'WARNING: Detected non-right-handed element.',
      $      /,2X,'Number',I8,'  C1-4:',4E12.4)
             IFCSTT=.FALSE.
 C           CALL QUERY(IFYES,'Proceed                                 ')
@@ -938,10 +940,11 @@ C
      $       V7.LE.0.0.OR.V8.LE.0.0    ) THEN
 C
             ieg=lglel(ie)
+            nnr = nnr+1
             WRITE(6,1800) IEG,V1,V2,V3,V4,V5,V6,V7,V8
- 1800       FORMAT(/,2X,'WARNINGb: Detected non-right-handed element.',
+ 1800       FORMAT(/,2X,'WARNING: Detected non-right-handed element.',
      $      /,2X,'Number',I8,'  V1-8:',4E12.4
-     $      /,2X,'      ',4X,'       ',4E12.4)
+     $      /,2X,'      ',8X,'       ',4E12.4)
             IFCSTT=.FALSE.
          ENDIF
  2000 CONTINUE
@@ -958,7 +961,8 @@ C
       CALL GLLOG(IFCSTT,.FALSE.)
 C
       IF (.NOT.IFCSTT) THEN
-         IF (NID.EQ.0) WRITE(6,2003) NELGT
+         nnr = iglsum(nnr,1)
+         IF (NID.EQ.0) WRITE(6,2003) nnr !print out number of non-right handed elements
          if (ifjac0_abort) then
             IF (NID.EQ.0) WRITE(6,2004)
             call exitt

--- a/core/connect1.f
+++ b/core/connect1.f
@@ -802,7 +802,7 @@ C
       include 'SCRCT'
       integer iwk(lelt)
 
-      call verrhe(.false.,iwk)
+      call verrhe(xyz,.false.,iwk)
 
       ierr = iglsum(iwk,nelt)
       if (ierr.eq.0) then
@@ -890,7 +890,7 @@ c     call exitt
       RETURN
       END
 c-----------------------------------------------------------------------
-      subroutine verrhe(ifprint,bad_elem)
+      subroutine verrhe(xyz,ifprint,bad_elem)
 C
 C     8 Mar 1989 21:58:26   PFF
 C     Verify right-handedness of given elements. 
@@ -898,10 +898,10 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'INPUT'
       INCLUDE 'PARALLEL'
-      INCLUDE 'SCRCT'
       INCLUDE 'TOPOL'
       logical ifprint
       integer bad_elem(lelt)
+      real xyz(3,8,1)
 C
       call izero(bad_elem,lelt)
 

--- a/core/connect1.f
+++ b/core/connect1.f
@@ -908,7 +908,6 @@ C
 C
             ieg=lglel(ie)
             WRITE(6,800) IEG,C1,C2,C3,C4
-            call exitt
   800       FORMAT(/,2X,'WARNINGa: Detected non-right-handed element.',
      $      /,2X,'Number',I8,'  C1-4:',4E12.4)
             IFCSTT=.FALSE.
@@ -940,7 +939,6 @@ C
 C
             ieg=lglel(ie)
             WRITE(6,1800) IEG,V1,V2,V3,V4,V5,V6,V7,V8
-            call exitt
  1800       FORMAT(/,2X,'WARNINGb: Detected non-right-handed element.',
      $      /,2X,'Number',I8,'  V1-8:',4E12.4
      $      /,2X,'      ',4X,'       ',4E12.4)
@@ -961,16 +959,18 @@ C
 C
       IF (.NOT.IFCSTT) THEN
          IF (NID.EQ.0) WRITE(6,2003) NELGT
-         call exitt
+         if (ifjac0_abort) then
+            IF (NID.EQ.0) WRITE(6,2004)
+            call exitt
+         endif
       ELSE
          IF (NIO.EQ.0) WRITE(6,2002) NELGT
       ENDIF
 C
- 2001 FORMAT(//,'  Elemental geometry not right-handed, ABORTING'
-     $      ,' in routine VERRHE.')
+ 2001 FORMAT(//,'  Elemental geometry not right-handed')
  2002 FORMAT('   Right-handed check complete for',I12,' elements. OK.')
- 2003 FORMAT('   Right-handed check failed for',I12,' elements.'
-     $      ,'   Exiting in routine VERRHE.')
+ 2003 FORMAT('   Right-handed check failed for',I12,' elements.')
+ 2004 FORMAT('   Exiting in routine VERRHE.')
       RETURN
       END
 c-----------------------------------------------------------------------

--- a/core/drive1.f
+++ b/core/drive1.f
@@ -112,7 +112,7 @@ c      COMMON /SCRCG/ DUMM10(LX1,LY1,LZ1,LELT,1)
 
       call chk_axis         ! verify axisymmetric mesh/BC requirements
       call vrdsmsh          ! verify mesh topology
-      call mesh_metrics     ! print some metrics
+      call mesh_check(ifjac0_abort,1) ! check mesh and print metrics
 
       call setlog(.true.)   ! Initalize logical flags
 
@@ -146,7 +146,7 @@ c      COMMON /SCRCG/ DUMM10(LX1,LY1,LZ1,LELT,1)
          call userchk
          if(nio.eq.0) write(6,'(A,/)') ' done :: userchk' 
       endif
-      call mesh_check   ! mesh can be changed in setics or userchk
+      call mesh_check(.true.,2) ! check mesh for possible changes from setics or userchk
       call setprop      ! call again because input has changed in userchk
 
       if (ifcvode .and. nsteps.gt.0) call cv_init

--- a/core/drive1.f
+++ b/core/drive1.f
@@ -146,7 +146,7 @@ c      COMMON /SCRCG/ DUMM10(LX1,LY1,LZ1,LELT,1)
          call userchk
          if(nio.eq.0) write(6,'(A,/)') ' done :: userchk' 
       endif
-
+      call mesh_check   ! mesh can be changed in setics or userchk
       call setprop      ! call again because input has changed in userchk
 
       if (ifcvode .and. nsteps.gt.0) call cv_init

--- a/core/drive1.f
+++ b/core/drive1.f
@@ -112,7 +112,7 @@ c      COMMON /SCRCG/ DUMM10(LX1,LY1,LZ1,LELT,1)
 
       call chk_axis         ! verify axisymmetric mesh/BC requirements
       call vrdsmsh          ! verify mesh topology
-      call mesh_check(ifjac0_abort,1) ! check mesh and print metrics
+      call mesh_check(ifjac0_abort,2,0) ! check mesh and print metrics
 
       call setlog(.true.)   ! Initalize logical flags
 
@@ -146,7 +146,7 @@ c      COMMON /SCRCG/ DUMM10(LX1,LY1,LZ1,LELT,1)
          call userchk
          if(nio.eq.0) write(6,'(A,/)') ' done :: userchk' 
       endif
-      call mesh_check(.true.,2) ! check mesh for possible changes from setics or userchk
+      call mesh_check(.true.,1,1) ! check mesh for possible changes from setics or userchk
       call setprop      ! call again because input has changed in userchk
 
       if (ifcvode .and. nsteps.gt.0) call cv_init

--- a/core/drive2.f
+++ b/core/drive2.f
@@ -57,6 +57,8 @@ c     Set default logicals
       ifcrrs = .true. ! crystal router restart
       lbrst = min(1024, lelt) ! batch size for restart
 
+      ifjac0_abort = .true. ! abort if initial mesh (rea/re2) is invalid
+
       CALL RZERO (PARAM,200)
 
       CALL BLANK(CCURVE ,12*LELT)

--- a/core/genxyz.f
+++ b/core/genxyz.f
@@ -1434,12 +1434,16 @@ c     it too should be updated.
       return
       end
 c-----------------------------------------------------------------------
-      subroutine mesh_metrics
+      subroutine mesh_metrics(ifprint)
       include 'SIZE'
       include 'TOTAL'
 
       parameter(nedge = 4 + 8*(ldim-2))
       real ledg(nedge)
+      logical ifprint
+
+      real elem_metric
+      common /msh_metrics/ elem_metric(3,3)
 
       nxyz = nx1*ny1*nz1
       ntot = nxyz*nelt
@@ -1503,7 +1507,17 @@ c-----------------------------------------------------------------------
       dxmax = glmax(ddmax,1)
       dxavg = glsum(ddavg,1)/nelgt 
 
-      if (nid.eq.0) then
+      elem_metric(1,1) = dxmin
+      elem_metric(2,1) = dxmax
+      elem_metric(3,1) = 0.0
+      elem_metric(1,2) = dsjmin
+      elem_metric(2,2) = dsjmax
+      elem_metric(3,2) = dsjavg
+      elem_metric(1,3) = darmin
+      elem_metric(2,3) = darmax
+      elem_metric(3,3) = daravg
+
+      if (nid.eq.0.AND.ifprint) then
          write(6,*) 'mesh metrics:'
          write(6,'(A,1p2E9.2)') ' GLL grid spacing min/max    :',
      $   dxmin,dxmax

--- a/core/ic.f
+++ b/core/ic.f
@@ -1856,36 +1856,7 @@ c
       CALL SETINVM
       CALL SETDEF
       CALL SFASTAX
-c
-      do ie = 1,nelt
-         ! x
-         xc(1,ie) = XM1(1  ,1  ,1  ,ie)
-         xc(2,ie) = XM1(lx1,1  ,1  ,ie)
-         xc(3,ie) = XM1(lx1,ly1,1  ,ie)
-         xc(4,ie) = XM1(1  ,ly1,1  ,ie)
-         xc(5,ie) = XM1(1  ,1  ,lz1,ie)
-         xc(6,ie) = XM1(lx1,1  ,lz1,ie)
-         xc(7,ie) = XM1(lx1,ly1,lz1,ie)
-         xc(8,ie) = XM1(1  ,ly1,lz1,ie)
-         ! y
-         yc(1,ie) = YM1(1  ,1  ,1  ,ie)
-         yc(2,ie) = YM1(lx1,1  ,1  ,ie)
-         yc(3,ie) = YM1(lx1,ly1,1  ,ie)
-         yc(4,ie) = YM1(1  ,ly1,1  ,ie)
-         yc(5,ie) = YM1(1  ,1  ,lz1,ie)
-         yc(6,ie) = YM1(lx1,1  ,lz1,ie)
-         yc(7,ie) = YM1(lx1,ly1,lz1,ie)
-         yc(8,ie) = YM1(1  ,ly1,lz1,ie)
-         ! z 
-         zc(1,ie) = ZM1(1  ,1  ,1  ,ie)
-         zc(2,ie) = ZM1(lx1,1  ,1  ,ie)
-         zc(3,ie) = ZM1(lx1,ly1,1  ,ie)
-         zc(4,ie) = ZM1(1  ,ly1,1  ,ie)
-         zc(5,ie) = ZM1(1  ,1  ,lz1,ie)
-         zc(6,ie) = ZM1(lx1,1  ,lz1,ie)
-         zc(7,ie) = ZM1(lx1,ly1,lz1,ie)
-         zc(8,ie) = ZM1(1  ,ly1,lz1,ie)
-      enddo
+      CALL XM1TOXC
 
       if(nio.eq.0) then
         write(6,*) 'done :: regenerate geometry data',icall


### PR DESCRIPTION
This PR adds an "allow bad mesh" mode so that users can inspect and possibly fix a bad mesh in `usrdat2`. Nek will now always enter `usrdat2` without exiting due to an initial mesh error.

With `ifjac0_abort = .false.`, the code continues at least until the first `userchk` call, so users can also perform meshing there or load a fixed mesh from a restart file.

Change log:
- Introduce `ifjac0_abort` to control whether the code aborts when a bad initial mesh is detected.
  - Defaults to `.true.`.
  - Can be overridden in `usrdat0`, `usrdat`, or `usrdat2`.
  - This enables a “pre-processing mode” in which users can fix the mesh in `usrdat2`, `userchk`, or by loading a checkpoint.
- Change the initial mesh check so it does not abort before entering `usrdat2`.
- Introduce a high-level `mesh_check` subroutine as a unified interface:
  - Includes both right-handedness and negative-Jacobian checks.
  - Supports configurable abort behavior on error.
  - Provides 3 verbosity levels for summary output.
  - Provides 3 debug modes when bad elements are present:
    - Can dump error type into `pr` (0=ok, 1=rhs, 2=jac, 3=both) and Jacobian into `temp`.

Default behavior (no user changes) is documented here:
https://github.com/Nek5000/Nek5000/pull/881#issuecomment-3648852204


This closes:
- https://github.com/Nek5000/Nek5000/issues/646
- https://github.com/Nek5000/Nek5000/issues/762
- https://github.com/Nek5000/Nek5000/issues/877