### PR TITLE
When lbelt != lelt and mhd is turned on, Nek fails to properly recognize the bounds of the arrays 

### DIFF
--- a/core/reader_rea.f
+++ b/core/reader_rea.f
@@ -290,6 +290,18 @@ c              read(string,*) IFSPLIT
          call exitt
       ENDIF
 
+      IF (LBELT.NE.LELT .AND. IFMHD) THEN
+         if(nid.eq.0) then
+           WRITE(6,23) LBELT,LELT
+   23      FORMAT(/s,2X,'Error: This NEKTON Solver has been compiled'
+     $      /,2X,'       with LBELT != LELT. A MHD run'
+     $      /,2X,'       requires that LBELT = LELT.'
+     $      /,2X,'       LBELT = ',I8
+     $      /,2X,'       LELT  = ',I8)
+         endif
+         call exitt
+      ENDIF
+
       if (ifmvbd) then
          if (lx1.ne.lx1m.or.ly1.ne.ly1m.or.lz1.ne.lz1m) 
      $      call exitti('Need lx1m=lx1 etc. in SIZE . $',lx1m)


### PR DESCRIPTION
## Cause/Symptoms
The SIZE file by default has lbelt = 1 to ensure that storage is not being wasted when MHD is not used. However, when MHD is turned on (ifmhd=.true., which is set by the reader_rea.f when param(29).ne.0), Nek expects the size of the arrays allocated for the magnetic field to be the same size as those allocated for the velocity field. This leads to undefined and unexpected behavior when writing outside the bounds of the array.

## Fix 
Added a check to ensure that lbelt = lelt when MHD is turned on and a corresponding error message when this is not met.