### PR TITLE
Allow overwrite ver for 3rd party install

### DIFF
--- a/3rd_party/cvode/install
+++ b/3rd_party/cvode/install
@@ -16,17 +16,17 @@ if [[ $NEK_DEPS_LOCAL_SRC -eq 1 ]]; then
 fi
 
 clean() {
-  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null
-  [ -L folder ] && rm -f $PREFIX 2>/dev/null # soft link only
+  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null || true
+  [ -L $PREFIX ] && rm -f -- $PREFIX 2>/dev/null || true # soft link only
 }
 
 distclean() {
   clean
-  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null
+  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null || true
 }
 
 fetch() {
-  rm -rf $DIR 2>/dev/null
+  rm -rf $DIR 2>/dev/null || true
   wget --no-check-certificate -O v$VER.tar.gz https://github.com/LLNL/sundials/archive/refs/tags/v$VER.tar.gz
 }
 

--- a/3rd_party/cvode/install
+++ b/3rd_party/cvode/install
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VER=2.7.0
+: ${VER:="2.7.0"}
 
 PREFIX=sundials
 DIR=${PREFIX}_v${VER}

--- a/3rd_party/cvode/install
+++ b/3rd_party/cvode/install
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+: ${NEK_DEPS_LOCAL_SRC:=0}
 : ${VER:="2.7.0"}
 
 PREFIX=sundials
@@ -8,13 +9,20 @@ DIR=${PREFIX}_v${VER}
 STAMP_FILE=install.stamp
 ROOT=$PWD
 
+# use existing local src
+if [[ $NEK_DEPS_LOCAL_SRC -eq 1 ]]; then
+  DIR=${PREFIX}
+  VER="local"
+fi
+
 clean() {
-  rm -rf "$DIR/build" lib include $PREFIX $STAMP_FILE 2>/dev/null
+  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null
+  [ -L folder ] && rm -f $PREFIX 2>/dev/null # soft link only
 }
 
 distclean() {
   clean
-  rm -rf ${PREFIX}_v* *.tar.gz 2>/dev/null
+  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null
 }
 
 fetch() {
@@ -53,13 +61,15 @@ if [ -f ./lib/libsundials_fcvode.a ]; then
   exit 0
 fi
 
-if [ ! -f v$VER.tar.gz ]; then
-  fetch
-fi
+if [[ $NEK_DEPS_LOCAL_SRC -eq 0 ]]; then
+  if [ ! -f v$VER.tar.gz ]; then
+    fetch
+  fi
 
-if [ ! -d $DIR ]; then
-  mkdir $DIR
-  tar -zxvf v$VER.tar.gz -C $DIR --strip-components=1
+  if [ ! -d $DIR ]; then
+    mkdir $DIR
+    tar -zxvf v$VER.tar.gz -C $DIR --strip-components=1
+  fi
 fi
 
 cd $DIR
@@ -89,7 +99,9 @@ set +x
 make install -j4
 
 cd $ROOT
-ln -sfn $DIR/ $PREFIX
+if [[ $NEK_DEPS_LOCAL_SRC -eq 0 ]]; then
+  ln -sfn $DIR/ $PREFIX
+fi
 
 if [ "$?" -eq 0 ]; then
   cd $ROOT

--- a/3rd_party/gslib/install
+++ b/3rd_party/gslib/install
@@ -16,19 +16,19 @@ if [[ $NEK_DEPS_LOCAL_SRC -eq 1 ]]; then
 fi
 
 clean() {
-  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null
-  [ -L folder ] && rm -f $PREFIX 2>/dev/null # soft link only
+  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null || true
+  [ -L $PREFIX ] && rm -f -- $PREFIX 2>/dev/null || true # soft link only
   find . -name '*.o' -exec rm {} +
   find . -name '*.a' -exec rm {} +
 }
 
 distclean() {
   clean
-  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null
+  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null || true
 }
 
 fetch() {
-  rm -rf $DIR 2>/dev/null
+  rm -rf $DIR 2>/dev/null || true
   wget --no-check-certificate -O v$VER.tar.gz https://github.com/gslib/gslib/archive/v$VER.tar.gz
 }
 

--- a/3rd_party/gslib/install
+++ b/3rd_party/gslib/install
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+: ${NEK_DEPS_LOCAL_SRC:=0}
 : ${VER:="1.0.9"}
 
 PREFIX=gslib
@@ -8,15 +9,22 @@ DIR=${PREFIX}_v${VER}
 STAMP_FILE=install.stamp
 ROOT=$PWD
 
+# use existing local src
+if [[ $NEK_DEPS_LOCAL_SRC -eq 1 ]]; then
+  DIR=${PREFIX}
+  VER="local"
+fi
+
 clean() {
-  rm -rf "$DIR/build" lib include $PREFIX $STAMP_FILE 2>/dev/null
+  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null
+  [ -L folder ] && rm -f $PREFIX 2>/dev/null # soft link only
   find . -name '*.o' -exec rm {} +
   find . -name '*.a' -exec rm {} +
 }
 
 distclean() {
   clean
-  rm -rf ${PREFIX}_v* *.tar.gz 2>/dev/null
+  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null
 }
 
 fetch() {
@@ -55,13 +63,15 @@ if [ -f ./lib/libgs.a ]; then
   exit 0
 fi
 
-if [ ! -f v$VER.tar.gz ]; then
-  fetch
-fi
+if [[ $NEK_DEPS_LOCAL_SRC -eq 0 ]]; then
+  if [ ! -f v$VER.tar.gz ]; then
+    fetch
+  fi
 
-if [ ! -d $DIR ]; then
-  mkdir $DIR
-  tar -zxvf v$VER.tar.gz -C $DIR --strip-components=1
+  if [ ! -d $DIR ]; then
+    mkdir $DIR
+    tar -zxvf v$VER.tar.gz -C $DIR --strip-components=1
+  fi
 fi
 
 cd $DIR
@@ -70,7 +80,9 @@ make -j4 $GSLIB_OPT
 set +x
 
 cd $ROOT
-ln -sfn $DIR/ $PREFIX
+if [[ $NEK_DEPS_LOCAL_SRC -eq 0 ]]; then
+  ln -sfn $DIR/ $PREFIX
+fi
 
 if [ "$?" -eq 0 ]; then
   cd $ROOT

--- a/3rd_party/gslib/install
+++ b/3rd_party/gslib/install
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VER=1.0.9
+: ${VER:="1.0.9"}
 
 PREFIX=gslib
 DIR=${PREFIX}_v${VER}

--- a/3rd_party/hypre/install
+++ b/3rd_party/hypre/install
@@ -16,17 +16,17 @@ if [[ $NEK_DEPS_LOCAL_SRC -eq 1 ]]; then
 fi
 
 clean() {
-  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null
-  [ -L folder ] && rm -f $PREFIX 2>/dev/null # soft link only
+  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null || true
+  [ -L $PREFIX ] && rm -f -- $PREFIX 2>/dev/null || true # soft link only
 }
 
 distclean() {
   clean
-  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null
+  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null || true
 }
 
 fetch() {
-  rm -rf $DIR 2>/dev/null
+  rm -rf $DIR 2>/dev/null || true
   wget --no-check-certificate -O v$VER.tar.gz https://github.com/hypre-space/hypre/archive/v$VER.tar.gz
 }
 

--- a/3rd_party/hypre/install
+++ b/3rd_party/hypre/install
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+: ${NEK_DEPS_LOCAL_SRC:=0}
 : ${VER:="2.15.1"}
 
 PREFIX=hypre
@@ -8,13 +9,20 @@ DIR=${PREFIX}_v${VER}
 STAMP_FILE=install.stamp
 ROOT=$PWD
 
+# use existing local src
+if [[ $NEK_DEPS_LOCAL_SRC -eq 1 ]]; then
+  DIR=${PREFIX}
+  VER="local"
+fi
+
 clean() {
-  rm -rf "$DIR/build" lib include $PREFIX $STAMP_FILE 2>/dev/null
+  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null
+  [ -L folder ] && rm -f $PREFIX 2>/dev/null # soft link only
 }
 
 distclean() {
   clean
-  rm -rf ${PREFIX}_v* *.tar.gz 2>/dev/null
+  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null
 }
 
 fetch() {
@@ -53,13 +61,15 @@ if [ -f ./lib/libHYPRE.a ]; then
   exit 0
 fi
 
-if [ ! -f v$VER.tar.gz ]; then
-  fetch
-fi
+if [[ $NEK_DEPS_LOCAL_SRC -eq 0 ]]; then
+  if [ ! -f v$VER.tar.gz ]; then
+    fetch
+  fi
 
-if [ ! -d $DIR ]; then
-  mkdir $DIR
-  tar -zxvf v$VER.tar.gz -C $DIR --strip-components=1
+  if [ ! -d $DIR ]; then
+    mkdir $DIR
+    tar -zxvf v$VER.tar.gz -C $DIR --strip-components=1
+  fi
 fi
 
 cd $DIR
@@ -76,10 +86,12 @@ cmake \
 ../src
 set +x
 
-make -j4 install
+make install -j4
 
 cd $ROOT
-ln -sfn $DIR/ $PREFIX
+if [[ $NEK_DEPS_LOCAL_SRC -eq 0 ]]; then
+  ln -sfn $DIR/ $PREFIX
+fi
 
 if [ "$?" -eq 0 ]; then
   cd $ROOT

--- a/3rd_party/hypre/install
+++ b/3rd_party/hypre/install
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VER=2.15.1
+: ${VER:="2.15.1"}
 
 PREFIX=hypre
 DIR=${PREFIX}_v${VER}

--- a/3rd_party/parRSB/install
+++ b/3rd_party/parRSB/install
@@ -16,17 +16,17 @@ if [[ $NEK_DEPS_LOCAL_SRC -eq 1 ]]; then
 fi
 
 clean() {
-  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null
-  [ -L folder ] && rm -f $PREFIX 2>/dev/null # soft link only
+  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null || true
+  [ -L $PREFIX ] && rm -f -- $PREFIX 2>/dev/null || true # soft link only
 }
 
 distclean() {
   clean
-  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null
+  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null || true
 }
 
 fetch() {
-  rm -rf $DIR 2>/dev/null
+  rm -rf $DIR 2>/dev/null || true
   wget --no-check-certificate -O v$VER.tar.gz https://github.com/Nek5000/parRSB/archive/v$VER.tar.gz
 }
 

--- a/3rd_party/parRSB/install
+++ b/3rd_party/parRSB/install
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VER=0.9.3
+: ${VER:="0.9.3"}
 
 PREFIX=parRSB
 DIR=${PREFIX}_v${VER}

--- a/3rd_party/parRSB/install
+++ b/3rd_party/parRSB/install
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+: ${NEK_DEPS_LOCAL_SRC:=0}
 : ${VER:="0.9.3"}
 
 PREFIX=parRSB
@@ -8,13 +9,20 @@ DIR=${PREFIX}_v${VER}
 STAMP_FILE=install.stamp
 ROOT=$PWD
 
+# use existing local src
+if [[ $NEK_DEPS_LOCAL_SRC -eq 1 ]]; then
+  DIR=${PREFIX}
+  VER="local"
+fi
+
 clean() {
-  rm -rf "$DIR/build" lib include $PREFIX $STAMP_FILE 2>/dev/null
+  rm -rf "$DIR/build" lib include $STAMP_FILE 2>/dev/null
+  [ -L folder ] && rm -f $PREFIX 2>/dev/null # soft link only
 }
 
 distclean() {
   clean
-  rm -rf ${PREFIX}_v* *.tar.gz 2>/dev/null
+  rm -rf ${PREFIX} ${PREFIX}_v* *.tar.gz 2>/dev/null
 }
 
 fetch() {
@@ -53,13 +61,15 @@ if [ -f ./lib/libparRSB.a ]; then
   exit 0
 fi
 
-if [ ! -f v$VER.tar.gz ]; then
-  fetch
-fi
+if [[ $NEK_DEPS_LOCAL_SRC -eq 0 ]]; then
+  if [ ! -f v$VER.tar.gz ]; then
+    fetch
+  fi
 
-if [ ! -d $DIR ]; then
-  mkdir $DIR
-  tar -zxvf v$VER.tar.gz -C $DIR --strip-components=1
+  if [ ! -d $DIR ]; then
+    mkdir $DIR
+    tar -zxvf v$VER.tar.gz -C $DIR --strip-components=1
+  fi
 fi
 
 cd $DIR
@@ -68,7 +78,9 @@ make lib install $PARRSB_OPT
 set +x
 
 cd $ROOT
-ln -sfn $DIR/ $PREFIX
+if [[ $NEK_DEPS_LOCAL_SRC -eq 0 ]]; then
+  ln -sfn $DIR/ $PREFIX
+fi
 
 if [ "$?" -eq 0 ]; then
   cd $ROOT

--- a/core/makenek.inc
+++ b/core/makenek.inc
@@ -26,28 +26,28 @@ function build_3rdparty() {
   set -o pipefail
 
   cd $SOURCE_ROOT_BLAS
-  FFLAGS="-O0 $FF77 $FFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
+  VER="$NEK_DEPS_VERSION" FFLAGS="-O0 $FF77 $FFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
   cd $CASEDIR 
 
   cd $SOURCE_ROOT_GSLIB
-  CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
+  VER="$NEK_DEPS_VERSION" CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
   cd $CASEDIR 
 
   if [ $PARRSB -ne 0 ]; then
      cd $SOURCE_ROOT_PARRSB
-     CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
+     VER="$NEK_DEPS_VERSION" CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
   fi
   cd $CASEDIR
 
   if [ $CVODE -ne 0 ]; then
      cd $SOURCE_ROOT_CVODE
-     CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
+     VER="$NEK_DEPS_VERSION" CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
   fi
   cd $CASEDIR
 
   if [ $HYPRE -ne 0 ]; then
      cd $SOURCE_ROOT_HYPRE
-     CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
+     VER="$NEK_DEPS_VERSION" CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
   fi
   cd $CASEDIR
 
@@ -88,6 +88,7 @@ function config_nek() {
 : ${PROFILING:=1}
 : ${VISIT:=0}
 : ${PPLIST:=""}
+: ${NEK_DEPS_VERSION:=""}
 
 # first do some checks ...
 if [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$PPLIST" == "?" ]; then

--- a/core/makenek.inc
+++ b/core/makenek.inc
@@ -26,28 +26,28 @@ function build_3rdparty() {
   set -o pipefail
 
   cd $SOURCE_ROOT_BLAS
-  VER="$NEK_DEPS_VERSION" FFLAGS="-O0 $FF77 $FFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
+  FFLAGS="-O0 $FF77 $FFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
   cd $CASEDIR 
 
   cd $SOURCE_ROOT_GSLIB
-  VER="$NEK_DEPS_VERSION" CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
+  CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
   cd $CASEDIR 
 
   if [ $PARRSB -ne 0 ]; then
      cd $SOURCE_ROOT_PARRSB
-     VER="$NEK_DEPS_VERSION" CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
+     CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
   fi
   cd $CASEDIR
 
   if [ $CVODE -ne 0 ]; then
      cd $SOURCE_ROOT_CVODE
-     VER="$NEK_DEPS_VERSION" CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
+     CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
   fi
   cd $CASEDIR
 
   if [ $HYPRE -ne 0 ]; then
      cd $SOURCE_ROOT_HYPRE
-     VER="$NEK_DEPS_VERSION" CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
+     CFLAGS="-O2 $CFLAGS" ./install 2>&1 | tee -a $CASEDIR/build.log >/dev/null
   fi
   cd $CASEDIR
 
@@ -88,7 +88,7 @@ function config_nek() {
 : ${PROFILING:=1}
 : ${VISIT:=0}
 : ${PPLIST:=""}
-: ${NEK_DEPS_VERSION:=""}
+: ${NEK_DEPS_LOCAL_SRC:=0}
 
 # first do some checks ...
 if [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$PPLIST" == "?" ]; then
@@ -134,6 +134,7 @@ SOURCE_ROOT_CVODE="$NEK_SOURCE_ROOT/3rd_party/cvode"
 export SOURCE_ROOT_CVODE
 SOURCE_ROOT_HYPRE="$NEK_SOURCE_ROOT/3rd_party/hypre"
 export SOURCE_ROOT_HYPRE
+export NEK_DEPS_LOCAL_SRC
 
 NODEP=1
 if [ "$1" == "-build-dep" ]; then


### PR DESCRIPTION
Application depends on Nek5000 (like nekrs) may pack the source code and Nek5000 3rd party libraries with it.

This PR introduces env-var `NEK_DEPS_LOCAL_SRC` to control 2 modes for installing 3rd party libraries.
- 0 by default, which will use a stored `$VER` to fetch code into folder `gslib_v$VER` and soft link `gslib -> gslib_v$VER` after compilation
- 1 by choice, which directly uses the code `3rd_party/gslib/gslib` in-place (prepared by others, says nekrs) compiles directly without extra versioning and linking.

