### PR TITLE
Precision mismatch in write_xyz produces corrupt re2 v003 files for Hex20 meshes

### DIFF
--- a/tools/gmsh2nek/gmsh2nek.f90
+++ b/tools/gmsh2nek/gmsh2nek.f90
@@ -1965,7 +1965,7 @@
 
       use SIZE
 
-      real     xx(8), yy(8), zz(8)
+      real*8   xx(8), yy(8), zz(8)
       real*8   rgroup, buf2(30)
 
       integer isym2pre(8)   ! Symmetric-to-prenek vertex ordering

--- a/tools/gmsh2nek/mod_SIZE.f90
+++ b/tools/gmsh2nek/mod_SIZE.f90
@@ -20,17 +20,16 @@ module SIZE
       integer,save,allocatable,dimension(:,:)   ::node_quad,node_hex
       integer,save,allocatable,dimension(:,:)   ::quad_array,hex_array,hex_face_array
       integer,save,allocatable,dimension(:,:)   ::node_line
-	  integer,save,allocatable,dimension(:,:)   ::line_array,quad_line_array
+      integer,save,allocatable,dimension(:,:)   ::line_array,quad_line_array
       integer,save,allocatable,dimension(:)     ::r_or_l ! for 2d msh quad elements, right-hand or left-hand 
 
       integer,save,allocatable,dimension(:,:)     :: bcID ! bcID(1) = bcID, bcID(2) = surface total quad/lines elements number, bcID(3)=periodic bc id
       character(32),save,allocatable,dimension(:) :: bcChar
-
-	  
+  
 ! NEK CORE variables:
 !
       real,save,allocatable,dimension(:,:,:)   ::  bc, curve
-      real,save,allocatable,dimension(:,:,:,:) ::  xm1, ym1, zm1
+      real*8,save,allocatable,dimension(:,:,:,:) ::  xm1, ym1, zm1
 
       character(1),save,allocatable,dimension(:,:) :: ccurve
       character(3),save,allocatable,dimension(:,:) :: cbc


### PR DESCRIPTION
Fixes #894. The `gmsh2nek` tool produces corrupt `.re2` files when converting Gmsh Hex20 meshes due to a single/double precision mismatch between the coordinate storage arrays and the re2 v003 binary format.

## Root Cause

The re2 header is written as `#v003` (line 1641 of `gmsh2nek.f90`), which NekRS expects to contain double-precision (`real*8`) coordinate data. However, the coordinate arrays in `mod_SIZE.f90` are declared as single precision (`real`), and `write_xyz` uses single-precision local arrays when populating the output buffer.

In `write_xyz` (lines 1648–1708):

​```fortran
real     xx(8), yy(8), zz(8)       ! single precision (4 bytes each)
real*8   buf2(30)                   ! double precision (8 bytes each)
...
call copy(buf2(1), xx, 8)          ! copies 8 × 4 = 32 bytes into buf2
call byte_write(buf2(1), 16, ierr) ! writes 16 × 4 = 64 bytes from buf2
​```

`copy` (from the nek5000 core) operates on `real*4`. It copies 32 bytes of valid x-coordinates into the start of `buf2`, but `byte_write` then writes 64 bytes — only the first 32 are valid, and the remaining 32 are uninitialized memory.

When NekRS reads the file as v003, it interprets each 8-byte block as a `real*8`, which produces:

- Corners 0–3: `real*8` values formed by concatenating two adjacent `real*4` values bit-by-bit
- Corners 4–7: values read from uninitialized memory

## Observed Impact

On a 201,600-element Hex20 mesh:

- 1,335,332 degenerate corner pairs detected in the output `.re2`
- NekRS fails during connectivity calculation in parRSB with `element_check failed`
- The error generated is `ERROR: Connectivity calculation failed! Try tightening mesh::connectivityTol`
- Tightening `connectivityTol` does not help, because the underlying coordinates are corrupt rather than imprecise

## Fix

Promote the coordinate storage and the local arrays in `write_xyz` to double precision so that `copy` and `byte_write` operate on consistent 8-byte values matching the `#v003` format.

In `3rd_party/nek5000/tools/gmsh2nek/mod_SIZE.f90`:

​```fortran
real*8,save,allocatable,dimension(:,:,:,:) ::  xm1, ym1, zm1
​```

In `3rd_party/nek5000/tools/gmsh2nek/gmsh2nek.f90` (`write_xyz`):

​```fortran
real*8   xx(8), yy(8), zz(8)
​```

## Testing

- Regenerated the `.re2` for the 201,600-element Hex20 mesh from issue #894; 0 degenerate corner pairs reported.
- NekRS now completes connectivity calculation successfully on the same mesh.
- Verified existing Hex8 conversion path is unaffected.



Closes #894.