### PR TITLE
core: rename /CTMP[01]/ and /SCR??/ COMMON blocks per source file (fix #897, related #828)

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -1,0 +1,65 @@
+name: CI (macOS)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  main:
+    runs-on: macos-14
+    strategy:
+      matrix:
+        test_case: [
+            "Tools",
+            "Axi::test_PnPn_Parallel",
+            "ConjHt::test_PnPn_Parallel",
+            "Eddy_EddyUv::test_PnPn_Parallel",
+            "Eddy_LegacySize::test_PnPn2_Parallel",
+            "Ethier::test_PnPn2_Parallel",
+            "Ethier::test_PnPn_Parallel",
+            "FsHydro::test_PnPn2_Parallel",
+            "InclDef::test_PnPn_Serial",
+            "KovStokes::test_PnPn2_Parallel",
+            "KovStokes::test_PnPn_Parallel",
+            "LowMachTest::test_PnPn_Parallel",
+            "chan2d::test_PnPn_Parallel"
+        ]
+        include:
+          - test_case: "Tools"
+            mpi: no
+      fail-fast: false
+
+    name: "${{ matrix.test_case }}"
+
+    env:
+      TEST_CASE: ${{ matrix.test_case }}
+      MPI: "${{ matrix.mpi == 'no' && '0' || '1' }}"
+      FC: "${{ matrix.mpi == 'no' && 'gfortran' || 'mpif77' }}"
+      CC: "${{ matrix.mpi == 'no' && 'gcc-15' || 'mpicc' }}"
+      FFLAGS: "-fallow-argument-mismatch -ffp-contract=off"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: brew dependencies
+        shell: bash
+        run: |
+          brew update
+          brew install gcc open-mpi python@3.13
+          /opt/homebrew/bin/python3.13 -m pip install --break-system-packages pytest
+
+      - name: test
+        shell: bash
+        run: |
+          export PATH=/opt/homebrew/bin:$PATH
+          export OMPI_FC=gfortran-15
+          export OMPI_CC=gcc-15
+          /opt/homebrew/bin/python3.13 -m pytest -s -v short_tests/NekTests.py::$TEST_CASE

--- a/core/bdry.f
+++ b/core/bdry.f
@@ -584,10 +584,10 @@ C
       INCLUDE 'SOLN'
       INCLUDE 'TOPOL'
       INCLUDE 'CTIMER'
-      COMMON /SCRUZ/ TMP1(LX1,LY1,LZ1,LELV)
+      COMMON /scruz_bdry/ TMP1(LX1,LY1,LZ1,LELV)
      $             , TMP2(LX1,LY1,LZ1,LELV)
      $             , TMP3(LX1,LY1,LZ1,LELV)
-      COMMON /SCRMG/ TMQ1(LX1,LY1,LZ1,LELV)
+      COMMON /scrmg_bdry/ TMQ1(LX1,LY1,LZ1,LELV)
      $             , TMQ2(LX1,LY1,LZ1,LELV)
      $             , TMQ3(LX1,LY1,LZ1,LELV)
 C
@@ -721,7 +721,7 @@ C
       INCLUDE 'CTIMER'
 C
       DIMENSION S(LX1,LY1,LZ1,LELT)
-      COMMON /SCRSF/ TMP(LX1,LY1,LZ1,LELT)
+      COMMON /scrsf_bdry/ TMP(LX1,LY1,LZ1,LELT)
      $             , TMA(LX1,LY1,LZ1,LELT)
      $             , SMU(LX1,LY1,LZ1,LELT)
       common  /nekcb/ cb
@@ -1204,10 +1204,10 @@ C
       INCLUDE 'SOLN'
       INCLUDE 'GEOM'
       INCLUDE 'INPUT'
-      COMMON /SCRSF/ TRX(LX1,LY1,LZ1)
+      COMMON /scrsf_bdry/ TRX(LX1,LY1,LZ1)
      $             , TRY(LX1,LY1,LZ1)
      $             , TRZ(LX1,LY1,LZ1)
-      COMMON /CTMP0/ STC(LX1,LY1,LZ1)
+      COMMON /ctmp0_bdry/ STC(LX1,LY1,LZ1)
       REAL SIGST(LX1,LY1)
 C
       LOGICAL IFALGN,IFNORX,IFNORY,IFNORZ
@@ -1351,7 +1351,7 @@ C
       INCLUDE 'DXYZ'
       INCLUDE 'TOPOL'
       INCLUDE 'WZ'
-      COMMON /CTMP1/ A1X(LX1),A1Y(LX1),STX(LX1),STY(LX1)
+      COMMON /ctmp1_bdry/ A1X(LX1),A1Y(LX1),STX(LX1),STY(LX1)
 C
       DIMENSION TRX(LX1,LY1,LZ1),TRY(LX1,LY1,LZ1),SIGST(LX1,1)
       DIMENSION CANG(2),SANG(2)
@@ -1416,9 +1416,9 @@ C
       INCLUDE 'DXYZ'
       INCLUDE 'TOPOL'
       INCLUDE 'WZ'
-      COMMON /CTMP1/ A1X(LX1),A1Y(LX1),A2X(LX1),A2Y(LX1)
+      COMMON /ctmp1_bdry/ A1X(LX1),A1Y(LX1),A2X(LX1),A2Y(LX1)
      $             , STX(LX1),STY(LX1),XJM1(LX1)
-      COMMON /CTMP0/ XFM1(LX1),YFM1(LX1),T1XF(LX1),T1YF(LX1)
+      COMMON /ctmp0_bdry/ XFM1(LX1),YFM1(LX1),T1XF(LX1),T1YF(LX1)
 C
       DIMENSION TRX(LX1,LY1,LZ1),TRY(LX1,LY1,LZ1),SIGST(LX1,LY1)
       DIMENSION CANG(2),SANG(2)
@@ -1596,15 +1596,15 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'GEOM'
       INCLUDE 'WZ'
-      COMMON /CTMP0/  XFM1(LX1,LY1),YFM1(LX1,LY1),ZFM1(LX1,LY1)
-      COMMON /CTMP1/  DRM1(LX1,LX1),DRTM1(LX1,LY1)
+      COMMON /ctmp0_bdry/  XFM1(LX1,LY1),YFM1(LX1,LY1),ZFM1(LX1,LY1)
+      COMMON /ctmp1_bdry/  DRM1(LX1,LX1),DRTM1(LX1,LY1)
      $             ,  DSM1(LX1,LX1),DSTM1(LX1,LY1)
      $             ,  WGS(LX1,LY1)
-      COMMON /SCRMG/  XRM1(LX1,LY1),YRM1(LX1,LY1),ZRM1(LX1,LY1)
+      COMMON /scrmg_bdry/  XRM1(LX1,LY1),YRM1(LX1,LY1),ZRM1(LX1,LY1)
      $             ,  XSM1(LX1,LY1),YSM1(LX1,LY1),ZSM1(LX1,LY1)
-      COMMON /SCRUZ/  S1X(LX1,LY1),S1Y(LX1,LY1),S1Z(LX1,LY1)
+      COMMON /scruz_bdry/  S1X(LX1,LY1),S1Y(LX1,LY1),S1Z(LX1,LY1)
      $             ,  S2X(LX1,LY1),S2Y(LX1,LY1),S2Z(LX1,LY1)
-      COMMON /SCRNS/  G1X(LX1,LY1),G1Y(LX1,LY1),G1Z(LX1,LY1)
+      COMMON /scrns_bdry/  G1X(LX1,LY1),G1Y(LX1,LY1),G1Z(LX1,LY1)
      $             ,  G2X(LX1,LY1),G2Y(LX1,LY1),G2Z(LX1,LY1)
      $             ,  GBS(LX1,LY1),GB1L(LX1,LY1),GB2L(LX1,LY1)
 C
@@ -1847,7 +1847,7 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'GEOM'
       INCLUDE 'SOLN'
-      COMMON /SCRMG/ V1(LX1,LY1,LZ1,LELV)
+      COMMON /scrmg_bdry/ V1(LX1,LY1,LZ1,LELV)
      $             , V2(LX1,LY1,LZ1,LELV)
      $             , V3(LX1,LY1,LZ1,LELV)
      $             , VV(LX1,LY1,LZ1,LELV)
@@ -1941,7 +1941,7 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
 
-      common /scrmg/ v1(lx1,ly1,lz1,lelt)
+      common /scrmg_bdry/ v1(lx1,ly1,lz1,lelt)
      $             , v2(lx1,ly1,lz1,lelt)
      $             , v3(lx1,ly1,lz1,lelt)
 

--- a/core/coef.f
+++ b/core/coef.f
@@ -408,24 +408,24 @@ C
 C     Note : work arrays for mesh 3 in scratch commons will be 
 C            changed after exit of routine.
 C
-      COMMON /SCRNS/ XRM3 (LX3,LY3,LZ3,LELT)
+      COMMON /scrns_coef/ XRM3 (LX3,LY3,LZ3,LELT)
      $ ,             XSM3 (LX3,LY3,LZ3,LELT)
      $ ,             XTM3 (LX3,LY3,LZ3,LELT)
      $ ,             YRM3 (LX3,LY3,LZ3,LELT)
      $ ,             YSM3 (LX3,LY3,LZ3,LELT)
      $ ,             YTM3 (LX3,LY3,LZ3,LELT)
      $ ,             ZRM3 (LX3,LY3,LZ3,LELT)
-      COMMON /CTMP0/ ZSM3 (LX3,LY3,LZ3,LELT)
+      COMMON /ctmp0_coef/ ZSM3 (LX3,LY3,LZ3,LELT)
      $ ,             ZTM3 (LX3,LY3,LZ3,LELT)
-      COMMON /CTMP1/ RXM3 (LX3,LY3,LZ3,LELT)
+      COMMON /ctmp1_coef/ RXM3 (LX3,LY3,LZ3,LELT)
      $ ,             RYM3 (LX3,LY3,LZ3,LELT)
      $ ,             RZM3 (LX3,LY3,LZ3,LELT)
      $ ,             SXM3 (LX3,LY3,LZ3,LELT)
-      COMMON /SCRMG/ SYM3 (LX3,LY3,LZ3,LELT)
+      COMMON /scrmg_coef/ SYM3 (LX3,LY3,LZ3,LELT)
      $ ,             SZM3 (LX3,LY3,LZ3,LELT)
      $ ,             TXM3 (LX3,LY3,LZ3,LELT)
      $ ,             TYM3 (LX3,LY3,LZ3,LELT)
-      COMMON /SCREV/ TZM3 (LX3,LY3,LZ3,LELT)
+      COMMON /screv_coef/ TZM3 (LX3,LY3,LZ3,LELT)
      $ ,             JACM3(LX3,LY3,LZ3,LELT)
       REAL           JACM3
       DIMENSION XM3(LX3,LY3,LZ3,1)
@@ -575,14 +575,14 @@ C
 C     Note: Subroutines GLMAPM1, GEODAT1, AREA2, SETWGTR and AREA3 
 C           share the same array structure in Scratch Common /SCRNS/.
 C
-      COMMON /SCRNS/ XRM1(LX1,LY1,LZ1,LELT)
+      COMMON /scrns_coef/ XRM1(LX1,LY1,LZ1,LELT)
      $ ,             YRM1(LX1,LY1,LZ1,LELT)
      $ ,             XSM1(LX1,LY1,LZ1,LELT)
      $ ,             YSM1(LX1,LY1,LZ1,LELT)
      $ ,             XTM1(LX1,LY1,LZ1,LELT)
      $ ,             YTM1(LX1,LY1,LZ1,LELT)
      $ ,             ZRM1(LX1,LY1,LZ1,LELT)
-      COMMON /CTMP1/ ZSM1(LX1,LY1,LZ1,LELT)
+      COMMON /ctmp1_coef/ ZSM1(LX1,LY1,LZ1,LELT)
      $ ,             ZTM1(LX1,LY1,LZ1,LELT)
 C
       NXY1  = lx1*ly1
@@ -647,14 +647,14 @@ C
 C     Note: Subroutines GLMAPM1, GEODAT1, AREA2, SETWGTR and AREA3 
 C           share the same array structure in Scratch Common /SCRNS/.
 C
-      COMMON /SCRNS/ XRM1(LX1,LY1,LZ1,LELT)
+      COMMON /scrns_coef/ XRM1(LX1,LY1,LZ1,LELT)
      $ ,             YRM1(LX1,LY1,LZ1,LELT)
      $ ,             XSM1(LX1,LY1,LZ1,LELT)
      $ ,             YSM1(LX1,LY1,LZ1,LELT)
      $ ,             XTM1(LX1,LY1,LZ1,LELT)
      $ ,             YTM1(LX1,LY1,LZ1,LELT)
      $ ,             ZRM1(LX1,LY1,LZ1,LELT)
-      COMMON /CTMP1/ ZSM1(LX1,LY1,LZ1,LELT)
+      COMMON /ctmp1_coef/ ZSM1(LX1,LY1,LZ1,LELT)
      $ ,             ZTM1(LX1,LY1,LZ1,LELT)
      $ ,             WJ   (LX1,LY1,LZ1,LELT)
 C
@@ -1241,11 +1241,11 @@ C
 C     Note: Subroutines GLMAPM1, GEODAT1, AREA2, SETWGTR and AREA3 
 C           share the same array structure in Scratch Common /SCRNS/.
 C
-      COMMON /SCRNS/ XRM1(LX1,LY1,LZ1,LELT)
+      COMMON /scrns_coef/ XRM1(LX1,LY1,LZ1,LELT)
      $ ,             YRM1(LX1,LY1,LZ1,LELT)
      $ ,             XSM1(LX1,LY1,LZ1,LELT)
      $ ,             YSM1(LX1,LY1,LZ1,LELT)
-      COMMON /CTMP0/ WGTR1(LX1,LELT)
+      COMMON /ctmp0_coef/ WGTR1(LX1,LELT)
      $ ,             WGTR2(LY1,LELT)
      $ ,             WGTR3(LX1,LELT)
      $ ,             WGTR4(LY1,LELT)
@@ -1308,7 +1308,7 @@ C
 C     Note: Subroutines GLMAPM1, GEODAT1, AREA2, SETWGTR and AREA3 
 C           share the same array structure in Scratch Common /SCRNS/.
 C
-      COMMON /SCRNS/ XRM1(LX1,LY1,LZ1,LELT)
+      COMMON /scrns_coef/ XRM1(LX1,LY1,LZ1,LELT)
      $ ,             YRM1(LX1,LY1,LZ1,LELT)
      $ ,             XSM1(LX1,LY1,LZ1,LELT)
      $ ,             YSM1(LX1,LY1,LZ1,LELT)
@@ -1364,18 +1364,18 @@ C
 C     Note: Subroutines GLMAPM1, GEODAT1, AREA2, SETWGTR and AREA3 
 C           share the same array structure in Scratch Common /SCRNS/.
 C
-      COMMON /SCRNS/ XRM1(LX1,LY1,LZ1,LELT)
+      COMMON /scrns_coef/ XRM1(LX1,LY1,LZ1,LELT)
      $ ,             YRM1(LX1,LY1,LZ1,LELT)
      $ ,             XSM1(LX1,LY1,LZ1,LELT)
      $ ,             YSM1(LX1,LY1,LZ1,LELT)
      $ ,             XTM1(LX1,LY1,LZ1,LELT)
      $ ,             YTM1(LX1,LY1,LZ1,LELT)
      $ ,             ZRM1(LX1,LY1,LZ1,LELT)
-      COMMON /CTMP1/ ZSM1(LX1,LY1,LZ1,LELT)
+      COMMON /ctmp1_coef/ ZSM1(LX1,LY1,LZ1,LELT)
      $ ,             ZTM1(LX1,LY1,LZ1,LELT)
      $ ,             A  (LX1,LY1,LZ1,LELT)
      $ ,             B  (LX1,LY1,LZ1,LELT)
-      COMMON /CTMP0/ C  (LX1,LY1,LZ1,LELT)
+      COMMON /ctmp0_coef/ C  (LX1,LY1,LZ1,LELT)
      $ ,             DOT(LX1,LY1,LZ1,LELT)
 C
       NXY1  = lx1*ly1
@@ -1561,7 +1561,7 @@ C
       REAL Y(LX1,LY1,LZ1)
 C
       REAL XA(lx1,NREST,NREST)
-      COMMON /CTMP0/ XB(LX1,LY1,LZ1)
+      COMMON /ctmp0_coef/ XB(LX1,LY1,LZ1)
 C
       REAL IXRES(LX1,LX1),IXTRES(LX1,LX1)
       REAL IYRES(LY1,LY1),IYTRES(LY1,LY1)
@@ -1628,7 +1628,7 @@ C
       REAL X(LX3,LY3,LZ3)
       REAL Y(LX1,LY1,LZ1)
 C
-      COMMON /CTMP0/ XA(LX1,LY3,LZ3), XB(LX1,LY1,LZ3)
+      COMMON /ctmp0_coef/ XA(LX1,LY3,LZ3), XB(LX1,LY1,LZ3)
 C
       NYZ3 = ly3*lz3
       NXY1 = lx1*ly1
@@ -1671,7 +1671,7 @@ C
       REAL X(LX1,LY1,LZ1)
       REAL Y(LX3,LY3,LZ3)
 C
-      COMMON /CTMP0/ XA(LX3,LY1,LZ1),  XB(LX3,LY3,LZ1)
+      COMMON /ctmp0_coef/ XA(LX3,LY1,LZ1),  XB(LX3,LY3,LZ1)
 C
       NYZ1 = ly1*lz1
       NXY3 = lx3*ly3
@@ -1746,7 +1746,7 @@ C
       REAL X(LX2,LY2,LZ2)
       REAL Y(LX1,LY1,LZ1)
 C
-      COMMON /CTMP0/ XA(LX1,LY2,LZ2), XB(LX1,LY1,LZ2)
+      COMMON /ctmp0_coef/ XA(LX1,LY2,LZ2), XB(LX1,LY1,LZ2)
 C
       NYZ2 = ly2*lz2
       NXY1 = lx1*ly1
@@ -1787,7 +1787,7 @@ C
       REAL X(LX2,LY2,LZ2)
       REAL Y(LX1,LY1,LZ1)
 C
-      COMMON /CTMP0/ XA(LX1,LY2,LZ2), XB(LX1,LY1,LZ2)
+      COMMON /ctmp0_coef/ XA(LX1,LY2,LZ2), XB(LX1,LY1,LZ2)
 C
       NYZ2 = ly2*lz2
       NXY1 = lx1*ly1

--- a/core/comm_mpi.f
+++ b/core/comm_mpi.f
@@ -784,7 +784,7 @@ c-----------------------------------------------------------------------
 
       parameter  (lt=lx1*ly1*lz1*lelt)
       parameter (mwd = 3*lt/2)
-      common /scrns/ x(mwd),y(mwd),x1(mwd),y1(mwd)
+      common /scrns_comm_mpi/ x(mwd),y(mwd),x1(mwd),y1(mwd)
 
       include 'mpif.h'
       integer status(mpi_status_size)
@@ -864,7 +864,7 @@ c-----------------------------------------------------------------------
 
       parameter  (lt=lx1*ly1*lz1*lelt)
       parameter (mwd = 3*lt)
-      common /scrns/ x(mwd),y(mwd)
+      common /scrns_comm_mpi/ x(mwd),y(mwd)
 
       include 'mpif.h'
       integer status(mpi_status_size)
@@ -958,7 +958,7 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       common /nekmpi/ mid,np,nekcomm,nekgroup,nekreal
       parameter (lt=lx1*ly1*lz1*lelt)
-      common /scrns/ x(3*lt),y(3*lt)
+      common /scrns_comm_mpi/ x(3*lt),y(3*lt)
 !
 !     Est. msg vol for dt s
 !
@@ -1018,9 +1018,9 @@ c-----------------------------------------------------------------------
 
       parameter  (lt=lx1*ly1*lz1*lelt)
       parameter (mwd = 3*lt)
-      common /scrns/ x(mwd),y(mwd)
-      common /scruz/ times(2,500)
-      common /scrcg/ nwd(500)
+      common /scrns_comm_mpi/ x(mwd),y(mwd)
+      common /scruz_comm_mpi/ times(2,500)
+      common /scrcg_comm_mpi/ nwd(500)
 
       nwds  = 1
       mtest = 0
@@ -1084,8 +1084,8 @@ c-----------------------------------------------------------------------
 
       parameter  (lt=lx1*ly1*lz1*lelt)
       parameter (mwd = 3*lt)
-      common /scrns/ x(mwd),y(mwd)
-      common /scruz/ times(2,500)
+      common /scrns_comm_mpi/ x(mwd),y(mwd)
+      common /scruz_comm_mpi/ times(2,500)
 
       call rzero(x,mwd)
 

--- a/core/conduct.f
+++ b/core/conduct.f
@@ -14,9 +14,9 @@ C
       LOGICAL          IFPRINT
       LOGICAL          IFCONV
 
-      COMMON /SCRNS/ TA(LX1,LY1,LZ1,LELT)
+      COMMON /scrns_conduct/ TA(LX1,LY1,LZ1,LELT)
      $              ,TB(LX1,LY1,LZ1,LELT)
-      COMMON /SCRVH/ H1(LX1,LY1,LZ1,LELT)
+      COMMON /scrvh_conduct/ H1(LX1,LY1,LZ1,LELT)
      $              ,H2(LX1,LY1,LZ1,LELT)
 
       include 'ORTHOT'
@@ -216,7 +216,7 @@ C---------------------------------------------------------------
       include 'MASS'
       include 'TSTEP'
 
-      common /scruz/ ta (lx1*ly1*lz1*lelt)
+      common /scruz_conduct/ ta (lx1*ly1*lz1*lelt)
 
       nel = nelfld(ifield)
       n   = lx1*ly1*lz1*nel
@@ -264,7 +264,7 @@ C-----------------------------------------------------------------------
       include 'TOTAL'
 
       parameter (lt=lx1*ly1*lz1*lelt)
-      common /scrns/ tb(lt),h2(lt)
+      common /scrns_conduct/ tb(lt),h2(lt)
 
       nel   = nelfld(ifield)
       n     = lx1*ly1*lz1*nel
@@ -304,7 +304,7 @@ C-----------------------------------------------------------------------
       include 'TOTAL'
 
       parameter (lt=lx1*ly1*lz1*lelt)
-      common /scrns/ tb(lt),h2(lt)
+      common /scrns_conduct/ tb(lt),h2(lt)
 
       nel   = nelfld(ifield)
       n     = lx1*ly1*lz1*nelv
@@ -431,9 +431,9 @@ C
       logical          ifprint
       logical          ifconv
 
-      common /scrns/ ta(lx1,ly1,lz1,lelt)
+      common /scrns_conduct/ ta(lx1,ly1,lz1,lelt)
      $              ,tb(lx1,ly1,lz1,lelt)
-      common /scrvh/ h1(lx1,ly1,lz1,lelt)
+      common /scrvh_conduct/ h1(lx1,ly1,lz1,lelt)
      $              ,h2(lx1,ly1,lz1,lelt)
 
 
@@ -492,7 +492,7 @@ c
       include 'TSTEP'
       include 'INPUT'
 
-      common /scruz/ ta(lx1,ly1,lz1,lelt)
+      common /scruz_conduct/ ta(lx1,ly1,lz1,lelt)
      $              ,h2(lx1,ly1,lz1,lelt)
 
       nel = nelfld(ifield)
@@ -569,7 +569,7 @@ c-----------------------------------------------------------------------
       integer e,f
 
       parameter(lf=lx1*lz1*2*ldim*lelt)
-      common /scrdg/uf(lx1*lz1,2*ldim,lelt)
+      common /scrdg_conduct/uf(lx1*lz1,2*ldim,lelt)
 
 
 
@@ -594,7 +594,7 @@ c-----------------------------------------------------------------------
       include 'TOTAL'
 
       common /ivrtx/ vertex ((2**ldim)*lelt)
-      common /ctmp1/ qs(lx1*ly1*lz1*lelt)
+      common /ctmp1_conduct/ qs(lx1*ly1*lz1*lelt)
       integer*8 vertex
 
       logical ifany
@@ -629,7 +629,7 @@ c-----------------------------------------------------------------------
       include 'TOTAL'
 
       real mask(1)
-      common /ctmp0/ qs(lx1*ly1*lz1*lelt)
+      common /ctmp0_conduct/ qs(lx1*ly1*lz1*lelt)
 
       integer ifld_last
       save    ifld_last
@@ -654,8 +654,8 @@ C
       logical          ifprint,ifconv
 
       parameter (lt=lx1*ly1*lz1*lelt)
-      common /scrns/ ta(lt),tb(lt)
-      common /scrvh/ h1(lt),h2(lt)
+      common /scrns_conduct/ ta(lt),tb(lt)
+      common /scrvh_conduct/ h1(lt),h2(lt)
 
       include 'ORTHOT'  ! This must be fixed
 

--- a/core/connect1.f
+++ b/core/connect1.f
@@ -25,7 +25,7 @@ C
 c
       common /nekmpi/ nidd,npp,nekcomm,nekgroup,nekreal
 c      
-      COMMON /SCRUZ/ XM3 (LX3,LY3,LZ3,LELT)
+      COMMON /scruz_connect1/ XM3 (LX3,LY3,LZ3,LELT)
      $ ,             YM3 (LX3,LY3,LZ3,LELT)
      $ ,             ZM3 (LX3,LY3,LZ3,LELT)
 C
@@ -307,7 +307,7 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'TOPOL'
 C
-      COMMON /CTMP0/ ITMP(3,3,3)
+      COMMON /ctmp0_connect1/ ITMP(3,3,3)
       INTEGER ORDER
 C
       NXL=3
@@ -713,7 +713,8 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'INPUT'
       INCLUDE 'SCRCT'
-      COMMON /CTMP0/ XCB(2,2,2),YCB(2,2,2),ZCB(2,2,2),H(3,3,2),INDX(8)
+      COMMON /ctmp0_connect1/ XCB(2,2,2),YCB(2,2,2),ZCB(2,2,2),H(3,3,2),
+     $ INDX(8)
 C
       NXL=3
       NYL=3
@@ -1604,11 +1605,12 @@ c-----------------------------------------------------------------------
       integer*8 vertex
 
       parameter(lxyz=lx1*ly1*lz1)
-      common /scrns/ enum(lxyz,lelt)
+      common /scrns_connect1/ enum(lxyz,lelt)
      $             ,  rnx(lxyz,lelt) , rny(lxyz,lelt) , rnz(lxyz,lelt)
      $             ,  tnx(lxyz,lelt) , tny(lxyz,lelt) , tnz(lxyz,lelt)
-      common /scruz/  snx(lxz) , sny(lxz) , snz(lxz) ,  efc(lxz)
-      common /scrsf/  jvrtex((2**ldim),lelt)
+      common /scruz_connect1/  snx(lxz) , sny(lxz) , snz(lxz) ,
+     $   efc(lxz)
+      common /scrsf_connect1/  jvrtex((2**ldim),lelt)
       integer*8 jvrtex,mvertx,i8glmax
 
       integer e,f,eg

--- a/core/connect2.f
+++ b/core/connect2.f
@@ -148,7 +148,7 @@ C=====================================================================
 C
       INCLUDE 'SIZE'
       INCLUDE 'TOTAL'
-      COMMON /SCRNS/ TA(LX1,LY1,LZ1,LELT),TB(LX1,LY1,LZ1,LELT)
+      COMMON /scrns_connect2/ TA(LX1,LY1,LZ1,LELT),TB(LX1,LY1,LZ1,LELT)
      $           ,QMASK(LX1,LY1,LZ1,LELT),tmp(2)
       CHARACTER*3 CB
 
@@ -378,7 +378,7 @@ C=====================================================================
 C
       INCLUDE 'SIZE'
       INCLUDE 'TOTAL'
-      common /scrns/ tc(lx1,ly1,lz1,lelt),td(lx1,ly1,lz1,lelt)
+      common /scrns_connect2/ tc(lx1,ly1,lz1,lelt),td(lx1,ly1,lz1,lelt)
      $             , ta(lx1,ly1,lz1,lelt),tb(lx1,ly1,lz1,lelt)
      $             , qmask(lx1,ly1,lz1,lelt)
       CHARACTER*3 CB
@@ -561,7 +561,7 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'INPUT'
       DIMENSION XYZ(3,1)
-      COMMON /CTMP0/ RMTRX(3,3),RX(3,3),RZ(3,3),XYZN(3,10)
+      COMMON /ctmp0_connect2/ RMTRX(3,3),RX(3,3),RZ(3,3),XYZN(3,10)
 C
       SINA=SIN(ANGLE)
       COSA=COS(ANGLE)
@@ -608,7 +608,7 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'INPUT'
       DIMENSION XYZL(3,8,LELT)
-      COMMON /CTMP0/ VO(LELT),XYZI(3,LELT),CG(3,LELT)
+      COMMON /ctmp0_connect2/ VO(LELT),XYZI(3,LELT),CG(3,LELT)
      $              ,TI(6),WORK(6)
 C
 C     Compute volumes -
@@ -781,7 +781,7 @@ C
 C
       DIMENSION LIST(LELT),LIST1(LELT),LIST2(LELT)
       DIMENSION XYZI(3),CG(3,LELT),wgt(1)
-      COMMON /CTMP0/ XCG(LELT),YCG(LELT),ZCG(LELT)
+      COMMON /ctmp0_connect2/ XCG(LELT),YCG(LELT),ZCG(LELT)
       REAL IXX,IYY,IZZ
       INTEGER WORK(2),WRK2(2)
       LOGICAL IFOK

--- a/core/convect.f
+++ b/core/convect.f
@@ -13,14 +13,14 @@ c
       real    p0(1),u(1),ulag(1),bm(1),bmlag(1),msk(1),c(1),cs(0:1)
       integer gsl
 
-      common /scrns/ ct  (lxd*lyd*lzd*lelv*ldim)
+      common /scrns_convect/ ct  (lxd*lyd*lzd*lelv*ldim)
 
-      common /scrvh/ bmsk(lx1*ly1*lz1*lelv)
+      common /scrvh_convect/ bmsk(lx1*ly1*lz1*lelv)
      $             , bdwt(lx1*ly1*lz1*lelv)
      $             , bmst(lx1*ly1*lz1*lelv)
      $             , u1  (lx1*ly1*lz1*lelv)
 
-      common /scrmg/ r1  (lx1*ly1*lz1*lelv)
+      common /scrmg_convect/ r1  (lx1*ly1*lz1*lelv)
      $             , r2  (lx1*ly1*lz1*lelv)
      $             , r3  (lx1*ly1*lz1*lelv)
      $             , r4  (lx1*ly1*lz1*lelv)
@@ -243,7 +243,7 @@ c
       real  u(mx*mx*mx,nel)
       real  c(md*md*md,nel,3)
       parameter (ldd=lxd*lyd*lzd)
-      common /ctmp1/ ur(ldd),us(ldd),ut(ldd),ud(ldd)
+      common /ctmp1_convect/ ur(ldd),us(ldd),ut(ldd),ud(ldd)
 c
       logical if3d,ifd
       integer e
@@ -285,7 +285,7 @@ c
       real  u(mx*mx,nel)
       real  c(md*md,nel,2)
       parameter (ldd=lxd*lyd*lzd)
-      common /ctmp1/ ur(ldd),us(ldd),ut(ldd),ud(ldd)
+      common /ctmp1_convect/ ur(ldd),us(ldd),ut(ldd),ud(ldd)
 c
       logical if3d,ifd
       integer e
@@ -360,7 +360,7 @@ c     If idir ^= 0, then apply transpose operator  (md to mx)
       real jgl,jgt
 
       parameter (ld=2*lxd)
-      common /ctmp0/ w(ld**ldim,2)
+      common /ctmp0_convect/ w(ld**ldim,2)
 
       call lim_chk(md,ld,'md   ','ld   ','grad_rstd ')
       call lim_chk(mx,ld,'mx   ','ld   ','grad_rstd ')
@@ -647,7 +647,7 @@ C
       logical ifuf,ifcf            ! u and/or c already on fine mesh?
 
       parameter (lxy=lx1*ly1*lz1,ltd=lxd*lyd*lzd)
-      common /scrcv/ fx(ltd),fy(ltd),fz(ltd)
+      common /scrcv_convect/ fx(ltd),fy(ltd),fz(ltd)
      $             , ur(ltd),us(ltd),ut(ltd)
      $             , tr(ltd,3),uf(ltd)
 
@@ -747,7 +747,7 @@ c     conservative form
       logical ifuf,ifcf            ! u and/or c already on fine mesh?
 
       parameter (lxy=lx1*ly1*lz1,ltd=lxd*lyd*lzd)
-      common /scrcv/ uf(ltd),cf(ltd),cu(ltd)
+      common /scrcv_convect/ uf(ltd),cf(ltd),cu(ltd)
      $             , cr(ltd),cs(ltd),ct(ltd)
 
 
@@ -860,7 +860,7 @@ C
       real cr(ltd,1),cs(ltd,1),ct(ltd,1)
       real ux(lxy,1),uy(lxy,1),uz(lxy,1)
 
-      common /scrcv/ fx(ltd),fy(ltd),fz(ltd)
+      common /scrcv_convect/ fx(ltd),fy(ltd),fz(ltd)
      $             , ur(ltd),us(ltd),ut(ltd)
      $             , tr(ltd,3),uf(ltd)
 
@@ -924,7 +924,7 @@ c
 
       common /cchar/ ct_vx(0:lorder) ! time for each slice in c_vx()
 
-      common /scruz/ phx  (lx1*ly1*lz1*lelt)
+      common /scruz_convect/ phx  (lx1*ly1*lz1*lelt)
      $ ,             phy  (lx1*ly1*lz1*lelt)
      $ ,             phz  (lx1*ly1*lz1*lelt)
      $ ,             hmsk (lx1*ly1*lz1*lelt)
@@ -984,7 +984,7 @@ c     operator-integrator-factor method (characteristics).
 
       common /cchar/ ct_vx(0:lorder) ! time for each slice in c_vx()
 
-      common /scruz/ phi  (lx1*ly1*lz1*lelt)
+      common /scruz_convect/ phi  (lx1*ly1*lz1*lelt)
      $ ,             hmsk (lx1*ly1*lz1*lelt)
 
       if (icalld.eq.0) tadvc=0.0
@@ -1023,7 +1023,8 @@ c     Assumes that current convecting field is on dealias mesh, in c()
       real  u(mx*mx*mx,nel)
       real  c(md*md*md,nel,3)
       parameter (ldd=lxd*lyd*lzd)
-      common /ctmp1/ ur(ldd),us(ldd),ut(ldd),ju(ldd),ud(ldd),tu(ldd)
+      common /ctmp1_convect/ ur(ldd),us(ldd),ut(ldd),ju(ldd),ud(ldd),
+     $ tu(ldd)
       real ju
 
       logical if3d,ifd
@@ -1079,7 +1080,8 @@ c     Assumes that current convecting field is on dealias mesh, in c()
       real  u(mx*mx,nel)
       real  c(md*md,nel,2)
       parameter (ldd=lxd*lyd*lzd)
-      common /ctmp1/ ur(ldd),us(ldd),ut(ldd),ju(ldd),ud(ldd),tu(ldd)
+      common /ctmp1_convect/ ur(ldd),us(ldd),ut(ldd),ju(ldd),ud(ldd),
+     $ tu(ldd)
       real ju
 
       logical if3d,ifd
@@ -1209,7 +1211,7 @@ c-----------------------------------------------------------------------
       include 'MASS'
       include 'INPUT'
       include 'MVGEOM'
-      common /scruz/ cx  (lx1*ly1*lz1*lelt)
+      common /scruz_convect/ cx  (lx1*ly1*lz1*lelt)
      $ ,             cy  (lx1*ly1*lz1*lelt)
      $ ,             cz  (lx1*ly1*lz1*lelt)
 
@@ -1392,7 +1394,8 @@ c     Apply convecting field c(1,ldim) to scalar field u(1).
       real du(1),u(1),c(1)
 
       parameter(lf=lx1*lz1*2*ldim*lelt)
-      common /scrdg/ uf(lf),uxf(lf),uyf(lf),uzf(lf),upwind_wgt(lf)
+      common /scrdg_convect/ uf(lf),uxf(lf),uyf(lf),uzf(lf),
+     $ upwind_wgt(lf)
 
       integer e,f
 
@@ -1471,7 +1474,7 @@ c     If idir ^= 0, then apply transpose operator  (md to mx)
       real jgl,jgt
 
       parameter (ld=2*lxd)
-      common /ctmp0/ w(ld**ldim,2)
+      common /ctmp0_convect/ w(ld**ldim,2)
 
       call lim_chk(md,ld,'md   ','ld   ','map_faced ')
       call lim_chk(mx,ld,'mx   ','ld   ','map_faced ')
@@ -1596,7 +1599,8 @@ c     Apply convecting field c(1,ldim) to scalar field u(1).
       real du(1),u(1),c(ldd*lelv,3)
 
       parameter(lf=lx1*lz1*2*ldim*lelt)
-      common /scrdg/ uf(lf),uxf(lf),uyf(lf),uzf(lf),upwind_wgt(lf)
+      common /scrdg_convect/ uf(lf),uxf(lf),uyf(lf),uzf(lf),
+     $ upwind_wgt(lf)
      $             , beta_c(lx1*lz1),jaco_c(lx1*lz1)
      $             , beta_f(lxd*lzd),jaco_f(lxd*lzd)
      $             , ufine (lxd*lzd)
@@ -1696,7 +1700,8 @@ c     Assumes that current convecting field is on dealias mesh, in c()
       real du(lxx,nel)
       real  u(lxx,nel)
       real  cr(ldd,nel),cs(ldd,nel),ct(ldd,nel)
-      common /ctmp1/ ur(ldd),us(ldd),ut(ldd),ju(ldd),ud(ldd),tu(ldd)
+      common /ctmp1_convect/ ur(ldd),us(ldd),ut(ldd),ju(ldd),ud(ldd),
+     $ tu(ldd)
       real ju
 
       integer e
@@ -1746,7 +1751,8 @@ c     Apply convecting field c(1,ldim) to scalar field u(1).
       real du(1),u(1)
 
       parameter(lf=lx1*lz1*2*ldim*lelt)
-      common /scrdg/uf(lf),uxf(lf),uyf(lf),uzf(lf),upwind_wgt(lf),us(lf)
+      common /scrdg_convect/uf(lf),uxf(lf),uyf(lf),uzf(lf),
+     $ upwind_wgt(lf),us(lf)
      $             ,beta_c(lx1*lz1),jaco_c(lx1*lz1)
      $             ,beta_f(lxd*lzd),jaco_f(lxd*lzd)
      $             ,ufine (lxd*lzd)
@@ -1833,7 +1839,8 @@ c     Apply convecting field c(1,ldim) to scalar field u(1).
       real du(1),u(1),cr(1),cs(1),ct(1)
 
       parameter(lf=lx1*lz1*2*ldim*lelt)
-      common /scrdg/uf(lf),uxf(lf),uyf(lf),uzf(lf),upwind_wgt(lf),us(lf)
+      common /scrdg_convect/uf(lf),uxf(lf),uyf(lf),uzf(lf),
+     $ upwind_wgt(lf),us(lf)
      $             ,beta_c(lx1*lz1),jaco_c(lx1*lz1)
      $             ,beta_f(lxd*lzd),jaco_f(lxd*lzd)
      $             ,ufine (lxd*lzd)

--- a/core/convect2.f
+++ b/core/convect2.f
@@ -20,7 +20,7 @@ c-----------------------------------------------------------------------
 
       common /cchar/ ct_vx(0:lorder+1) ! time for each slice in c_vx()
 
-      common /scruz/ cx  (lx1*ly1*lz1*lelt)
+      common /scruz_convect2/ cx  (lx1*ly1*lz1*lelt)
      $ ,             cy  (lx1*ly1*lz1*lelt)
      $ ,             cz  (lx1*ly1*lz1*lelt)
      $ ,             hmsk(lx1*ly1*lz1*lelt)
@@ -82,7 +82,7 @@ c-----------------------------------------------------------------------
       integer msk(0:1)
       character      cb*3
       parameter (lxyz1=lx1*ly1*lz1)
-      common /ctmp1/ work(lxyz1,lelt)
+      common /ctmp1_convect2/ work(lxyz1,lelt)
 
       real mask(lxyz1,1),u(lxyz1,1),v(lxyz1,1),w(lxyz1,1)
 

--- a/core/cvode_driver.f
+++ b/core/cvode_driver.f
@@ -402,7 +402,7 @@ c
      &                ,wy_ (lx1,ly1,lz1,lelv)
      &                ,wz_ (lx1,ly1,lz1,lelv)
 
-      COMMON /SCRSF/ dtmp(lx1*ly1*lz1*lelv)
+      COMMON /scrsf_cvode_driver/ dtmp(lx1*ly1*lz1*lelv)
 
       ntot = lx1*ly1*lz1*nelv
 

--- a/core/drive2.f
+++ b/core/drive2.f
@@ -385,7 +385,7 @@ C----------------------------------------------------------------------
       include 'GEOM'
       include 'WZ'
 C
-      COMMON /SCRUZ/ XM3 (LX3,LY3,LZ3,LELT)
+      COMMON /scruz_drive2/ XM3 (LX3,LY3,LZ3,LELT)
      $ ,             YM3 (LX3,LY3,LZ3,LELT)
      $ ,             ZM3 (LX3,LY3,LZ3,LELT)
 C
@@ -1291,7 +1291,7 @@ c-----------------------------------------------------------------------
       subroutine dofcnt
       include 'SIZE'
       include 'TOTAL'
-      COMMON /SCRNS/ WORK(LCTMP1)
+      COMMON /scrns_drive2/ WORK(LCTMP1)
 
       integer*8 ntot,ntotp,ntotv
 
@@ -1514,11 +1514,11 @@ c
      $   , vzc(lx1,ly1,lz1,lelv)
      $   , prc(lx2,ly2,lz2,lelv)
 C
-      COMMON /SCRNS/ RESV1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_drive2/ RESV1 (LX1,LY1,LZ1,LELV)
      $ ,             RESV2 (LX1,LY1,LZ1,LELV)
      $ ,             RESV3 (LX1,LY1,LZ1,LELV)
      $ ,             RESPR (LX2,LY2,LZ2,LELV)
-      COMMON /SCRVH/ H1    (LX1,LY1,LZ1,LELV)
+      COMMON /scrvh_drive2/ H1    (LX1,LY1,LZ1,LELV)
      $ ,             H2    (LX1,LY1,LZ1,LELV)
 c
       common /cvflow_i/ icvflow,iavflow
@@ -1573,16 +1573,16 @@ c
      $   , vzc(lx1,ly1,lz1,lelv)
      $   , prc(lx2,ly2,lz2,lelv)
 C
-      COMMON /SCRNS/ rw1   (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_drive2/ rw1   (LX1,LY1,LZ1,LELV)
      $ ,             rw2   (LX1,LY1,LZ1,LELV)
      $ ,             rw3   (LX1,LY1,LZ1,LELV)
      $ ,             dv1   (LX1,LY1,LZ1,LELV)
      $ ,             dv2   (LX1,LY1,LZ1,LELV)
      $ ,             dv3   (LX1,LY1,LZ1,LELV)
      $ ,             RESPR (LX2,LY2,LZ2,LELV)
-      COMMON /SCRVH/ H1    (LX1,LY1,LZ1,LELV)
+      COMMON /scrvh_drive2/ H1    (LX1,LY1,LZ1,LELV)
      $ ,             H2    (LX1,LY1,LZ1,LELV)
-      COMMON /SCRHI/ H2INV (LX1,LY1,LZ1,LELV)
+      COMMON /scrhi_drive2/ H2INV (LX1,LY1,LZ1,LELV)
       common /cvflow_i/ icvflow,iavflow
 c
 c
@@ -1654,11 +1654,11 @@ c     (Tombo splitting scheme).
      $   , vzc(lx1,ly1,lz1,lelv)
      $   , prc(lx1,ly1,lz1,lelv)
 
-      common /scrns/ resv1 (lx1,ly1,lz1,lelv)
+      common /scrns_drive2/ resv1 (lx1,ly1,lz1,lelv)
      $ ,             resv2 (lx1,ly1,lz1,lelv)
      $ ,             resv3 (lx1,ly1,lz1,lelv)
      $ ,             respr (lx1,ly1,lz1,lelv)
-      common /scrvh/ h1    (lx1,ly1,lz1,lelv)
+      common /scrvh_drive2/ h1    (lx1,ly1,lz1,lelv)
      $ ,             h2    (lx1,ly1,lz1,lelv)
 
       common /cvflow_i/ icvflow,iavflow
@@ -1705,8 +1705,8 @@ c-----------------------------------------------------------------------
 c
       include 'SIZE'
       include 'TOTAL'
-      COMMON /SCRNS/ w(LX1,LY1,LZ1,LELT)
-      COMMON /SCRUZ/ v (LX1,LY1,LZ1,LELT)
+      COMMON /scrns_drive2/ w(LX1,LY1,LZ1,LELT)
+      COMMON /scruz_drive2/ v (LX1,LY1,LZ1,LELT)
      $             , h1(LX1,LY1,LZ1,LELT)
      $             , h2(LX1,LY1,LZ1,LELT)
 c
@@ -1750,9 +1750,9 @@ C
 C     Caution: 2nd and 3rd strainrate invariants residing in scratch
 C              common /SCREV/ are used in STNRINV and NEKASGN
 C
-      COMMON /SCREV/ SII (LX1,LY1,LZ1,LELT)
+      COMMON /screv_drive2/ SII (LX1,LY1,LZ1,LELT)
      $             , SIII(LX1,LY1,LZ1,LELT)
-      COMMON /SCRUZ/ TA(LX1,LY1,LZ1,LELT)
+      COMMON /scruz_drive2/ TA(LX1,LY1,LZ1,LELT)
 C
       real    rstart
       save    rstart

--- a/core/eigsolv.f
+++ b/core/eigsolv.f
@@ -109,9 +109,9 @@ C-------------------------------------------------------------------------
       INCLUDE 'SOLN'
       INCLUDE 'TSTEP'
 C
-      COMMON /SCRVH/ H1 (LX1,LY1,LZ1,LELT)
+      COMMON /scrvh_eigsolv/ H1 (LX1,LY1,LZ1,LELT)
      $ ,             H2 (LX1,LY1,LZ1,LELT)
-      COMMON /SCRHI/ H2INV (LX1,LY1,LZ1,LELV)
+      COMMON /scrhi_eigsolv/ H2INV (LX1,LY1,LZ1,LELV)
 C
       NTOT1  = lx1*ly1*lz1*NELV
 C
@@ -214,7 +214,7 @@ C
       REAL            MULT (LX1,LY1,LZ1,1)
       REAL            H1   (LX1,LY1,LZ1,1)
       REAL            H2   (LX1,LY1,LZ1,1)
-      COMMON /SCREV/  X1   (LX1,LY1,LZ1,LELT)
+      COMMON /screv_eigsolv/  X1   (LX1,LY1,LZ1,LELT)
      $ ,              Y1   (LX1,LY1,LZ1,LELT)
       CHARACTER NAME*4
 C
@@ -269,7 +269,7 @@ C
       REAL            MULT (LX1,LY1,LZ1,1)
       REAL            H1   (LX1,LY1,LZ1,1)
       REAL            H2   (LX1,LY1,LZ1,1)
-      COMMON /SCREV/  X1   (LX1,LY1,LZ1,LELT)
+      COMMON /screv_eigsolv/  X1   (LX1,LY1,LZ1,LELT)
      $ ,              Y1   (LX1,LY1,LZ1,LELT)
 C
       IF (IMESH.EQ.1) NEL = NELV
@@ -323,7 +323,7 @@ C
       REAL           H1   (LX1,LY1,LZ1,1)
       REAL           H2   (LX1,LY1,LZ1,1)
       REAL           H2INV(LX1,LY1,LZ1,1)
-      COMMON /SCREV/ X2   (LX2,LY2,LZ2,LELV)
+      COMMON /screv_eigsolv/ X2   (LX2,LY2,LZ2,LELV)
      $ ,             Y2   (LX2,LY2,LZ2,LELV)
 C
       NTOT2  = lx2*ly2*lz2*NELV
@@ -368,7 +368,7 @@ C
       REAL           H1    (LX1,LY1,LZ1,1)
       REAL           H2    (LX1,LY1,LZ1,1)
       REAL           H2INV (LX1,LY1,LZ1,1)
-      COMMON /SCREV/ X2 (LX2,LY2,LZ2,LELV)
+      COMMON /screv_eigsolv/ X2 (LX2,LY2,LZ2,LELV)
      $ ,             Y2 (LX2,LY2,LZ2,LELV)
 C
       NTOT2  = lx2*ly2*lz2*NELV

--- a/core/fasts.f
+++ b/core/fasts.f
@@ -23,9 +23,9 @@ c
       include 'CTIMER'
 c
       real u(lx2,ly2,lz2,lelv),v(lx2,ly2,lz2,lelv)
-      common /scrpre/ v1(lx1,ly1,lz1,lelv)
+      common /scrpre_fasts/ v1(lx1,ly1,lz1,lelv)
      $               ,w1(lx1,ly1,lz1),w2(lx1,ly1,lz1)
-      common /scrover/ ar(lelv)
+      common /scrover_fasts/ ar(lelv)
 
       parameter(lxx=lx1*lx1, levb=lelv+lbelv)
       common /fastd/  df(lx1*ly1*lz1,levb)

--- a/core/genxyz.f
+++ b/core/genxyz.f
@@ -8,7 +8,8 @@ c-----------------------------------------------------------------------
 C
 C     ....note..... CTMP1 is used in this format in several subsequent routines
 C
-      COMMON /CTMP1/ H(LX1,3,2),XCRVED(LX1),YCRVED(LY1),ZCRVED(LZ1)
+      COMMON /ctmp1_genxyz/ H(LX1,3,2),XCRVED(LX1),YCRVED(LY1),
+     $ ZCRVED(LZ1)
      $             , ZGML(LX1,3),WORK(3,LX1,LZ1)
       DIMENSION XML(NXL,NYL,NZL,1),YML(NXL,NYL,NZL,1),ZML(NXL,NYL,NZL,1)
       LOGICAL IFGLJ
@@ -105,7 +106,8 @@ c-----------------------------------------------------------------------
       include 'TOPOL'
       include 'GEOM'
       include 'WZ'
-      COMMON /CTMP1/ H(LX1,3,2),XCRVED(LX1),YCRVED(LY1),ZCRVED(LZ1)
+      COMMON /ctmp1_genxyz/ H(LX1,3,2),XCRVED(LX1),YCRVED(LY1),
+     $ ZCRVED(LZ1)
      $             , ZGML(LX1,3),WORK(3,LX1,LZ1)
 C
       DIMENSION XML(NXL,NYL,NZL,1),YML(NXL,NYL,NZL,1),ZML(NXL,NYL,NZL,1)
@@ -567,11 +569,12 @@ C
       real xml(nxl,nyl,nzl,1),yml(nxl,nyl,nzl,1),zml(nxl,nyl,nzl,1)
 
 C     Note : CTMP1 is used in this format in several subsequent routines
-      common /ctmp1/ h(lx1,3,2),xcrved(lx1),ycrved(ly1),zcrved(lz1)
+      common /ctmp1_genxyz/ h(lx1,3,2),xcrved(lx1),ycrved(ly1),
+     $ zcrved(lz1)
      $             , zgml(lx1,3),work(3,lx1,lz1)
 
       parameter (ldw=2*lx1*ly1*lz1)
-      common /ctmp0/ w(ldw)
+      common /ctmp0_genxyz/ w(ldw)
 
       character*1 ccv
 
@@ -688,9 +691,10 @@ C
       DIMENSION XML(NX,NY,NZ,1),YML(NX,NY,NZ,1),ZML(NX,NY,NZ,1)
       DIMENSION XYSRF(3,NX,NZ)
 C
-      COMMON /CTMP1/ H(LX1,3,2),XCRVED(LX1),YCRVED(LY1),ZCRVED(LZ1)
+      COMMON /ctmp1_genxyz/ H(LX1,3,2),XCRVED(LX1),YCRVED(LY1),
+     $ ZCRVED(LZ1)
      $             , ZGML(LX1,3),WORK(3,LX1,LZ1)
-      COMMON /CTMP0/ XCV(3,2,2),VN1(3),VN2(3)
+      COMMON /ctmp0_genxyz/ XCV(3,2,2),VN1(3),VN2(3)
      $              ,X1(3),X2(3),X3(3),DX(3)
       DIMENSION IOPP(3),NXX(3)
 c
@@ -846,7 +850,8 @@ C
 C     Generate XYZ vector along an edge of a surface.
 C
       include 'SIZE'
-      COMMON /CTMP1/ H(LX1,3,2),XCRVED(LX1),YCRVED(LY1),ZCRVED(LZ1)
+      COMMON /ctmp1_genxyz/ H(LX1,3,2),XCRVED(LX1),YCRVED(LY1),
+     $ ZCRVED(LZ1)
      $             , ZGML(LX1,3),WORK(3,LX1,LZ1)
 C
       DIMENSION XYSRF(3,NX,NY)
@@ -1291,7 +1296,7 @@ c        5+-----+6    t                      5+-----+6    t
       data    indx / 1,2,4,3,5,6,8,7 /
 
       parameter (ldw=4*lx1*ly1*lz1)
-      common /ctmp0/ xcb(2,2,2),ycb(2,2,2),zcb(2,2,2),w(ldw)
+      common /ctmp0_genxyz/ xcb(2,2,2),ycb(2,2,2),zcb(2,2,2),w(ldw)
 
       common /cxyzl/ zgml(lx1,3),jx (lx1*2),jy (lx1*2),jz (lx1*2)
      $                          ,jxt(lx1*2),jyt(lx1*2),jzt(lx1*2)
@@ -1342,7 +1347,7 @@ c     Generate bi- or trilinear mesh
       integer e
 
       parameter (ldw=4*lx1*ly1*lz1)
-      common /ctmp0/ w(ldw,2),zg(3)
+      common /ctmp0_genxyz/ w(ldw,2),zg(3)
 
 c     Note : CTMP1 is used in this format in several subsequent routines
 

--- a/core/gfldr.f
+++ b/core/gfldr.f
@@ -16,7 +16,7 @@ c
 
       character sourcefld*(*)
 
-      common /scrcg/  pm1(lx1*ly1*lz1,lelv)
+      common /scrcg_gfldr/  pm1(lx1*ly1*lz1,lelv)
       common /nekmpi/ nidd,npp,nekcomm,nekgroup,nekreal
 
       character*1   hdr(iHeaderSize)

--- a/core/gmres.f
+++ b/core/gmres.f
@@ -18,9 +18,9 @@ c     intype = -1  (implicit)
       real             h2   (lx1,ly1,lz1,lelv)
       real             h2inv(lx1,ly1,lz1,lelv)
 
-      common /scrmg/    wp (lx2,ly2,lz2,lelv)
+      common /scrmg_gmres/    wp (lx2,ly2,lz2,lelv)
 
-      common /ctmp0/   wk1(lgmres),wk2(lgmres)
+      common /ctmp0_gmres/   wk1(lgmres),wk2(lgmres)
       common /cgmres1/ y(lgmres)
 
       real alpha, l, temp
@@ -319,10 +319,10 @@ c     GMRES iteration.
       real             h2   (lx1,ly1,lz1,lelv)
       real             wt   (lx1,ly1,lz1,lelv)
 
-      common /scrcg/ d(lx1*ly1*lz1*lelv),wk(lx1*ly1*lz1*lelv)
+      common /scrcg_gmres/ d(lx1*ly1*lz1*lelv),wk(lx1*ly1*lz1*lelv)
 
       common /cgmres1/ y(lgmres)
-      common /ctmp0/   wk1(lgmres),wk2(lgmres)
+      common /ctmp0_gmres/   wk1(lgmres),wk2(lgmres)
       real alpha, l, temp
       integer outer
 

--- a/core/hmholtz.f
+++ b/core/hmholtz.f
@@ -93,7 +93,7 @@ C
      $ ,             U     (LX1,LY1,LZ1,1)
      $ ,             HELM1 (LX1,LY1,LZ1,1)
      $ ,             HELM2 (LX1,LY1,LZ1,1)
-      COMMON /CTMP1/ DUDR  (LX1,LY1,LZ1)
+      COMMON /ctmp1_hmholtz/ DUDR  (LX1,LY1,LZ1)
      $ ,             DUDS  (LX1,LY1,LZ1)
      $ ,             DUDT  (LX1,LY1,LZ1)
      $ ,             TMP1  (LX1,LY1,LZ1)
@@ -538,7 +538,7 @@ C-------------------------------------------------------------------
       include 'EIGEN'
       COMMON  /CPRINT/ IFPRINT
       LOGICAL          IFPRINT
-      COMMON /CTMP0/ W1   (LX1,LY1,LZ1,LELT)
+      COMMON /ctmp0_hmholtz/ W1   (LX1,LY1,LZ1,LELT)
      $ ,             W2   (LX1,LY1,LZ1,LELT)
       REAL RES  (LX1,LY1,LZ1,1)
       REAL H1   (LX1,LY1,LZ1,1)
@@ -630,8 +630,8 @@ C------------------------------------------------------------------------
  
       real x(1),f(1),h1(1),h2(1),mask(1),mult(1),binv(1)
       parameter        (lg=lx1*ly1*lz1*lelt)
-      COMMON /SCRCG/ d (lg) , scalar(2)
-      common /SCRMG/ r (lg) , w (lg) , p (lg) , z (lg)
+      COMMON /scrcg_hmholtz/ d (lg) , scalar(2)
+      common /scrmg_hmholtz/ r (lg) , w (lg) , p (lg) , z (lg)
 c
       parameter (maxcg=900)
       common /tdarray/ diagt(maxcg),upper(maxcg)
@@ -938,7 +938,7 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
 c
-      common /ctmp0/ w(lx1,ly1,lz1)
+      common /ctmp0_hmholtz/ w(lx1,ly1,lz1)
 c
       include 'FDMH1'
 c
@@ -1035,7 +1035,7 @@ c
 c
       include 'FDMH1'
 c
-      COMMON /CTMP0/ W(LX1,LX1),aa(lx1,lx1),bb(lx1,lx1)
+      COMMON /ctmp0_hmholtz/ W(LX1,LX1),aa(lx1,lx1),bb(lx1,lx1)
 c
       integer left,right
 c
@@ -1128,7 +1128,7 @@ c
       include 'TOPOL'
       include 'WZ'
 c
-      COMMON /CTMP0/ W(LX1,LX1),aa(lx1,lx1),bb(lx1,lx1)
+      COMMON /ctmp0_hmholtz/ W(LX1,LX1),aa(lx1,lx1),bb(lx1,lx1)
      $             , mask(lx1,ly1,lz1,lelt)
       real mask
       character*3 cb
@@ -1505,8 +1505,8 @@ C------------------------------------------------------------------------
 
       real x(1),f(1),h1(1),h2(1),binv(1),mask(1)
       parameter        (lg=lx1*ly1*lz1*lelt)
-      common /scrcg/ d (lg) , scalar(2)
-      common /scrmg/ r (lg) , w (lg) , p (lg) , z (lg)
+      common /scrcg_hmholtz/ d (lg) , scalar(2)
+      common /scrmg_hmholtz/ r (lg) , w (lg) , p (lg) , z (lg)
 
       parameter (maxcg=900)
       common /tdarray/ diagt(maxcg),upper(maxcg)
@@ -2064,8 +2064,8 @@ c     Helmholtz matrix-vector product: Au = h1*[A]u + h2*[B]u
       parameter(lxyz=lx1*ly1*lz1)
       real au(lx1,ly1,lz1,1),u(lx1,ly1,lz1,1),h1(lx1,ly1,lz1,1),h2(1)
 
-      common /ctmp0/ w(2*lx1*lz1*2*ldim*lelt)
-      common /ctmp1/ ur(lx1,ly1,lz1,lelt),us(lx1,ly1,lz1,lelt)
+      common /ctmp0_hmholtz/ w(2*lx1*lz1*2*ldim*lelt)
+      common /ctmp1_hmholtz/ ur(lx1,ly1,lz1,lelt),us(lx1,ly1,lz1,lelt)
      $                                   ,ut(lx1,ly1,lz1,lelt)
       common /ytmp9/ qr(lx1,ly1,lz1),qs(lx1,ly1,lz1),qt(lx1,ly1,lz1)
       common /ytmp0/ uf(lx1*lz1,2*ldim,lelt,2)
@@ -2180,11 +2180,11 @@ c     GMRES iteration.
       real             wt   (lx1,ly1,lz1,lelv)
 
       parameter (lt=lx1*ly1*lz1*lelt)
-      common /scrcg/ r(lt),z(lt),p(lt),w(lt)
-      common /scrmg/ r1(lt)
+      common /scrcg_hmholtz/ r(lt),z(lt),p(lt),w(lt)
+      common /scrmg_hmholtz/ r1(lt)
 
       common /cgmres1/ y(lgmres)
-      common /ctmp0/   wk1(lgmres),wk2(lgmres)
+      common /ctmp0_hmholtz/   wk1(lgmres),wk2(lgmres)
       real alpha, l, temp
       integer outer
 

--- a/core/hpf.f
+++ b/core/hpf.f
@@ -26,7 +26,7 @@
       data icalld /0/
 
       real TA1,TA2,TA3
-      COMMON /SCRUZ/ TA1 (LX1,LY1,LZ1,LELV)
+      COMMON /scruz_hpf/ TA1 (LX1,LY1,LZ1,LELV)
      $ ,             TA2 (LX1,LY1,LZ1,LELV)
      $ ,             TA3 (LX1,LY1,LZ1,LELV)
 

--- a/core/hrefine.f
+++ b/core/hrefine.f
@@ -40,7 +40,8 @@ c                                   ncut = 4 --> 64x number of elements
       integer e,eg,egn,el,en,er,es,et
 
       parameter(lxyz=lx1*ly1*lz1,mxmin=512,mxnew=max(mxmin,lelt))
-      common /scrns/ x0(lxyz,mxnew),y0(lxyz,mxnew),z0(lxyz,mxnew)
+      common /scrns_hrefine/ x0(lxyz,mxnew),y0(lxyz,mxnew),z0(lxyz,
+     $ mxnew)
      $             , pc(lx1*lx1,mxnew),pt(lx1*lx1,mxnew)
       real x0,y0,z0,pc,pt
 
@@ -490,7 +491,8 @@ c     apply one round of refinement to a field
       integer e,eg,egn,el,en,er,es,et
 
       parameter(lxyz=lx1*ly1*lz1,mxmin=512,mxnew=max(mxmin,lelt))
-      common /scrns/ x0(lxyz,mxnew),y0(lxyz,mxnew),z0(lxyz,mxnew)
+      common /scrns_hrefine/ x0(lxyz,mxnew),y0(lxyz,mxnew),z0(lxyz,
+     $ mxnew)
      $             , pc(lx1*lx1,mxnew),pt(lx1*lx1,mxnew)
       real x0,y0,z0,pc,pt
 
@@ -576,7 +578,8 @@ c     restart, refine fields after readfld
 
       integer lxyz,mxmin,mxnew
       parameter(lxyz=lx1*ly1*lz1,mxmin=512,mxnew=max(mxmin,lelt))
-      common /scrns/ x0(lxyz,mxnew),y0(lxyz,mxnew),z0(lxyz,mxnew)
+      common /scrns_hrefine/ x0(lxyz,mxnew),y0(lxyz,mxnew),z0(lxyz,
+     $ mxnew)
      $             , pc(lx1*lx1,mxnew),pt(lx1*lx1,mxnew)
       real x0,y0,z0,pc,pt
 

--- a/core/hsmg.f
+++ b/core/hsmg.f
@@ -787,7 +787,7 @@ c----------------------------------------------------------------------
       
       include 'SIZE'
       parameter(lxm=lx1+2)
-      common /ctmp0/ b(2*lxm*lxm),w(2*lxm*lxm)
+      common /ctmp0_hsmg/ b(2*lxm*lxm),w(2*lxm*lxm)
       
       call hsmg_setup_fast1d_a(s,lbc,rbc,ll,lm,lr,ah,n)
       call hsmg_setup_fast1d_b(b,lbc,rbc,ll,lm,lr,bh,n)
@@ -1390,8 +1390,8 @@ c----------------------------------------------------------------------
 c     common /quick/ ecrs  (lx2*ly2*lz2*lelv)  ! quick work array
 c    $             , ecrs2 (lx2*ly2*lz2*lelv)  ! quick work array
 
-      common /scrhi/ h2inv (lx1,ly1,lz1,lelv)
-      common /scrvh/ h1    (lx1,ly1,lz1,lelv),
+      common /scrhi_hsmg/ h2inv (lx1,ly1,lz1,lelv)
+      common /scrvh_hsmg/ h1    (lx1,ly1,lz1,lelv),
      $               h2    (lx1,ly1,lz1,lelv)
       
       integer ilstep,iter
@@ -1868,11 +1868,11 @@ c     Assumes that preprocessing has been completed via h1mg_setup()
       include 'CTIMER'
       include 'PARALLEL'
       
-      common /scrhi/ h2inv (lx1,ly1,lz1,lelv)
-      common /scrvh/ h1    (lx1,ly1,lz1,lelv),
+      common /scrhi_hsmg/ h2inv (lx1,ly1,lz1,lelv)
+      common /scrvh_hsmg/ h1    (lx1,ly1,lz1,lelv),
      $               h2    (lx1,ly1,lz1,lelv)
       parameter (lt=lx1*ly1*lz1*lelt)
-      common /scrmg/ e(2*lt),w(lt),r(lt)
+      common /scrmg_hsmg/ e(2*lt),w(lt),r(lt)
       integer p_msk,p_b
       logical if_hybrid
 
@@ -2024,7 +2024,7 @@ c
       logical ifh2
 
       parameter (lxyz=lx1*ly1*lz1)
-      common /ctmp0/ ur(lxyz),us(lxyz),ut(lxyz)
+      common /ctmp0_hsmg/ ur(lxyz),us(lxyz),ut(lxyz)
 
       integer e
 
@@ -2236,8 +2236,8 @@ c----------------------------------------------------------------------
       include 'TOTAL'
       include 'HSMG'
 
-      common /scrhi/ h2inv (lx1,ly1,lz1,lelt)
-      common /scrvh/ h1    (lx1,ly1,lz1,lelt),
+      common /scrhi_hsmg/ h2inv (lx1,ly1,lz1,lelt)
+      common /scrvh_hsmg/ h1    (lx1,ly1,lz1,lelt),
      $               h2    (lx1,ly1,lz1,lelt)
 
       integer p_h1,p_h2,p_g,p_b,p_msk
@@ -2514,7 +2514,7 @@ c----------------------------------------------------------------------
 
 c     As a first pass, rely on the cheesy common-block interface to get h1
 
-      common /scrvh/ h1    (lx1,ly1,lz1,lelv)
+      common /scrvh_hsmg/ h1    (lx1,ly1,lz1,lelv)
      $             , h2    (lx1,ly1,lz1,lelv)
      $             , h2inv (lx1,ly1,lz1,lelv)
 
@@ -2553,7 +2553,7 @@ c-----------------------------------------------------------------------
 
 c     As a first pass, rely on the cheesy common-block interface to get h2
 
-      common /scrvh/ h1    (lx1,ly1,lz1,lelv)
+      common /scrvh_hsmg/ h1    (lx1,ly1,lz1,lelv)
      $             , h2    (lx1,ly1,lz1,lelv)
      $             , h2inv (lx1,ly1,lz1,lelv)
 
@@ -2724,7 +2724,7 @@ c-----------------------------------------------------------------------
       real b(1),g(ng,1),wt(1),wk(1)
       logical ifinv
 
-      common /ctmp0/ wi(2*lx1+4)
+      common /ctmp0_hsmg/ wi(2*lx1+4)
 
       n = nx*ny*nz
 
@@ -2788,7 +2788,7 @@ c-----------------------------------------------------------------------
       include 'TSTEP'  ! nelfld
 
       integer p_g,p_b,e
-      common /ctmp1/ w(lx1*ly1*lz1*lelt*2)
+      common /ctmp1_hsmg/ w(lx1*ly1*lz1*lelt*2)
 
       l                 = mg_h1_lmax
       p_mg_b (l,mg_fld) = 0
@@ -2905,7 +2905,7 @@ c-----------------------------------------------------------------------
 
       integer e
       real a(ng,nx,ny)
-      common /ctmp0/ w(100000)
+      common /ctmp0_hsmg/ w(100000)
       character*6 name6
 
 c     do i=1,ng

--- a/core/ic.f
+++ b/core/ic.f
@@ -22,7 +22,7 @@ C-----------------------------------------------------------------------
  
       LOGICAL  IFANYP
       common /inelr/ nelrr
-      common /ctmp1/ work(lx1,ly1,lz1,lelv)
+      common /ctmp1_ic/ work(lx1,ly1,lz1,lelv)
      $ ,             ta1 (lx2,ly1,lz1)
      $ ,             ta2 (lx2,ly2,lz1)
       integer*8 ntotg,nn
@@ -442,12 +442,12 @@ C----------------------------------------------------------------------
       PARAMETER (LXYZT=LX1*LY1*LZ1*LELT)
       PARAMETER (LPSC9=LDIMT+9)
 
-      common /scrcg/ pm1(lx1*ly1*lz1,lelv)
-      COMMON /SCRNS/ SDUMP(LXYZT,7)
+      common /scrcg_ic/ pm1(lx1*ly1*lz1,lelv)
+      COMMON /scrns_ic/ SDUMP(LXYZT,7)
       integer mesg(40)
 
 C     note, this usage of CTMP1 will be less than elsewhere if NELT ~> 9.
-      COMMON /CTMP1/ TDUMP(LXYZR,LPSC9)
+      COMMON /ctmp1_ic/ TDUMP(LXYZR,LPSC9)
       real*4         tdump
 c
       REAL SDMP2(LXYZT,LDIMT)
@@ -1222,7 +1222,7 @@ C
       DIMENSION X(lx1,ly1,lz1,NEL)
       DIMENSION Y(NXR,NXR,NXR,NEL)
 
-      common /ctmp0/  xa(lxyzr)      ,xb(lx1,ly1,lzr) ,xc(lxyzr)
+      common /ctmp0_ic/  xa(lxyzr)      ,xb(lx1,ly1,lzr) ,xc(lxyzr)
      $              , zgmr(lxr)      ,wgtr(lxr)
       common /ctmpab/ ires(lxr,lxr)  ,itres(lxr,lxr)
       real ires,itres
@@ -1294,7 +1294,7 @@ C
       REAL*4 X(lx1,ly1,lz1,NEL)
       REAL   Y(NXR,NXR,NXR,NEL)
 
-      common /ctmp0/  xa(lxyzr)      ,xb(lx1,ly1,lzr) ,xc(lxyzr)
+      common /ctmp0_ic/  xa(lxyzr)      ,xb(lx1,ly1,lzr) ,xc(lxyzr)
      $              , zgmr(lxr)      ,wgtr(lxr)
       common /ctmpa4/ ires(lxr,lxr)  ,itres(lxr,lxr)
       real ires,itres
@@ -1832,7 +1832,7 @@ C
       INCLUDE 'TSTEP'
       include 'WZ'
 c
-      COMMON /scruz/ XM3 (LX1,LY1,LZ1,LELT)
+      COMMON /scruz_ic/ XM3 (LX1,LY1,LZ1,LELT)
      $ ,             YM3 (LX1,LY1,LZ1,LELT)
      $ ,             ZM3 (LX1,LY1,LZ1,LELT)
 C
@@ -2550,8 +2550,8 @@ c
       character*1    frontc
 
       parameter (lwk = 7*lx1*ly1*lz1*lelt)
-      common /scrns/ wk(lwk)
-      common /scrcg/ pm1(lx1*ly1*lz1,lelv)
+      common /scrns_ic/ wk(lwk)
+      common /scrcg_ic/ pm1(lx1*ly1*lz1,lelv)
       integer e
 
       integer*8 offs0,offs,nbyte,stride,strideB,nxyzr8
@@ -2914,7 +2914,7 @@ c-----------------------------------------------------------------------
 
       real pm1(lx1,ly1,lz1,lelv)
 
-      common /ctmp0/ axism1 (lx1,ly1)
+      common /ctmp0_ic/ axism1 (lx1,ly1)
       integer e
 
       if (.not.ifaxis) return

--- a/core/induct.f
+++ b/core/induct.f
@@ -21,13 +21,13 @@ c
       include 'TSTEP'
       include 'MASS'
 
-      common /scrns/  resv1 (lx1,ly1,lz1,lelv)
+      common /scrns_induct/  resv1 (lx1,ly1,lz1,lelv)
      $ ,              resv2 (lx1,ly1,lz1,lelv)
      $ ,              resv3 (lx1,ly1,lz1,lelv)
      $ ,              dv1   (lx1,ly1,lz1,lelv)
      $ ,              dv2   (lx1,ly1,lz1,lelv)
      $ ,              dv3   (lx1,ly1,lz1,lelv)
-      common /scrvh/  h1    (lx1,ly1,lz1,lelv)
+      common /scrvh_induct/  h1    (lx1,ly1,lz1,lelv)
      $ ,              h2    (lx1,ly1,lz1,lelv)
 
       ifield = ifldmhd
@@ -148,7 +148,7 @@ c
       include 'MASS'
       include 'TSTEP'
 C
-      common /scrns/ ta1 (lx1,ly1,lz1,lelv)
+      common /scrns_induct/ ta1 (lx1,ly1,lz1,lelv)
      $ ,             ta2 (lx1,ly1,lz1,lelv)
      $ ,             ta3 (lx1,ly1,lz1,lelv)
 c
@@ -186,7 +186,7 @@ C
       include 'INPUT'
       include 'TSTEP'
 C
-      COMMON /SCRNS/ TA1(LX1,LY1,LZ1,LELV)
+      COMMON /scrns_induct/ TA1(LX1,LY1,LZ1,LELV)
      $ ,             TA2(LX1,LY1,LZ1,LELV)
      $ ,             TA3(LX1,LY1,LZ1,LELV)
      $ ,             TB1(LX1,LY1,LZ1,LELV)
@@ -232,7 +232,7 @@ c
       real           resv3 (lx1,ly1,lz1,1)
       real           h1    (lx1,ly1,lz1,1)
       real           h2    (lx1,ly1,lz1,1)
-      common /scruz/ w1    (lx1,ly1,lz1,lelv)
+      common /scruz_induct/ w1    (lx1,ly1,lz1,lelv)
      $ ,             w2    (lx1,ly1,lz1,lelv)
      $ ,             w3    (lx1,ly1,lz1,lelv)
 c
@@ -262,7 +262,7 @@ c
       real           resv3 (lx1,ly1,lz1,1)
       real           h1    (lx1,ly1,lz1,1)
       real           h2    (lx1,ly1,lz1,1)
-      common /scruz/ w1    (lx1,ly1,lz1,lelv)
+      common /scruz_induct/ w1    (lx1,ly1,lz1,lelv)
      $ ,             w2    (lx1,ly1,lz1,lelv)
      $ ,             w3    (lx1,ly1,lz1,lelv)
 c
@@ -301,16 +301,16 @@ c
       include 'TOTAL'
       include 'CTIMER'
 c
-      common /scrns/ w1    (lx1,ly1,lz1,lelv)
+      common /scrns_induct/ w1    (lx1,ly1,lz1,lelv)
      $ ,             w2    (lx1,ly1,lz1,lelv)
      $ ,             w3    (lx1,ly1,lz1,lelv)
      $ ,             dv1   (lx1,ly1,lz1,lelv)
      $ ,             dv2   (lx1,ly1,lz1,lelv)
      $ ,             dv3   (lx1,ly1,lz1,lelv)
      $ ,             dp    (lx2,ly2,lz2,lelv)
-      common /scrvh/ h1    (lx1,ly1,lz1,lelv)
+      common /scrvh_induct/ h1    (lx1,ly1,lz1,lelv)
      $ ,             h2    (lx1,ly1,lz1,lelv)
-      common /scrhi/ h2inv (lx1,ly1,lz1,lelv)
+      common /scrhi_induct/ h2inv (lx1,ly1,lz1,lelv)
 
       parameter(nset = 1 + lbelv/lelv)
       common /orthov/ pset(lx2*ly2*lz2*lelv*mxprev,nset)
@@ -862,16 +862,16 @@ c
       include 'MASS'
       include 'GEOM'
 C
-      common /scrnt/  besv1 (lbx1,lby1,lbz1,lbelv)
+      common /scrnt_induct/  besv1 (lbx1,lby1,lbz1,lbelv)
      $ ,              besv2 (lbx1,lby1,lbz1,lbelv)
      $ ,              besv3 (lbx1,lby1,lbz1,lbelv)
-      COMMON /SCRNS/  RESV1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_induct/  RESV1 (LX1,LY1,LZ1,LELV)
      $ ,              RESV2 (LX1,LY1,LZ1,LELV)
      $ ,              RESV3 (LX1,LY1,LZ1,LELV)
      $ ,              DV1   (LX1,LY1,LZ1,LELV)
      $ ,              DV2   (LX1,LY1,LZ1,LELV)
      $ ,              DV3   (LX1,LY1,LZ1,LELV)
-      COMMON /SCRVH/  H1    (LX1,LY1,LZ1,LELV)
+      COMMON /scrvh_induct/  H1    (LX1,LY1,LZ1,LELV)
      $ ,              H2    (LX1,LY1,LZ1,LELV)
 c
       n  = lx1*ly1*lz1*nelv
@@ -1336,7 +1336,7 @@ C
       include 'TSTEP'
 c
       parameter (lxy=lx1*ly1*lz1,ltd=lxd*lyd*lzd)
-      common /scrns/ wk(2*ltd)
+      common /scrns_induct/ wk(2*ltd)
      $             , fx(lxy),fy(lxy),fz(lxy)
      $             , gx(lxy),gy(lxy),gz(lxy)
      $             , zr(ltd),zs(ltd),zt(ltd)
@@ -1534,7 +1534,7 @@ c
       include 'MASS'
       include 'TSTEP'
 c
-      common /scrns/ ta1 (lx1,ly1,lz1,lelv)
+      common /scrns_induct/ ta1 (lx1,ly1,lz1,lelv)
      $ ,             ta2 (lx1,ly1,lz1,lelv)
      $ ,             ta3 (lx1,ly1,lz1,lelv)
      $ ,             tb1 (lx1,ly1,lz1,lelv)

--- a/core/lb_setqvol.f
+++ b/core/lb_setqvol.f
@@ -59,7 +59,7 @@ c
       integer*8 i8gl_running_sum, i8rsum
       integer*8 n8, np8, nb8
 
-      common /scrns/ vi(2,lx1*ly1*lz1*lelt)
+      common /scrns_lb_setqvol/ vi(2,lx1*ly1*lz1*lelt)
       integer vi
 
       integer icalld,cr_lb

--- a/core/makeq.f
+++ b/core/makeq.f
@@ -9,7 +9,7 @@ C     !! NOTE: Do not change the content of the array BQ until the current
       include 'CTIMER'
 
       logical  if_conv_std
-      common /SCRUZ/ w1(lx1,ly1,lz1,lelt)
+      common /scruz_makeq/ w1(lx1,ly1,lz1,lelt)
 
       nxyz = lx1*ly1*lz1
       ntot = nxyz*nelv

--- a/core/map2.f
+++ b/core/map2.f
@@ -143,7 +143,7 @@ c-----------------------------------------------------------------------
 
       parameter(mdw=2+2**ldim)
       parameter(ndw=7*lx1*ly1*lz1*lelv/mdw)
-      common /scrns/ wk(mdw*ndw)
+      common /scrns_map2/ wk(mdw*ndw)
       integer*8 wk
 
       integer     wk4(2*mdw*ndw)
@@ -158,9 +158,9 @@ c-----------------------------------------------------------------------
 
       integer*8 eid8(lelt), vtx8(lelt*2**ldim)
       integer   iwork(lelt)
-      common /ctmp0/ eid8, vtx8, iwork
+      common /ctmp0_map2/ eid8, vtx8, iwork
 
-      common /scrcg/ xyz(ldim*lelt*2**ldim)
+      common /scrcg_map2/ xyz(ldim*lelt*2**ldim)
 
       integer cnt, algo
       integer opt_parrsb(3)
@@ -483,10 +483,10 @@ c-----------------------------------------------------------------------
       real tol
 
       common /nekmpi/ mid,mp,nekcomm,nekgroup,nekreal
-      common /scrcg/ xyz(ldim*(2**ldim)*lelt)
+      common /scrcg_map2/ xyz(ldim*(2**ldim)*lelt)
 
       integer*8 eid8(4*lelt),vtx8(lelt*(2**ldim+1))
-      common /ctmp0/ eid8, vtx8, iwork
+      common /ctmp0_map2/ eid8, vtx8, iwork
 
       ierr = 0
 
@@ -660,7 +660,7 @@ C
       include 'SOLN'
       include 'SCRCT'
       include 'TSTEP'
-      common /ctmp0/ iwork(lelt)
+      common /ctmp0_map2/ iwork(lelt)
 
       REAL*8 dnekclock,t0
 

--- a/core/math.f
+++ b/core/math.f
@@ -832,7 +832,7 @@ c-----------------------------------------------------------------------
 
       real a(1)
 
-      common /scrsf/ w1 (lx1,ly1,lz1,lelt)
+      common /scrsf_math/ w1 (lx1,ly1,lz1,lelt)
 
       call col3 (w1,a,a,n)
       call col2 (w1,bm1,n)
@@ -848,7 +848,7 @@ c-----------------------------------------------------------------------
 
       real a(n)
 
-      common /scrsf/ w1 (lx2*ly2*lz2*lelt)
+      common /scrsf_math/ w1 (lx2*ly2*lz2*lelt)
 
       call col3 (w1,a,a,n)
       call col2 (w1,bm2,n)

--- a/core/multimesh.f
+++ b/core/multimesh.f
@@ -421,7 +421,7 @@ c-----------------------------------------------------------------------
       include 'CTIMER'
 
       parameter (lt=lx1*ly1*lz1*lelt,lxyz=lx1*ly1*lz1)
-      common /scrcg/ pm1(lt),wk1(lxyz),wk2(lxyz)
+      common /scrcg_multimesh/ pm1(lt),wk1(lxyz),wk2(lxyz)
 
       real fieldout(nmaxl_nn,nfldmax_nn)
       real field(lx1*ly1*lz1*lelt)
@@ -533,7 +533,7 @@ C--------------------------------------------------------------------------
       include 'TOTAL'
       include 'NEKNEK'
       integer e,f
-      common /ctmp1/ work(lx1*ly1*lz1*lelt)
+      common /ctmp1_multimesh/ work(lx1*ly1*lz1*lelt)
       integer itchk
       common /idumochk/ itchk
       integer icalld
@@ -849,16 +849,16 @@ c
      $   , vzc(lx1,ly1,lz1,lelv)
      $   , prc(lx2,ly2,lz2,lelv)
 C
-      COMMON /SCRNS/ rw1   (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_multimesh/ rw1   (LX1,LY1,LZ1,LELV)
      $ ,             rw2   (LX1,LY1,LZ1,LELV)
      $ ,             rw3   (LX1,LY1,LZ1,LELV)
      $ ,             dv1   (LX1,LY1,LZ1,LELV)
      $ ,             dv2   (LX1,LY1,LZ1,LELV)
      $ ,             dv3   (LX1,LY1,LZ1,LELV)
      $ ,             RESPR (LX2,LY2,LZ2,LELV)
-      COMMON /SCRVH/ H1    (LX1,LY1,LZ1,LELV)
+      COMMON /scrvh_multimesh/ H1    (LX1,LY1,LZ1,LELV)
      $ ,             H2    (LX1,LY1,LZ1,LELV)
-      COMMON /SCRHI/ H2INV (LX1,LY1,LZ1,LELV)
+      COMMON /scrhi_multimesh/ H2INV (LX1,LY1,LZ1,LELV)
       common /cvflow_i/ icvflow,iavflow
 
       common /cbplan_vol_ms/  vxcp, dvxc, vycp,
@@ -992,7 +992,7 @@ c     (Tombo splitting scheme).
      $   , vzc(lx1,ly1,lz1,lelv)
      $   , prc(lx2,ly2,lz2,lelv)
 
-      common /scrns/ resv1 (lx1,ly1,lz1,lelv)
+      common /scrns_multimesh/ resv1 (lx1,ly1,lz1,lelv)
      $ ,             resv2 (lx1,ly1,lz1,lelv)
      $ ,             resv3 (lx1,ly1,lz1,lelv)
      $ ,             respr (lx2*ly2*lz2,lelv)
@@ -1002,9 +1002,9 @@ c     (Tombo splitting scheme).
      $ ,             WA1 (lx1*ly1*lz1*lelv)
      $ ,             WA2 (lx1*ly1*lz1*lelv)
      $ ,             WA3 (lx1*ly1*lz1*lelv)
-      common /scrvh/ h1    (lx1,ly1,lz1,lelv)
+      common /scrvh_multimesh/ h1    (lx1,ly1,lz1,lelv)
      $ ,             h2    (lx1,ly1,lz1,lelv)
-      COMMON /SCRMG/ W1    (LX1*LY1*LZ1,LELV)
+      COMMON /scrmg_multimesh/ W1    (LX1*LY1*LZ1,LELV)
      $ ,             W2    (LX1*LY1*LZ1,LELV)
      $ ,             W3    (LX1*LY1*LZ1,LELV)
 

--- a/core/mvmesh.f
+++ b/core/mvmesh.f
@@ -84,7 +84,7 @@ C
       include 'SOLN'
       include 'TSTEP'
 C
-      COMMON /SCRUZ/ FM1(LX1,LY1,LZ1,LELT)
+      COMMON /scruz_mvmesh/ FM1(LX1,LY1,LZ1,LELT)
      $             , FM2(LX1,LY1,LZ1,LELT)
      $             , FM3(LX1,LY1,LZ1,LELT)
      $             , PHI(LX1,LY1,LZ1,LELT)
@@ -113,7 +113,7 @@ C
       include 'SOLN'
       include 'TSTEP'
 C
-      COMMON /SCRUZ/ FMT(LX1,LY1,LZ1,LELT)
+      COMMON /scruz_mvmesh/ FMT(LX1,LY1,LZ1,LELT)
      $             , PHI(LX1,LY1,LZ1,LELT)
 C
       IFLD = 0
@@ -137,7 +137,7 @@ C
       include 'WZ'
       include 'INPUT'
 C
-      COMMON /SCRSF/ PHR(LX1,LY1,LZ1,LELT)
+      COMMON /scrsf_mvmesh/ PHR(LX1,LY1,LZ1,LELT)
      $             , PHS(LX1,LY1,LZ1,LELT)
      $             , PHT(LX1,LY1,LZ1,LELT)
 
@@ -185,7 +185,7 @@ C
       include 'MASS'
       include 'MVGEOM'
       include 'WZ'
-      COMMON /SCRSF/ PHR(LX1,LY1,LZ1,LELT)
+      COMMON /scrsf_mvmesh/ PHR(LX1,LY1,LZ1,LELT)
      $             , PHS(LX1,LY1,LZ1,LELT)
      $             , PHT(LX1,LY1,LZ1,LELT)
 C
@@ -257,16 +257,16 @@ c     Evaluate mesh velocities at all moving boundaries
       include 'SOLN'
       include 'TSTEP'
 
-      common /scrsf/ wvx(lx1*ly1*lz1,lelt)
+      common /scrsf_mvmesh/ wvx(lx1*ly1*lz1,lelt)
      $             , wvy(lx1*ly1*lz1,lelt)
      $             , wvz(lx1*ly1*lz1,lelt)
-      common /scrch/ wtx(lx1*ly1*lz1,lelt)
+      common /scrch_mvmesh/ wtx(lx1*ly1*lz1,lelt)
      $             , wty(lx1*ly1*lz1,lelt)
-      common /scrmg/ wtz(lx1*ly1*lz1,lelt)
+      common /scrmg_mvmesh/ wtz(lx1*ly1*lz1,lelt)
      $             , rnx(lx1*ly1*lz1,lelt)
      $             , rny(lx1*ly1*lz1,lelt)
      $             , rnz(lx1*ly1*lz1,lelt)
-      common /scruz/ dsa(lx1*ly1*lz1,lelt)
+      common /scruz_mvmesh/ dsa(lx1*ly1*lz1,lelt)
      $             , qni(lx1*ly1*lz1,lelt)
      $             , smt(lx1*ly1*lz1,lelt)
      $             , ta (lx1*ly1*lz1,lelt)
@@ -505,7 +505,8 @@ c-----------------------------------------------------------------------
 
       integer e,f
 
-      common /scruz/ r1(lx1,ly1,lz1),r2(lx1,ly1,lz1),r3(lx1,ly1,lz1)
+      common /scruz_mvmesh/ r1(lx1,ly1,lz1),r2(lx1,ly1,lz1),r3(lx1,ly1,
+     $ lz1)
 
       call facind(i0,i1,j0,j1,k0,k1,lx1,ly1,lz1,f)
 
@@ -533,7 +534,8 @@ c-----------------------------------------------------------------------
       subroutine norcmp (wt1,wt2,wt3,rnx,rny,rnz,ifc)
 C
       include 'SIZE'
-      COMMON /SCRUZ/ R1(LX1,LY1,LZ1),R2(LX1,LY1,LZ1),R3(LX1,LY1,LZ1)
+      COMMON /scruz_mvmesh/ R1(LX1,LY1,LZ1),R2(LX1,LY1,LZ1),R3(LX1,LY1,
+     $ LZ1)
 C
       DIMENSION WT1(LX1,LY1,LZ1),WT2(LX1,LY1,LZ1),WT3(LX1,LY1,LZ1)
      $        , RNX(LX1,LY1,LZ1),RNY(LX1,LY1,LZ1),RNZ(LX1,LY1,LZ1)
@@ -571,7 +573,8 @@ c-----------------------------------------------------------------------
       subroutine facemv (wt1,wt2,wt3,rnx,rny,rnz,smt,ifc)
 C
       include 'SIZE'
-      COMMON /SCRUZ/ R1(LX1,LY1,LZ1),R2(LX1,LY1,LZ1),R3(LX1,LY1,LZ1)
+      COMMON /scruz_mvmesh/ R1(LX1,LY1,LZ1),R2(LX1,LY1,LZ1),R3(LX1,LY1,
+     $ LZ1)
 C
       DIMENSION WT1(LX1,LY1,LZ1),WT2(LX1,LY1,LZ1),WT3(LX1,LY1,LZ1)
      $        , RNX(LX1,LY1,LZ1),RNY(LX1,LY1,LZ1),RNZ(LX1,LY1,LZ1)
@@ -612,7 +615,8 @@ C
       include 'SIZE'
       include 'GEOM'
       include 'TOPOL'
-      COMMON /SCRUZ/ R1(LX1,LY1,LZ1),R2(LX1,LY1,LZ1),R3(LX1,LY1,LZ1)
+      COMMON /scruz_mvmesh/ R1(LX1,LY1,LZ1),R2(LX1,LY1,LZ1),R3(LX1,LY1,
+     $ LZ1)
 C
       DIMENSION WT1(LX1,LY1,LZ1),WT2(LX1,LY1,LZ1),WT3(LX1,LY1,LZ1)
 C
@@ -670,7 +674,7 @@ C
       include 'INPUT'
       include 'SOLN'
       include 'TSTEP'
-      COMMON /SCRVH/ H1(LX1,LY1,LZ1,LELT)
+      COMMON /scrvh_mvmesh/ H1(LX1,LY1,LZ1,LELT)
      $             , H2(LX1,LY1,LZ1,LELT)
 C
       DIMENSION QNI(LX1,LY1,LZ1,1)
@@ -736,15 +740,15 @@ C
       include 'SOLN'
       include 'TSTEP'
 C
-      COMMON /SCRNS/ DW1  (LX1,LY1,LZ1,LELT)
+      COMMON /scrns_mvmesh/ DW1  (LX1,LY1,LZ1,LELT)
      $             , DW2  (LX1,LY1,LZ1,LELT)
      $             , DW3  (LX1,LY1,LZ1,LELT)
      $             , AW1  (LX1,LY1,LZ1,LELT)
      $             , AW2  (LX1,LY1,LZ1,LELT)
      $             , AW3  (LX1,LY1,LZ1,LELT)
-      COMMON /SCRVH/ H1   (LX1,LY1,LZ1,LELT)
+      COMMON /scrvh_mvmesh/ H1   (LX1,LY1,LZ1,LELT)
      $             , H2   (LX1,LY1,LZ1,LELT)
-      common /scruz/ prt  (lx1,ly1,lz1,lelt)
+      common /scruz_mvmesh/ prt  (lx1,ly1,lz1,lelt)
       COMMON /FASTMD/ IFDFRM(LELT), IFFAST(LELT), IFH2, IFSOLV
       LOGICAL IFDFRM, IFFAST, IFH2, IFSOLV
 
@@ -855,7 +859,7 @@ C
       include 'MVGEOM'
       include 'GEOM'
       include 'INPUT'
-      COMMON /SCRSF/ UX(LX1,LY1,LZ1,LELT)
+      COMMON /scrsf_mvmesh/ UX(LX1,LY1,LZ1,LELT)
      $             , UY(LX1,LY1,LZ1,LELT)
      $             , UZ(LX1,LY1,LZ1,LELT)
       DIMENSION ABM(3)
@@ -959,7 +963,7 @@ C-----------------------------------------------------------------------
       include 'SOLN'
       include 'TSTEP'
       include 'INPUT'
-      COMMON /SCRUZ/ XM3 (LX3,LY3,LZ3,LELT)
+      COMMON /scruz_mvmesh/ XM3 (LX3,LY3,LZ3,LELT)
      $ ,             YM3 (LX3,LY3,LZ3,LELT)
      $ ,             ZM3 (LX3,LY3,LZ3,LELT)
 C

--- a/core/mxm_std.f
+++ b/core/mxm_std.f
@@ -3928,9 +3928,9 @@ c-----------------------------------------------------------------------
 
       include 'SIZE'
       parameter (lt=4*lx1*ly1*lz1*lelt)
-      common /scrns/ a(lt)
-      common /scruz/ b(lt)
-      common /scrmg/ c(lt)
+      common /scrns_mxm_std/ a(lt)
+      common /scruz_mxm_std/ b(lt)
+      common /scrmg_mxm_std/ c(lt)
 
       integer ll,icalld
       save    ll,icalld

--- a/core/navier0.f
+++ b/core/navier0.f
@@ -12,7 +12,7 @@ C
       REAL H1    (LX1,LY1,LZ1,LELV)
       REAL H2    (LX1,LY1,LZ1,LELV)
       REAL H2INV (LX1,LY1,LZ1,LELV)
-      common /scruz/ wk1(lx2*ly2*lz2*lelv)
+      common /scruz_navier0/ wk1(lx2*ly2*lz2*lelv)
      $             , wk2(lx2*ly2*lz2*lelv)
      $             , wk3(lx2*ly2*lz2*lelv)
 
@@ -51,7 +51,7 @@ c
       include 'TOTAL'
 
       common /ivrtx/ vertex ((2**ldim)*lelt)
-      common /scruz/ xbar(ldim,lelt),ibar(lelt)
+      common /scruz_navier0/ xbar(ldim,lelt),ibar(lelt)
       integer*8 vertex
       integer imap(nelgt)
 

--- a/core/navier1.f
+++ b/core/navier1.f
@@ -10,15 +10,15 @@ C-------------------------------------------------------------------------
       include 'SOLN'
       include 'TSTEP'
 C
-      COMMON /SCRHI/ H2INV (LX1,LY1,LZ1,LELV)
-      COMMON /SCRNS/ RESV1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrhi_navier1/ H2INV (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_navier1/ RESV1 (LX1,LY1,LZ1,LELV)
      $ ,             RESV2 (LX1,LY1,LZ1,LELV)
      $ ,             RESV3 (LX1,LY1,LZ1,LELV)
      $ ,             DV1   (LX1,LY1,LZ1,LELV)
      $ ,             DV2   (LX1,LY1,LZ1,LELV)
      $ ,             DV3   (LX1,LY1,LZ1,LELV)
      $ ,             WP    (LX2,LY2,LZ2,LELV)
-      COMMON /SCRVH/ H1    (LX1,LY1,LZ1,LELV)
+      COMMON /scrvh_navier1/ H1    (LX1,LY1,LZ1,LELV)
      $ ,             H2    (LX1,LY1,LZ1,LELV)
       REAL           G1    (LX1,LY1,LZ1,LELV)
       REAL           G2    (LX1,LY1,LZ1,LELV)
@@ -89,10 +89,10 @@ c     Compute start-residual/right-hand-side in the pressure equation
       REAL           H1     (LX1,LY1,LZ1,LELV)
       REAL           H2     (LX1,LY1,LZ1,LELV)
       REAL           H2INV  (LX1,LY1,LZ1,LELV)
-      COMMON /SCRUZ/ TA1    (LX1,LY1,LZ1,LELV)
+      COMMON /scruz_navier1/ TA1    (LX1,LY1,LZ1,LELV)
      $ ,             TA2    (LX1,LY1,LZ1,LELV)
      $ ,             TA3    (LX1,LY1,LZ1,LELV)
-      COMMON /SCRMG/ VBDRY1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrmg_navier1/ VBDRY1 (LX1,LY1,LZ1,LELV)
      $ ,             VBDRY2 (LX1,LY1,LZ1,LELV)
      $ ,             VBDRY3 (LX1,LY1,LZ1,LELV)
 
@@ -119,10 +119,10 @@ c     Compute the residual for the velocity - UZAWA SCHEME.
       REAL           RESV1 (LX1,LY1,LZ1,1)
       REAL           RESV2 (LX1,LY1,LZ1,1)
       REAL           RESV3 (LX1,LY1,LZ1,1)
-      COMMON /SCRMG/ TA1   (LX1,LY1,LZ1,LELV)
+      COMMON /scrmg_navier1/ TA1   (LX1,LY1,LZ1,LELV)
      $ ,             TA2   (LX1,LY1,LZ1,LELV)
      $ ,             TA3   (LX1,LY1,LZ1,LELV)
-      COMMON /SCREV/ H1    (LX1,LY1,LZ1,LELV)
+      COMMON /screv_navier1/ H1    (LX1,LY1,LZ1,LELV)
      $ ,             H2    (LX1,LY1,LZ1,LELV)
 C
       INLOC   = -1
@@ -153,10 +153,10 @@ C-----------------------------------------------------------------------
       REAL           OUT3  (LX1,LY1,LZ1,LELV)
       REAL           H1    (LX1,LY1,LZ1,LELV)
       REAL           H2    (LX1,LY1,LZ1,LELV)
-      COMMON /SCRMG/ TA1   (LX1,LY1,LZ1,LELV)
+      COMMON /scrmg_navier1/ TA1   (LX1,LY1,LZ1,LELV)
      $              ,TA2   (LX1,LY1,LZ1,LELV)
      $              ,TA3   (LX1,LY1,LZ1,LELV)
-      COMMON /SCRUZ/ TB1   (LX1,LY1,LZ1,LELV)
+      COMMON /scruz_navier1/ TB1   (LX1,LY1,LZ1,LELV)
      $              ,TB2   (LX1,LY1,LZ1,LELV)
      $              ,TB3   (LX1,LY1,LZ1,LELV)
      $              ,HZERO (LX1,LY1,LZ1,LELV)
@@ -198,7 +198,7 @@ C
       include 'MASS'
       include 'TSTEP'
       REAL           RESPR (LX2,LY2,LZ2,LELV)
-      COMMON /SCRMG/ WORK  (LX1,LY1,LZ1,LELV)
+      COMMON /scrmg_navier1/ WORK  (LX1,LY1,LZ1,LELV)
 C
       NTOT1 = lx1*ly1*lz1*NELV
       CALL INVCOL3 (WORK,RESPR,BM1,NTOT1)
@@ -269,7 +269,7 @@ C     INTYPE=-1  Compute the matrix-vector product    D(A+B/DT)(-1)DT*p
       REAL           H2    (LX1,LY1,LZ1,1)
       REAL           H2INV (LX1,LY1,LZ1,1)
 C
-      COMMON /SCRNS/ TA1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_navier1/ TA1 (LX1,LY1,LZ1,LELV)
      $ ,             TA2 (LX1,LY1,LZ1,LELV)
      $ ,             TA3 (LX1,LY1,LZ1,LELV)
      $ ,             TB1 (LX1,LY1,LZ1,LELV)
@@ -348,7 +348,7 @@ C
       real sm2  (lx2*ly2*lz2,lelv)
       real tm2  (lx2*ly2*lz2,lelv)
 C
-      common /ctmp1/ wx  (lx1*ly1*lz1)
+      common /ctmp1_navier1/ wx  (lx1*ly1*lz1)
      $ ,             ta1 (lx1*ly1*lz1)
      $ ,             ta2 (lx1*ly1*lz1)
      $ ,             ta3 (lx1*ly1,lz1)
@@ -563,7 +563,7 @@ C---------------------------------------------------------------------
       real           sm2  (lx2*ly2*lz2,lelv)
       real           tm2  (lx2*ly2*lz2,lelv)
 
-      common /ctmp1/ ta1 (lx1*ly1*lz1)
+      common /ctmp1_navier1/ ta1 (lx1*ly1*lz1)
      $ ,             ta2 (lx1*ly1*lz1)
      $ ,             ta3 (lx1*ly1*lz1)
 
@@ -913,7 +913,7 @@ c
       REAL           WP   (LX2,LY2,LZ2,LELV)
       REAL           H1M1 (LX1,LY1,LZ1,LELV)
       REAL           H2M1 (LX1,LY1,LZ1,LELV)
-      COMMON /SCRCH/ H1M2 (LX2,LY2,LZ2,LELV)
+      COMMON /scrch_navier1/ H1M2 (LX2,LY2,LZ2,LELV)
      $ ,             H2M2 (LX2,LY2,LZ2,LELV)
 C
       integer kstep
@@ -977,7 +977,7 @@ C----------------------------------------------------------------
       include 'TSTEP'
       REAL           Z2   (LX2,LY2,LZ2,LELV)
       REAL           R2   (LX2,LY2,LZ2,LELV)
-      COMMON /SCRNS/ MASK (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_navier1/ MASK (LX1,LY1,LZ1,LELV)
      $              ,R1   (LX1,LY1,LZ1,LELV)
      $              ,X1   (LX1,LY1,LZ1,LELV)
      $              ,W2   (LX2,LY2,LZ2,LELV)
@@ -1072,7 +1072,7 @@ C-----------------------------------------------------------------
       include 'SIZE'
       include 'MASS'
       REAL           RES  (LX2,LY2,LZ2,LELV)
-      COMMON /SCRMG/ TA   (LX2,LY2,LZ2,LELV)
+      COMMON /scrmg_navier1/ TA   (LX2,LY2,LZ2,LELV)
      $ ,             TB   (LX2,LY2,LZ2,LELV)
 C
       RBNORM = 0.
@@ -1100,7 +1100,7 @@ C-------------------------------------------------------------------
       include 'MASS'
       include 'TSTEP'
       REAL           RES (LX2,LY2,LZ2,LELV)
-      COMMON /CTMP0/ TA  (LX2,LY2,LZ2,LELV)
+      COMMON /ctmp0_navier1/ TA  (LX2,LY2,LZ2,LELV)
      $ ,             TB  (LX2,LY2,LZ2,LELV)
       COMMON /CPRINT/ IFPRINT
       LOGICAL         IFPRINT
@@ -1238,9 +1238,9 @@ C--------------------------------------------------------------------
 C
 C     Use the common blocks CTMP0 and CTMP1 as work space.
 C
-      COMMON /SCRCH/  CMASK1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrch_navier1/  CMASK1 (LX1,LY1,LZ1,LELV)
      $ ,              CMASK2 (LX1,LY1,LZ1,LELV)
-      COMMON /CTMP1/  MFI    (LX1,LY1,LZ1,LELV)
+      COMMON /ctmp1_navier1/  MFI    (LX1,LY1,LZ1,LELV)
      $ ,              DMFI   (LX1,LY1,LZ1,LELV)
      $ ,              MDMFI  (LX1,LY1,LZ1,LELV)
       REAL   MFI,DMFI,MDMFI
@@ -1305,7 +1305,7 @@ C--------------------------------------------------------------------
       include 'TOTAL'
       REAL           DTFI (LX1,LY1,LZ1,1) 
       REAL           FI   (LX1,LY1,LZ1,1)
-      COMMON /SCRNS/ TA1  (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_navier1/ TA1  (LX1,LY1,LZ1,LELV)
      $ ,             TA2  (LX1,LY1,LZ1,LELV)
      $ ,             TA3  (LX1,LY1,LZ1,LELV)
      $ ,             TB1  (LX1,LY1,LZ1,LELV)
@@ -1525,7 +1525,7 @@ C---------------------------------------------------------------
       include 'MASS'
       include 'TSTEP'
 C
-      COMMON /SCRUZ/ TA1 (LX1,LY1,LZ1,LELV)
+      COMMON /scruz_navier1/ TA1 (LX1,LY1,LZ1,LELV)
      $ ,             TA2 (LX1,LY1,LZ1,LELV)
      $ ,             TA3 (LX1,LY1,LZ1,LELV)
 C
@@ -1556,7 +1556,7 @@ C
       include 'INPUT'
       include 'TSTEP'
 C
-      COMMON /SCRNS/ TA1(LX1,LY1,LZ1,LELV)
+      COMMON /scrns_navier1/ TA1(LX1,LY1,LZ1,LELV)
      $ ,             TA2(LX1,LY1,LZ1,LELV)
      $ ,             TA3(LX1,LY1,LZ1,LELV)
      $ ,             TB1(LX1,LY1,LZ1,LELV)
@@ -1605,7 +1605,7 @@ C-----------------------------------------------------------------------
       include 'SOLN'
       include 'TSTEP'
 C
-      COMMON /SCRUZ/ TA1 (LX1,LY1,LZ1,LELV)
+      COMMON /scruz_navier1/ TA1 (LX1,LY1,LZ1,LELV)
      $ ,             TA2 (LX1,LY1,LZ1,LELV)
      $ ,             TA3 (LX1,LY1,LZ1,LELV)
 C
@@ -1968,7 +1968,7 @@ C---------------------------------------------------------------------
       REAL           HV3MSK (LX1,LY1,LZ1,1)
       CHARACTER      CB*3
       PARAMETER (LXYZ1=LX1*LY1*LZ1)
-      COMMON /CTMP1/ WORK   (LXYZ1,LELT)
+      COMMON /ctmp1_navier1/ WORK   (LXYZ1,LELT)
 C
       NFACES= 2*ldim
       NTOT1 = lx1*ly1*lz1*NELV
@@ -2035,7 +2035,7 @@ C---------------------------------------------------------------
       include 'MASS'
 C
       REAL           X  (LX1,LY1,LZ1,1)
-      COMMON /SCRNRM/ Y  (LX1,LY1,LZ1,LELT)
+      COMMON /scrnrm_navier1/ Y  (LX1,LY1,LZ1,LELT)
      $               ,TA1(LX1,LY1,LZ1,LELT)
      $               ,TA2(LX1,LY1,LZ1,LELT)
       REAL H1,SEMI,L2,LINF
@@ -2094,11 +2094,11 @@ C
       REAL           X1 (LX1,LY1,LZ1,1)
       REAL           X2 (LX1,LY1,LZ1,1)
       REAL           X3 (LX1,LY1,LZ1,1)
-      COMMON /SCRMG/ Y1 (LX1,LY1,LZ1,LELT)
+      COMMON /scrmg_navier1/ Y1 (LX1,LY1,LZ1,LELT)
      $              ,Y2 (LX1,LY1,LZ1,LELT)
      $              ,Y3 (LX1,LY1,LZ1,LELT)
      $              ,TA1(LX1,LY1,LZ1,LELT)
-      COMMON /SCRCH/ TA2(LX1,LY1,LZ1,LELT)
+      COMMON /scrch_navier1/ TA2(LX1,LY1,LZ1,LELT)
       REAL H1,SEMI,L2,LINF
       REAL LENGTH
 C
@@ -2186,18 +2186,18 @@ C--------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
       LOGICAL        IFSTUZ
-      COMMON /SCRNS/ RESV1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_navier1/ RESV1 (LX1,LY1,LZ1,LELV)
      $ ,             RESV2 (LX1,LY1,LZ1,LELV)
      $ ,             RESV3 (LX1,LY1,LZ1,LELV)
      $ ,             RESP  (LX2,LY2,LZ2,LELV)
      $ ,             TA1   (LX1,LY1,LZ1,LELV)
      $ ,             TA2   (LX1,LY1,LZ1,LELV)
      $ ,             TA3   (LX1,LY1,LZ1,LELV) 
-      COMMON /SCRMG/ TB1   (LX1,LY1,LZ1,LELV)
+      COMMON /scrmg_navier1/ TB1   (LX1,LY1,LZ1,LELV)
      $ ,             TB2   (LX1,LY1,LZ1,LELV)
      $ ,             TB3   (LX1,LY1,LZ1,LELV)
      $ ,             WP    (LX2,LY2,LZ2,LELV)
-      COMMON /SCRVH/ H1    (LX1,LY1,LZ1,LELV)
+      COMMON /scrvh_navier1/ H1    (LX1,LY1,LZ1,LELV)
      $ ,             H2    (LX1,LY1,LZ1,LELV)
 C
       IFSTUZ = .TRUE.
@@ -2842,7 +2842,7 @@ C-----------------------------------------------------------------------
       REAL             H1   (LX1,LY1,LZ1,LELV)
       REAL             H2   (LX1,LY1,LZ1,LELV)
       REAL             H2INV(LX1,LY1,LZ1,LELV)
-      COMMON /SCRUZ/   WP   (LX2,LY2,LZ2,LELV)
+      COMMON /scruz_navier1/   WP   (LX2,LY2,LZ2,LELV)
      $ ,               XCG  (LX2,LY2,LZ2,LELV)
      $ ,               PCG  (LX2,LY2,LZ2,LELV) 
      $ ,               RPCG (LX2,LY2,LZ2,LELV)
@@ -3154,9 +3154,9 @@ C
 C
 C     Use the common blocks CTMP0 and CTMP1 as work space.
 C
-      COMMON /SCRCH/  CMASK1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrch_navier1/  CMASK1 (LX1,LY1,LZ1,LELV)
      $ ,              CMASK2 (LX1,LY1,LZ1,LELV)
-      COMMON /CTMP1/  MFI    (LX1,LY1,LZ1,LELV)
+      COMMON /ctmp1_navier1/  MFI    (LX1,LY1,LZ1,LELV)
      $ ,              DMFI   (LX1,LY1,LZ1,LELV)
      $ ,              MDMFI  (LX1,LY1,LZ1,LELV)
       REAL   MFI,DMFI,MDMFI
@@ -3230,7 +3230,7 @@ C--------------------------------------------------------------------
       REAL           DFI (LX1,LY1,LZ1,1) 
       REAL           FI  (LX1,LY1,LZ1,1) 
 c
-      COMMON /CTMP0/ TA1  (LX1,LY1,LZ1,LELV)
+      COMMON /ctmp0_navier1/ TA1  (LX1,LY1,LZ1,LELV)
      $             , DFID (LXD,LYD,LZD,LELV) 
      $             , TA1D (LXD,LYD,LZD,lelv) 
 C
@@ -3290,7 +3290,7 @@ c
 C
 C     Store the inverse jacobian to speed this operation up
 C
-      common /ctmp0/ dudr(lx1,ly1,lz1)
+      common /ctmp0_navier1/ dudr(lx1,ly1,lz1)
      $             , duds(lx1,ly1,lz1)
      $             , dudt(lx1,ly1,lz1)
 
@@ -3368,7 +3368,7 @@ C
 C     Store the inverse jacobian to speed this operation up
 C
 C
-      common /ctmp0/ dudr(lx1,ly1,lz1)
+      common /ctmp0_navier1/ dudr(lx1,ly1,lz1)
      $             , duds(lx1,ly1,lz1)
      $             , dudt(lx1,ly1,lz1)
 C
@@ -3443,7 +3443,7 @@ c
       common /fastmd/ ifdfrm(lelt), iffast(lelt), ifh2, ifsolv
       logical ifdfrm, iffast, ifh2, ifsolv
 C
-      common /ctmp0/ duds(lx1,ly1,lz1)
+      common /ctmp0_navier1/ duds(lx1,ly1,lz1)
      $             , dvds(lx1,ly1,lz1)
      $             , dwds(lx1,ly1,lz1)
 C
@@ -3678,7 +3678,7 @@ c
       real  cu(lx1,ly1,lz1,1),cv(lx1,ly1,lz1,1),cw(lx1,ly1,lz1,1)
       real  wk(lx1,ly1,lz1,3)
 c
-      common /ctmp0/ duds(lx1,ly1,lz1)
+      common /ctmp0_navier1/ duds(lx1,ly1,lz1)
      $             , dvds(lx1,ly1,lz1)
      $             , dwds(lx1,ly1,lz1)
 C
@@ -3878,7 +3878,7 @@ C---------------------------------------------------------------------
       integer msk(0:1)
       CHARACTER      CB*3
       PARAMETER (LXYZ1=LX1*LY1*LZ1)
-      COMMON /CTMP1/ WORK(LXYZ1,LELT)
+      COMMON /ctmp1_navier1/ WORK(LXYZ1,LELT)
       real mask(lxyz1,lelt)
 C
       NFACES= 2*ldim
@@ -3932,24 +3932,24 @@ C
       REAL           VEL1  (LX1,LY1,LZ1,1)
       REAL           VEL2  (LX1,LY1,LZ1,1)
       REAL           VEL3  (LX1,LY1,LZ1,1)
-      COMMON /SCRNS/ VXN   (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_navier1/ VXN   (LX1,LY1,LZ1,LELV)
      $ ,             VYN   (LX1,LY1,LZ1,LELV)
      $ ,             VZN   (LX1,LY1,LZ1,LELV)
      $ ,             HV1MSK(LX1,LY1,LZ1,LELV)
      $ ,             HV2MSK(LX1,LY1,LZ1,LELV)
      $ ,             HV3MSK(LX1,LY1,LZ1,LELV)
      $ ,             WORK  (LX1,LY1,LZ1,LELV)
-      COMMON /CTMP1/ RKX1  (LX1,LY1,LZ1,LELV)
+      COMMON /ctmp1_navier1/ RKX1  (LX1,LY1,LZ1,LELV)
      $ ,             RKX2  (LX1,LY1,LZ1,LELV)
      $ ,             RKX3  (LX1,LY1,LZ1,LELV)
      $ ,             RKX4  (LX1,LY1,LZ1,LELV)
-      COMMON /SCRMG/ RKY1  (LX1,LY1,LZ1,LELV)
+      COMMON /scrmg_navier1/ RKY1  (LX1,LY1,LZ1,LELV)
      $ ,             RKY2  (LX1,LY1,LZ1,LELV)
      $ ,             RKY3  (LX1,LY1,LZ1,LELV)
      $ ,             RKY4  (LX1,LY1,LZ1,LELV)
-      COMMON /SCREV/ RKZ1  (LX1,LY1,LZ1,LELV)
+      COMMON /screv_navier1/ RKZ1  (LX1,LY1,LZ1,LELV)
      $ ,             RKZ2  (LX1,LY1,LZ1,LELV)
-      COMMON /SCRCH/ RKZ3  (LX1,LY1,LZ1,LELV)
+      COMMON /scrch_navier1/ RKZ3  (LX1,LY1,LZ1,LELV)
      $ ,             RKZ4  (LX1,LY1,LZ1,LELV)
 C
       NTOT1 = lx1*ly1*lz1*NELV
@@ -4074,7 +4074,7 @@ C---------------------------------------------------------------------
       real inpx   (lx1,ly1,lz1,1)
       real inpy   (lx1,ly1,lz1,1)
       real inpz   (lx1,ly1,lz1,1)
-      common /ctmp0/ work (lx2,ly2,lz2,lelv)
+      common /ctmp0_navier1/ work (lx2,ly2,lz2,lelv)
 C
       iflg = 1
 
@@ -4181,7 +4181,7 @@ c
       parameter (lxyz=lx1*ly1*lz1)
       real ux(lxyz,1),uy(lxyz,1),uz(lxyz,1),u(lxyz,1)
 c
-      common /ctmp1/ ur(lxyz),us(lxyz),ut(lxyz)
+      common /ctmp1_navier1/ ur(lxyz),us(lxyz),ut(lxyz)
 
       integer e
 
@@ -4249,11 +4249,11 @@ C----------------------------------------------------------------------
       INCLUDE 'MASS'
       INCLUDE 'TSTEP'
 C
-      COMMON /SCRUZ/ W1 (LX1,LY1,LZ1,LELV)
+      COMMON /scruz_navier1/ W1 (LX1,LY1,LZ1,LELV)
      $ ,             W2 (LX1,LY1,LZ1,LELV)
      $ ,             W3 (LX1,LY1,LZ1,LELV)
 C
-      COMMON /SCRNS/ SXZ(LX1,LY1,LZ1,LELT)
+      COMMON /scrns_navier1/ SXZ(LX1,LY1,LZ1,LELT)
      $             , SYZ(LX1,LY1,LZ1,LELT)
      $             , SXX(LX1,LY1,LZ1,LELT)
      $             , SXY(LX1,LY1,LZ1,LELT)
@@ -4323,7 +4323,7 @@ C
       INCLUDE 'INPUT'
       INCLUDE 'GEOM'
 
-      COMMON /SCRNS/ EXZ(LX1,LY1,LZ1,LELT)
+      COMMON /scrns_navier1/ EXZ(LX1,LY1,LZ1,LELT)
      $             , EYZ(LX1,LY1,LZ1,LELT)
      $             , EXX(LX1,LY1,LZ1,LELT)
      $             , EXY(LX1,LY1,LZ1,LELT)
@@ -4402,7 +4402,8 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
 
-      common /scruz/ u(lx1*ly1*lz1),v(lx1*ly1*lz1),w(lx1*ly1*lz1)
+      common /scruz_navier1/ u(lx1*ly1*lz1),v(lx1*ly1*lz1),
+     $ w(lx1*ly1*lz1)
 
       integer e
 
@@ -4491,7 +4492,7 @@ c     \dxj/   \     dxj       dxi /
       real nu
 
       parameter (lxyz=lx1*ly1*lz1)
-      common /ctmp1/ ur(lxyz),us(lxyz),ut(lxyz)
+      common /ctmp1_navier1/ ur(lxyz),us(lxyz),ut(lxyz)
      $             , vr(lxyz),vs(lxyz),vt(lxyz)
      $             , wr(lxyz),ws(lxyz),wt(lxyz)
 
@@ -4572,7 +4573,7 @@ c
       real nu
 
       parameter (lxyz=lx1*ly1*lz1)
-      common /ctmp1/ ur(lxyz),us(lxyz),ut(lxyz)
+      common /ctmp1_navier1/ ur(lxyz),us(lxyz),ut(lxyz)
      $             , vr(lxyz),vs(lxyz),vt(lxyz)
      $             , wr(lxyz),ws(lxyz),wt(lxyz)
 

--- a/core/navier2.f
+++ b/core/navier2.f
@@ -187,7 +187,7 @@ c
       parameter (lxyz=lx1*ly1*lz1)
       real ux(lxyz),uy(lxyz),uz(lxyz),u(lxyz,1)
 c
-      common /ctmp1/ ur(lxyz),us(lxyz),ut(lxyz)
+      common /ctmp1_navier2/ ur(lxyz),us(lxyz),ut(lxyz)
 c
       integer e
 

--- a/core/navier3.f
+++ b/core/navier3.f
@@ -17,7 +17,7 @@ C----------------------------------------------------------------
       INCLUDE 'TSTEP'
       REAL           Z2   (LX2,LY2,LZ2,LELV)
       REAL           R2   (LX2,LY2,LZ2,LELV)
-      COMMON /SCRNS/ MASK (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_navier3/ MASK (LX1,LY1,LZ1,LELV)
      $              ,R1   (LX1,LY1,LZ1,LELV)
      $              ,X1   (LX1,LY1,LZ1,LELV)
      $              ,W2   (LX2,LY2,LZ2,LELV)
@@ -59,7 +59,7 @@ c
       include 'CTIMER'
 c
       real u(1),v(1)
-      common /scrprc/ uc(lx1*ly1*lz1*lelt)
+      common /scrprc_navier3/ uc(lx1*ly1*lz1*lelt)
 c
       if (icalld.eq.0) then
          tddsl=0.0

--- a/core/navier4.f
+++ b/core/navier4.f
@@ -284,7 +284,7 @@ C--------------------------------------------------------------------
       COMMON /CPRINT/ IFPRINT
       LOGICAL         IFPRINT
 C
-      COMMON /SCRUZ/  DIVV (LX2,LY2,LZ2,LELV)
+      COMMON /scruz_navier4/  DIVV (LX2,LY2,LZ2,LELV)
      $ ,              BDIVV(LX2,LY2,LZ2,LELV)
 C
       if (ifsplit) return
@@ -525,7 +525,7 @@ c
       REAL           MASK (LX1,LY1,LZ1,1)
       REAL           MULT (LX1,LY1,LZ1,1)
       REAL           bi   (LX1,LY1,LZ1,1)
-      COMMON /CTMP0/ W1   (LX1,LY1,LZ1,LELT)
+      COMMON /ctmp0_navier4/ W1   (LX1,LY1,LZ1,LELT)
      $ ,             W2   (LX1,LY1,LZ1,LELT)
 c
       etime1=dnekclock()
@@ -1253,8 +1253,8 @@ c
       integer   napprox(1)
 
       parameter (lt=lx1*ly1*lz1*lelt)
-      common /scrvh/ h1(lt),h2(lt)
-      common /scruz/ r (lt),ub(lt)
+      common /scrvh_navier4/ h1(lt),h2(lt)
+      common /scruz_navier4/ r (lt),ub(lt)
 
       logical ifstdh
       character*4  cname

--- a/core/navier5.f
+++ b/core/navier5.f
@@ -25,7 +25,7 @@ c
       save intv
       save intp
 
-      common /ctmp0/ intw,intt
+      common /ctmp0_navier5/ intw,intt
      $             , wk1,wk2
      $             , zgmv,wgtv,zgmp,wgtp,tmax(100),omax(103)
 
@@ -37,7 +37,7 @@ c
 c
 c     outpost arrays
       parameter (lt=lx1*ly1*lz1*lelv)
-      common /scruz/ w1(lt),w2(lt),w3(lt),wt(lt)
+      common /scruz_navier5/ w1(lt),w2(lt),w3(lt),wt(lt)
 
       character*18 sfmt
 
@@ -472,7 +472,7 @@ c
       parameter (lxyz=lx1*ly1*lz1)
       real ux(lxyz,1),uy(lxyz,1),uz(lxyz,1),u(lxyz,1)
 
-      common /ctmp1/ ur(lxyz),us(lxyz),ut(lxyz)
+      common /ctmp1_navier5/ ur(lxyz),us(lxyz),ut(lxyz)
 
       integer e
 
@@ -521,7 +521,7 @@ c-----------------------------------------------------------------------
       real ur(lx),us(lx),ut(lx)
      $    ,vr(lx),vs(lx),vt(lx)
      $    ,wr(lx),ws(lx),wt(lx)
-      common /ctmp0/ ur,us,ut,vr,vs,vt,wr,ws,wt
+      common /ctmp0_navier5/ ur,us,ut,vr,vs,vt,wr,ws,wt
 
       integer e
       real jacmil
@@ -1639,14 +1639,14 @@ c
       real x0(3),w1(0:maxobj)
       logical ifdout,iftout
 c
-      common /scrns/         sij (lx1*ly1*lz1*6*lelv)
-      common /scrcg/         pm1 (lx1,ly1,lz1,lelv)
-      common /scrsf/         xm0(lx1,ly1,lz1,lelt)
+      common /scrns_navier5/         sij (lx1*ly1*lz1*6*lelv)
+      common /scrcg_navier5/         pm1 (lx1,ly1,lz1,lelv)
+      common /scrsf_navier5/         xm0(lx1,ly1,lz1,lelt)
      $,                      ym0(lx1,ly1,lz1,lelt)
      $,                      zm0(lx1,ly1,lz1,lelt)
 c
       parameter (lr=lx1*ly1*lz1)
-      common /scruz/         ur(lr),us(lr),ut(lr)
+      common /scruz_navier5/         ur(lr),us(lr),ut(lr)
      $                     , vr(lr),vs(lr),vt(lr)
      $                     , wr(lr),ws(lr),wt(lr)
 c
@@ -1971,8 +1971,8 @@ c
       character*1   f1(127)
 
       parameter (lt=lx1*ly1*lz1*lelt)
-      common /scravg/ ua(lt),va(lt),wa(lt),pa(lt)
-      common /scrsf/  ta(lt,ldimt)
+      common /scravg_navier5/ ua(lt),va(lt),wa(lt),pa(lt)
+      common /scrsf_navier5/  ta(lt,ldimt)
 
       character*1 s1(127)
       equivalence (s1,initc) ! equivalence to initial condition
@@ -2148,14 +2148,14 @@ c
      $                , scale_vf(3)
 
 
-      common /scrns/         sij (lx1*ly1*lz1*6*lelv)
-      common /scrcg/         pm1 (lx1,ly1,lz1,lelv)
-      common /scrsf/         xm0(lx1,ly1,lz1,lelt)
+      common /scrns_navier5/         sij (lx1*ly1*lz1*6*lelv)
+      common /scrcg_navier5/         pm1 (lx1,ly1,lz1,lelv)
+      common /scrsf_navier5/         xm0(lx1,ly1,lz1,lelt)
      $,                      ym0(lx1,ly1,lz1,lelt)
      $,                      zm0(lx1,ly1,lz1,lelt)
 
       parameter (lr=lx1*ly1*lz1)
-      common /scruz/         ur(lr),us(lr),ut(lr)
+      common /scruz_navier5/         ur(lr),us(lr),ut(lr)
      $                     , vr(lr),vs(lr),vt(lr)
      $                     , wr(lr),ws(lr),wt(lr)
 
@@ -2325,8 +2325,8 @@ c-----------------------------------------------------------------------
       include 'TOTAL'
 
       parameter (lt = lx1*ly1*lz1)
-      common /scrns/ xb(lt,lelt),yb(lt,lelt),zb(lt,lelt)
-      common /scruz/ tmsk(lt,lelt),tmlt(lt,lelt),w1(lt),w2(lt)
+      common /scrns_navier5/ xb(lt,lelt),yb(lt,lelt),zb(lt,lelt)
+      common /scruz_navier5/ tmsk(lt,lelt),tmlt(lt,lelt),w1(lt),w2(lt)
 
       integer e,f
       character*3 cb
@@ -2785,7 +2785,7 @@ c
       real u(1),diag(1)
 
       parameter (lxx=lx1*lx1,lxyz=lx1*ly1*lz1)
-      common /ctmp0/ f(lxx),wk1(lxyz),wk2(lxyz),wk3(lxyz)
+      common /ctmp0_navier5/ f(lxx),wk1(lxyz),wk2(lxyz),wk3(lxyz)
 
       ifldt = ifield
       ifield = ifld
@@ -2808,7 +2808,8 @@ c
       real u(1)
 
       parameter (lxx=lx1*lx1,lxyz=lx1*ly1*lz1)
-      common /ctmp0/ f(lxx),wk1(lxyz),wk2(lxyz),wk3(lxyz),diag(lx1)
+      common /ctmp0_navier5/ f(lxx),wk1(lxyz),wk2(lxyz),wk3(lxyz),
+     $ diag(lx1)
 
       ifldt = ifield
       ifield = ifld
@@ -2835,7 +2836,7 @@ c-----------------------------------------------------------------------
       real v(lt,nelt)
       logical ifd4
 
-      common /ctmp1/ w(lt,lelt),ur(lt),us(lt),ut(lt),w1(2*lt)
+      common /ctmp1_navier5/ w(lt,lelt),ur(lt),us(lt),ut(lt),w1(2*lt)
 
       integer e
 
@@ -3246,7 +3247,7 @@ c
       real d(lx2,ly2,lz2,lelt),m1(lx1*ly1*lz1,lelt)
 
       parameter (lw = 3*lx1*ly1*lz1)
-      common /ctmp1/ w(lw)
+      common /ctmp1_navier5/ w(lw)
 
       integer icalld,noutf,e,f
       save    icalld,noutf
@@ -3444,7 +3445,7 @@ c
       real ua(*)
       real u (*)
 
-      common /scrcg/ wrk(lx1*ly1*lz1*lelv)
+      common /scrcg_navier5/ wrk(lx1*ly1*lz1*lelv)
 
       n = nx1*ny1*nz1*nelv
 

--- a/core/navier6.f
+++ b/core/navier6.f
@@ -40,22 +40,22 @@ c
       REAL*8 dnekclock,t0
 c
       parameter (          n_tri = 7*ltotd )
-      common /scrns/  tri (n_tri)
+      common /scrns_navier6/  tri (n_tri)
       integer         tri,elem
 c
-      common /screv/ x(2*ltotd)
-      common /scrvh/ y(2*ltotd)
-      common /scrch/ z(2*ltotd)
+      common /screv_navier6/ x(2*ltotd)
+      common /scrvh_navier6/ y(2*ltotd)
+      common /scrch_navier6/ z(2*ltotd)
 c
-      common /ctmp0/ nv_to_t(2*ltotd)
+      common /ctmp0_navier6/ nv_to_t(2*ltotd)
 c
       parameter (lia = ltotd - 2 - 2*lelt)
-      common /scrcg/ ntri(lelt+1),nmask(lelt+1)
+      common /scrcg_navier6/ ntri(lelt+1),nmask(lelt+1)
      $             , ia(lia)
 c
-      common /scruz/ color   (4*ltotd)
-      common /scrmg/ ddmask  (4*ltotd)
-      common /ctmp1/ mask    (4*ltotd)
+      common /scruz_navier6/ color   (4*ltotd)
+      common /scrmg_navier6/ ddmask  (4*ltotd)
+      common /ctmp1_navier6/ mask    (4*ltotd)
 
       parameter(lxx=lx1*lx1, levb=lelv+lbelv)
       common /fastd/  df(lx1*ly1*lz1,levb)
@@ -156,7 +156,7 @@ c
       real p(lx1,ly1,lz1,1)
       integer ce,cf
 c
-      common /ctmp0/ w1(lx1,ly1),w2(lx1,ly1)
+      common /ctmp0_navier6/ w1(lx1,ly1),w2(lx1,ly1)
 c
 c     First, copy local geometry to temporary, expanded, arrays
 c

--- a/core/navier8.f
+++ b/core/navier8.f
@@ -47,7 +47,7 @@ c
       include 'INPUT'
       include 'TSTEP'
       real uf(1),vf(1)
-      common /scrpre/ uc(lcr*lelt),w(2*lx1*ly1*lz1)
+      common /scrpre_navier8/ uc(lcr*lelt),w(2*lx1*ly1*lz1)
 
       call map_f_to_c_l2_bilin(uf,vf,w)
       call crs_solve(xxth(ifield),uc,uf)
@@ -97,21 +97,21 @@ c
       integer null_space,e
 
       character*3 cb
-      common /scrxxt/ cmlt(lcr,lelv),mask(lcr,lelv)
-      common /scrxxti/ ia(lcr,lcr,lelv), ja(lcr,lcr,lelv)
+      common /scrxxt_navier8/ cmlt(lcr,lelv),mask(lcr,lelv)
+      common /scrxxti_navier8/ ia(lcr,lcr,lelv), ja(lcr,lcr,lelv)
       real mask
       integer ia,ja
       real z
 
-      common /scrch/ iwork(2,lx1*ly1*lz1*lelv)
-      common /scrns/ w(7*lx1*ly1*lz1*lelv)
+      common /scrch_navier8/ iwork(2,lx1*ly1*lz1*lelv)
+      common /scrns_navier8/ w(7*lx1*ly1*lz1*lelv)
       common /vptsol/ a(27*lx1*ly1*lz1*lelv)
       integer w
       real wr(1)
       equivalence (wr,w)
 
-      common /scrvhx/ h1(lx1*ly1*lz1*lelv),h2(lx1*ly1*lz1*lelv)
-      common /scrmgx/ w1(lx1*ly1*lz1*lelv),w2(lx1*ly1*lz1*lelv)
+      common /scrvhx_navier8/ h1(lx1*ly1*lz1*lelv),h2(lx1*ly1*lz1*lelv)
+      common /scrmgx_navier8/ w1(lx1*ly1*lz1*lelv),w2(lx1*ly1*lz1*lelv)
 
       integer*8 ngv
       character*132 amgfile_c
@@ -621,7 +621,7 @@ c
       real   a(1),h1(1),h2(1),w(ldw)
 c
       parameter (lcrd=lx1**ldim)
-      common /ctmp1/ x(lcrd),y(lcrd),z(lcrd)
+      common /ctmp1_navier8/ x(lcrd),y(lcrd),z(lcrd)
 c
 c
       ncrs_loc = nxc**ldim
@@ -1501,9 +1501,9 @@ c
       include 'TSTEP'
 
       real uf(1),vf(1)
-      common /scrpre/ uc(lcr*lelt)
-      common /scrpr2/ vc(lcr*lelt)
-      common /scrxxt/ cmlt(lcr,lelv),mask(lcr,lelv)
+      common /scrpre_navier8/ uc(lcr*lelt)
+      common /scrpr2_navier8/ vc(lcr*lelt)
+      common /scrxxt_navier8/ cmlt(lcr,lelv),mask(lcr,lelv)
 
       integer icalld1
       save    icalld1
@@ -1564,7 +1564,7 @@ c
       parameter (lxyz = lx1*ly1*lz1)
       real uc(2,2,ldim-1,lelt),uf(lxyz,lelt)
       parameter (l2 = ldim-1)
-      common /ctmp0/ w(lx1,lx1,2),v(lx1,2,l2,lelt)
+      common /ctmp0_navier8/ w(lx1,lx1,2),v(lx1,2,l2,lelt)
 c
       integer icalld
       save    icalld
@@ -1613,7 +1613,7 @@ c
 c
       parameter (lxyz = lx1*ly1*lz1)
       real uc(lcr,lelt),uf(lx1,ly1,lz1,lelt)
-      common /ctmp0/ w(2,2,lx1),v(2,ly1,lz1,lelt)
+      common /ctmp0_navier8/ w(2,2,lx1),v(2,ly1,lz1,lelt)
 c
       integer icalld
       save    icalld
@@ -2021,12 +2021,12 @@ c
       logical ifcenter
 
       integer*8 edge(0:1,0:1,0:1,3,lelt),enum(12,lelt),fnum(6,lelt)
-      common  /scrmg/ edge,enum,fnum
+      common  /scrmg_navier8/ edge,enum,fnum
 
       parameter (nsafe=8)  ! OFTEN, nsafe=2 suffices
       integer*8 etuple(4,12*lelt*nsafe),ftuple(5,6,lelt*nsafe)
       integer ind(12*lelt*nsafe)
-      common  /scrns/ etuple,ind
+      common  /scrns_navier8/ etuple,ind
       equivalence  (etuple,ftuple)
 
       logical ifij
@@ -2375,12 +2375,12 @@ c
       logical ifcenter
 
       integer*8  edge(0:1,0:1,2,lelt),enum(4,lelt)
-      common  /scrmg/ edge,enum
+      common  /scrmg_navier8/ edge,enum
 
       parameter (nsafe=8)  ! OFTEN, nsafe=2 suffices
       integer*8 etuple(4,4*lelt*nsafe)
       integer   ind(4*lelt*nsafe)
-      common  /scrns/ etuple,ind
+      common  /scrns_navier8/ etuple,ind
 
       integer e,eg
       logical ifij

--- a/core/perturb.f
+++ b/core/perturb.f
@@ -36,13 +36,13 @@ c
       include 'TSTEP'
       include 'MASS'
 C
-      COMMON /SCRNS/  RESV1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_perturb/  RESV1 (LX1,LY1,LZ1,LELV)
      $ ,              RESV2 (LX1,LY1,LZ1,LELV)
      $ ,              RESV3 (LX1,LY1,LZ1,LELV)
      $ ,              DV1   (LX1,LY1,LZ1,LELV)
      $ ,              DV2   (LX1,LY1,LZ1,LELV)
      $ ,              DV3   (LX1,LY1,LZ1,LELV)
-      COMMON /SCRVH/  H1    (LX1,LY1,LZ1,LELV)
+      COMMON /scrvh_perturb/  H1    (LX1,LY1,LZ1,LELV)
      $ ,              H2    (LX1,LY1,LZ1,LELV)
 c
       ifield = 1
@@ -140,7 +140,7 @@ C
       include 'MASS'
       include 'TSTEP'
 C
-      COMMON /SCRNS/ TA1 (LX1*LY1*LZ1*LELV)
+      COMMON /scrns_perturb/ TA1 (LX1*LY1*LZ1*LELV)
      $ ,             TA2 (LX1*LY1*LZ1*LELV)
      $ ,             TA3 (LX1*LY1*LZ1*LELV)
      $ ,             TB1 (LX1*LY1*LZ1*LELV)
@@ -219,7 +219,7 @@ C
       include 'GEOM'
       include 'ADJOINT'
 C
-      COMMON /SCRNS/ TA1 (LX1*LY1*LZ1*LELV)
+      COMMON /scrns_perturb/ TA1 (LX1*LY1*LZ1*LELV)
      $ ,             TA2 (LX1*LY1*LZ1*LELV)
      $ ,             TA3 (LX1*LY1*LZ1*LELV)
      $ ,             TB1 (LX1*LY1*LZ1*LELV)
@@ -320,7 +320,7 @@ c--------------------------------------------------------------------
       include 'TOTAL'
 
       parameter (lxy=lx1*ly1*lz1,ltd=lxd*lyd*lzd)
-      common /scrcv/ fx(ltd),fy(ltd),fz(ltd)
+      common /scrcv_perturb/ fx(ltd),fy(ltd),fz(ltd)
      $     , uf1(ltd),uf2(ltd),uf3(ltd),uf4(ltd),uf5(ltd),uf6(ltd)
       real urx(ltd),usx(ltd),utx(ltd)
       real ury(ltd),usy(ltd),uty(ltd)
@@ -437,7 +437,7 @@ c
       include 'MASS'
       include 'TSTEP'
 C
-      common /scrns/ ta1 (lx1,ly1,lz1,lelv)
+      common /scrns_perturb/ ta1 (lx1,ly1,lz1,lelv)
      $ ,             ta2 (lx1,ly1,lz1,lelv)
      $ ,             ta3 (lx1,ly1,lz1,lelv)
 c
@@ -475,7 +475,7 @@ C
       include 'INPUT'
       include 'TSTEP'
 C
-      COMMON /SCRNS/ TA1(LX1,LY1,LZ1,LELV)
+      COMMON /scrns_perturb/ TA1(LX1,LY1,LZ1,LELV)
      $ ,             TA2(LX1,LY1,LZ1,LELV)
      $ ,             TA3(LX1,LY1,LZ1,LELV)
      $ ,             TB1(LX1,LY1,LZ1,LELV)
@@ -524,7 +524,7 @@ c
       real           resv3 (lx1,ly1,lz1,1)
       real           h1    (lx1,ly1,lz1,1)
       real           h2    (lx1,ly1,lz1,1)
-      common /scruz/ w1    (lx1,ly1,lz1,lelv)
+      common /scruz_perturb/ w1    (lx1,ly1,lz1,lelv)
      $ ,             w2    (lx1,ly1,lz1,lelv)
      $ ,             w3    (lx1,ly1,lz1,lelv)
      $ ,             prextr(lx2,ly2,lz2,lelv)
@@ -599,9 +599,9 @@ C-----------------------------------------------------------------------
       LOGICAL          IFPRINT
       LOGICAL          IFCONV
 C
-      COMMON /SCRNS/ TA(LX1,LY1,LZ1,LELT)
+      COMMON /scrns_perturb/ TA(LX1,LY1,LZ1,LELT)
      $              ,TB(LX1,LY1,LZ1,LELT)
-      COMMON /SCRVH/ H1(LX1,LY1,LZ1,LELT)
+      COMMON /scrvh_perturb/ H1(LX1,LY1,LZ1,LELT)
      $              ,H2(LX1,LY1,LZ1,LELT)
 c
       include 'ORTHOT'
@@ -722,7 +722,7 @@ C---------------------------------------------------------------
       include 'MASS'
       include 'TSTEP'
 c
-      common /scruz/ ta (lx1,ly1,lz1,lelt)
+      common /scruz_perturb/ ta (lx1,ly1,lz1,lelt)
      $             , ua (lx1,ly1,lz1,lelt)
      $             , ub (lx1,ly1,lz1,lelt)
      $             , uc (lx1,ly1,lz1,lelt)
@@ -765,7 +765,7 @@ C-----------------------------------------------------------------------
       INCLUDE 'SOLN'
       INCLUDE 'TSTEP'
 C
-      COMMON /SCRUZ/ TA (LX1,LY1,LZ1,LELT)
+      COMMON /scruz_perturb/ TA (LX1,LY1,LZ1,LELT)
 C
       AB0   = AB(1)
       AB1   = AB(2)
@@ -797,7 +797,7 @@ C-----------------------------------------------------------------------
       INCLUDE 'INPUT'
       INCLUDE 'TSTEP'
 C
-      COMMON /SCRNS/ TA (LX1,LY1,LZ1,LELT)
+      COMMON /scrns_perturb/ TA (LX1,LY1,LZ1,LELT)
      $ ,             TB (LX1,LY1,LZ1,LELT)
      $ ,             H2 (LX1,LY1,LZ1,LELT)
 C
@@ -867,17 +867,17 @@ c
       include 'TOTAL'
       include 'CTIMER'
 c
-      common /scrns/ w1    (lx1,ly1,lz1,lelv)
+      common /scrns_perturb/ w1    (lx1,ly1,lz1,lelv)
      $ ,             w2    (lx1,ly1,lz1,lelv)
      $ ,             w3    (lx1,ly1,lz1,lelv)
      $ ,             dv1   (lx1,ly1,lz1,lelv)
      $ ,             dv2   (lx1,ly1,lz1,lelv)
      $ ,             dv3   (lx1,ly1,lz1,lelv)
      $ ,             dp    (lx2,ly2,lz2,lelv)
-      common /scrvh/ h1    (lx1,ly1,lz1,lelv)
+      common /scrvh_perturb/ h1    (lx1,ly1,lz1,lelv)
      $ ,             h2    (lx1,ly1,lz1,lelv)
-      common /scrhi/ h2inv (lx1,ly1,lz1,lelv)
-      COMMON /SCRCH/ PREXTR(LX2,LY2,LZ2,LELV)
+      common /scrhi_perturb/ h2inv (lx1,ly1,lz1,lelv)
+      COMMON /scrch_perturb/ PREXTR(LX2,LY2,LZ2,LELV)
       logical ifprjp
 
 c
@@ -938,7 +938,7 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'SOLN'
       INCLUDE 'TSTEP'
-      COMMON /CTMP0/ DPR (LX2,LY2,LZ2,LELV)
+      COMMON /ctmp0_perturb/ DPR (LX2,LY2,LZ2,LELV)
       REAL        PREXTR (LX2,LY2,LZ2,LELV)
 C
       ntot2 = lx2*ly2*lz2*nelv

--- a/core/plan4.f
+++ b/core/plan4.f
@@ -18,14 +18,14 @@ c
       INCLUDE 'ORTHOP'
       INCLUDE 'CTIMER'
 C
-      COMMON /SCRNS/ RES1  (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_plan4/ RES1  (LX1,LY1,LZ1,LELV)
      $ ,             RES2  (LX1,LY1,LZ1,LELV)
      $ ,             RES3  (LX1,LY1,LZ1,LELV)
      $ ,             DV1   (LX1,LY1,LZ1,LELV)
      $ ,             DV2   (LX1,LY1,LZ1,LELV)
      $ ,             DV3   (LX1,LY1,LZ1,LELV)
      $ ,             RESPR (LX2,LY2,LZ2,LELV)
-      common /scrvh/ h1    (lx1,ly1,lz1,lelv)
+      common /scrvh_plan4/ h1    (lx1,ly1,lz1,lelv)
      $ ,             h2    (lx1,ly1,lz1,lelv)
  
       REAL           DPR   (LX2,LY2,LZ2,LELV)
@@ -105,19 +105,19 @@ C     Compute startresidual/right-hand-side in the pressure
 
       REAL           RESPR (LX1*LY1*LZ1,LELV)
 c
-      COMMON /SCRNS/ TA1   (LX1*LY1*LZ1,LELV)
+      COMMON /scrns_plan4/ TA1   (LX1*LY1*LZ1,LELV)
      $ ,             TA2   (LX1*LY1*LZ1,LELV)
      $ ,             TA3   (LX1*LY1*LZ1,LELV)
      $ ,             WA1   (LX1*LY1*LZ1*LELV)
      $ ,             WA2   (LX1*LY1*LZ1*LELV)
      $ ,             WA3   (LX1*LY1*LZ1*LELV)
-      COMMON /SCRMG/ W1    (LX1*LY1*LZ1,LELV)
+      COMMON /scrmg_plan4/ W1    (LX1*LY1*LZ1,LELV)
      $ ,             W2    (LX1*LY1*LZ1,LELV)
      $ ,             W3    (LX1*LY1*LZ1,LELV)
 
-      common /scruz/         sij (lx1*ly1*lz1,6,lelv)
+      common /scruz_plan4/         sij (lx1*ly1*lz1,6,lelv)
       parameter (lr=lx1*ly1*lz1)
-      common /scrvz/         ur(lr),us(lr),ut(lr)
+      common /scrvz_plan4/         ur(lr),us(lr),ut(lr)
      $                     , vr(lr),vs(lr),vt(lr)
      $                     , wr(lr),ws(lr),wt(lr)
 
@@ -274,7 +274,7 @@ C     Compute the residual for the velocity
      $   , h1   (lx1,ly1,lz1,lelv)
      $   , h2   (lx1,ly1,lz1,lelv)
 
-      COMMON /SCRUZ/ TA1   (LX1,LY1,LZ1,LELV)
+      COMMON /scruz_plan4/ TA1   (LX1,LY1,LZ1,LELV)
      $ ,             TA2   (LX1,LY1,LZ1,LELV)
      $ ,             TA3   (LX1,LY1,LZ1,LELV)
      $ ,             TA4   (LX1,LY1,LZ1,LELV)
@@ -318,11 +318,11 @@ C     Compute the residual for the velocity
      $   , h1   (lx1,ly1,lz1,lelv)
      $   , h2   (lx1,ly1,lz1,lelv)
 
-      COMMON /SCRUZ/ TA1   (LX1,LY1,LZ1,LELV)
+      COMMON /scruz_plan4/ TA1   (LX1,LY1,LZ1,LELV)
      $ ,             TA2   (LX1,LY1,LZ1,LELV)
      $ ,             TA3   (LX1,LY1,LZ1,LELV)
      $ ,             TA4   (LX1,LY1,LZ1,LELV)
-      COMMON /SCRMG/ wa1   (LX1*LY1*LZ1,LELV)
+      COMMON /scrmg_plan4/ wa1   (LX1*LY1*LZ1,LELV)
      $ ,             wa2   (LX1*LY1*LZ1,LELV)
      $ ,             wa3   (LX1*LY1*LZ1,LELV)
 
@@ -550,7 +550,7 @@ c
       include 'TOTAL'
       include 'CVODE'
 
-      common /scrns/ w1(lx1,ly1,lz1,lelt)
+      common /scrns_plan4/ w1(lx1,ly1,lz1,lelt)
      $              ,w2(lx1,ly1,lz1,lelt)
      $              ,w3(lx1,ly1,lz1,lelt)
      $              ,tx(lx1,ly1,lz1,lelt)
@@ -653,7 +653,7 @@ c
       INCLUDE 'SIZE'
       INCLUDE 'TOTAL'
 
-      COMMON /SCRNS/ DVC  (LX1,LY1,LZ1,LELV),
+      COMMON /scrns_plan4/ DVC  (LX1,LY1,LZ1,LELV),
      $               DV1  (LX1,LY1,LZ1,LELV),
      $               DV2  (LX1,LY1,LZ1,LELV),
      $               DFC  (LX1,LY1,LZ1,LELV)
@@ -718,7 +718,7 @@ C
       INCLUDE 'CTIMER'
 C
       DIMENSION S(LX1,LY1,LZ1,LELT)
-      COMMON /SCRSF/ TMP(LX1,LY1,LZ1,LELT)
+      COMMON /scrsf_plan4/ TMP(LX1,LY1,LZ1,LELT)
      $             , TMA(LX1,LY1,LZ1,LELT)
      $             , SMU(LX1,LY1,LZ1,LELT)
       common  /nekcb/ cb

--- a/core/plan5.f
+++ b/core/plan5.f
@@ -7,7 +7,7 @@ c     Operator splitting technique.
       include 'SIZE'
       include 'TOTAL'
 
-      common /scrns/  resv  (lx1*ly1*lz1*lelv,3)
+      common /scrns_plan5/  resv  (lx1*ly1*lz1*lelv,3)
 
       n   = lx1*ly1*lz1*nelv
       n2  = lx2*ly2*lz2*nelv
@@ -75,11 +75,11 @@ c-----------------------------------------------------------------------
 
       common /p5var/ rhs2   (lx1*ly1*lz1*lelv,3)
 
-      common /scrns/  resv  (lx1*ly1*lz1*lelv,3)
+      common /scrns_plan5/  resv  (lx1*ly1*lz1*lelv,3)
      $ ,              dv1   (lx1*ly1*lz1*lelv)
      $ ,              dv2   (lx1*ly1*lz1*lelv)
      $ ,              dv3   (lx1*ly1*lz1*lelv)
-      common /scrvh/  h1    (lx1*ly1*lz1*lelv)
+      common /scrvh_plan5/  h1    (lx1*ly1*lz1*lelv)
      $ ,              h2    (lx1*ly1*lz1*lelv)
 
 

--- a/core/planx.f
+++ b/core/planx.f
@@ -11,13 +11,13 @@ C-----------------------------------------------------------------------
       include 'SOLN'
       include 'TSTEP'
 C
-      COMMON /SCRNS/  RESV1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_planx/  RESV1 (LX1,LY1,LZ1,LELV)
      $ ,              RESV2 (LX1,LY1,LZ1,LELV)
      $ ,              RESV3 (LX1,LY1,LZ1,LELV)
      $ ,              DV1   (LX1,LY1,LZ1,LELV)
      $ ,              DV2   (LX1,LY1,LZ1,LELV)
      $ ,              DV3   (LX1,LY1,LZ1,LELV)
-      COMMON /SCRVH/  H1    (LX1,LY1,LZ1,LELV)
+      COMMON /scrvh_planx/  H1    (LX1,LY1,LZ1,LELV)
      $ ,              H2    (LX1,LY1,LZ1,LELV)
 C
       IF (IGEOM.EQ.1) THEN
@@ -76,7 +76,7 @@ C---------------------------------------------------------------------
       REAL           RESV3 (LX1,LY1,LZ1,1)
       REAL           H1    (LX1,LY1,LZ1,1)
       REAL           H2    (LX1,LY1,LZ1,1)
-      COMMON /SCRUZ/ W1    (LX1,LY1,LZ1,LELV)
+      COMMON /scruz_planx/ W1    (LX1,LY1,LZ1,LELV)
      $ ,             W2    (LX1,LY1,LZ1,LELV)
      $ ,             W3    (LX1,LY1,LZ1,LELV)
 

--- a/core/postpro.f
+++ b/core/postpro.f
@@ -325,7 +325,7 @@ c-----------------------------------------------------------------------
       real scalar(lxyz,1)
       real fh(nx*nx),fht(nx*nx),tf(nx)
 
-      common /screv/ w1
+      common /screv_postpro/ w1
       real w1(lxyz,lelt)
 
 c     Build 1D-filter based on the transfer function (tf)
@@ -352,9 +352,9 @@ c-----------------------------------------------------------------------
       real intdv(l1),intuv(l1),intdp(l1),intup(l1),intv(l1),intp(l1)
       save intdv    ,intuv    ,intdp    ,intup    ,intv    ,intp
 
-      common /ctmp0/ intt
-      common /screv/ wk1,wk2
-      common /scrvh/ zgmv,wgtv,zgmp,wgtp,tmax(100)
+      common /ctmp0_postpro/ intt
+      common /screv_postpro/ wk1,wk2
+      common /scrvh_postpro/ zgmv,wgtv,zgmp,wgtp,tmax(100)
 
       real intt (lx1,lx1)
       real wk1  (lx1,lx1,lx1,lelt)
@@ -722,8 +722,8 @@ c-----------------------------------------------------------------------
       include 'TOTAL'
 
       parameter (lv=2**ldim,lblock=1000)
-      common /scrns/ xyz(lv,ldim,lblock),wk(lv*ldim*lblock)
-      common /scruz/ igr(lblock)
+      common /scrns_postpro/ xyz(lv,ldim,lblock),wk(lv*ldim*lblock)
+      common /scruz_postpro/ igr(lblock)
 
       integer e,eb,eg,ierr,wdsiz2
 
@@ -918,8 +918,8 @@ c     A two pass strategy is used:  first count, then write
       equivalence (buf,buf2)
 
       parameter (lblock=500)
-      common /scrns/ vcurve(5,12,lblock),wk(5*12*lblock)
-      common /scruz/ icurve(12,lblock)
+      common /scrns_postpro/ vcurve(5,12,lblock),wk(5*12*lblock)
+      common /scruz_postpro/ icurve(12,lblock)
 
       wdsiz2=4
       if(wdsize.eq.8) wdsiz2=8
@@ -1029,8 +1029,8 @@ c-----------------------------------------------------------------------
       integer e,eb,eg,wdsiz2
 
       parameter (lblock=500)
-      common /scrns/ vbc(5,6,lblock),wk(5*6*lblock)
-      common /scruz/ ibc(6,lblock)
+      common /scrns_postpro/ vbc(5,6,lblock),wk(5*6*lblock)
+      common /scruz_postpro/ ibc(6,lblock)
 
       character*1 s4(4)
       character*3 s3
@@ -1170,8 +1170,8 @@ c-----------------------------------------------------------------------
       include 'TOTAL'
 
       parameter (lv=2**ldim,lblock=1000)
-      common /scrns/ xyz(lv,ldim,lblock),wk(lv*ldim*lblock)
-      common /scruz/ igr(lblock)
+      common /scrns_postpro/ xyz(lv,ldim,lblock),wk(lv*ldim*lblock)
+      common /scruz_postpro/ igr(lblock)
 
       integer e,eb,eg
       character*1 letapt
@@ -1275,8 +1275,8 @@ c     A two pass strategy is used:  first count, then write
       character*1 cc
 
       parameter (lblock=500)
-      common /scrns/ vcurve(5,12,lblock),wk(5*12*lblock)
-      common /scruz/ icurve(12,lblock)
+      common /scrns_postpro/ vcurve(5,12,lblock),wk(5*12*lblock)
+      common /scruz_postpro/ icurve(12,lblock)
 
       if (imid.gt.0) then
 
@@ -1371,8 +1371,8 @@ c-----------------------------------------------------------------------
       integer e,eb,eg
 
       parameter (lblock=500)
-      common /scrns/ vbc(5,6,lblock),wk(5*6*lblock)
-      common /scruz/ ibc(6,lblock)
+      common /scrns_postpro/ vbc(5,6,lblock),wk(5*6*lblock)
+      common /scruz_postpro/ ibc(6,lblock)
 
       character*1 s4(4)
       character*3 s3
@@ -1457,7 +1457,7 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
 
-      common /scrns/ x3(27),y3(27),z3(27),xyz(3,3)
+      common /scrns_postpro/ x3(27),y3(27),z3(27),xyz(3,3)
       character*1 ccrve(12)
       integer e,edge
 
@@ -1534,7 +1534,7 @@ c     ASSUMING LHIS IS MAX NUMBER OF POINTS TO READ IN ON ONE PROCESSOR
       integer rcode, elid, proc
       common /c_hptsi/ rcode(lhis),elid(lhis),proc(lhis)
 
-      common /scrcg/  pm1 (lx1,ly1,lz1,lelv) ! mapped pressure
+      common /scrcg_postpro/  pm1 (lx1,ly1,lz1,lelv) ! mapped pressure
       common /outtmp/ wrk (lx1*ly1*lz1*lelt,nfldm)
 
 
@@ -1716,8 +1716,8 @@ c                        npts=local count; npoints=total count
       include 'PARALLEL'
 
       parameter (lt2=2*lx1*ly1*lz1*lelt)
-      common /scrns/ xyz(ldim,lt2)
-      common /scruz/ mid(lt2)  ! Target proc id
+      common /scrns_postpro/ xyz(ldim,lt2)
+      common /scruz_postpro/ mid(lt2)  ! Target proc id
       real    pts(ldim,npts)
 
       if (lt2.gt.npts) then

--- a/core/prepost.f
+++ b/core/prepost.f
@@ -45,7 +45,7 @@ c     Check for io request in file 'ioinfo'
 
       parameter (lxyz=lx1*ly1*lz1)
       parameter (lpsc9=ldimt1+9)
-      common /ctmp1/ tdump(lxyz,lpsc9)
+      common /ctmp1_prepost/ tdump(lxyz,lpsc9)
       real*4         tdump
       real           tdmp(4)
       equivalence   (tdump,tdmp)
@@ -101,7 +101,7 @@ c
       include 'TOTAL'
       include 'CTIMER'
 
-      common /scrcg/ pm1 (lx1,ly1,lz1,lelv)
+      common /scrcg_prepost/ pm1 (lx1,ly1,lz1,lelv)
 
       character*3    prefin,prefix
 
@@ -141,12 +141,12 @@ c     Store results for later postprocessing
 C
 C     Work arrays and temporary arrays
 C
-      common /scruz/ vxax   (lx1,ly1,lelv)
+      common /scruz_prepost/ vxax   (lx1,ly1,lelv)
      $             , vyax   (lx1,ly1,lelv)
      $             , prax   (lx2,ly2,lelv)
      $             , yax    (lx1,ly1,lelt)
-      common /scrmg/ tax    (lx1,ly1,lelt,ldimt)
-      common /scrcg/ pm1    (lx1,ly1,lz1,lelv)
+      common /scrmg_prepost/ tax    (lx1,ly1,lelt,ldimt)
+      common /scrcg_prepost/ pm1    (lx1,ly1,lz1,lelv)
 C
 c
       common /prepst/ pa(lx1,ly2,lz2),pb(lx1,ly1,lz2)
@@ -258,12 +258,12 @@ c     output .fld file
 C
 C     Work arrays and temporary arrays
 C
-      common /scrcg/ pm1 (lx1,ly1,lz1,lelv)
+      common /scrcg_prepost/ pm1 (lx1,ly1,lz1,lelv)
 c
 c     note, this usage of CTMP1 will be less than elsewhere if NELT ~> 3.
       parameter (lxyz=lx1*ly1*lz1)
       parameter (lpsc9=ldimt1+9)
-      common /ctmp1/ tdump(lxyz,lpsc9)
+      common /ctmp1_prepost/ tdump(lxyz,lpsc9)
       real*4         tdump
       real           tdmp(4)
       equivalence   (tdump,tdmp)
@@ -705,7 +705,7 @@ C
       include 'SIZE'
       include 'TOTAL'
 c
-      common /scrcg/ pm1 (lx1,ly1,lz1,lelv)
+      common /scrcg_prepost/ pm1 (lx1,ly1,lz1,lelv)
 C
 C     Fill work array
 C
@@ -815,7 +815,7 @@ c-----------------------------------------------------------------------
       parameter (lxyz=lx1*ly1*lz1)
       parameter (lpsc9=ldimt1+9)
 
-      common /ctmp1/ tdump(lxyz,lpsc9)
+      common /ctmp1_prepost/ tdump(lxyz,lpsc9)
       real*4         tdump
 
       character*11 frmat
@@ -852,7 +852,7 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
       include 'RESTART'
-      common /scrcg/ pm1 (lx1,ly1,lz1,lelv)  ! mapped pressure
+      common /scrcg_prepost/ pm1 (lx1,ly1,lz1,lelv)  ! mapped pressure
 
       integer*8 offs0,offs,nbyte,stride,strideB,nxyzo8
       character prefix*(*)
@@ -860,7 +860,7 @@ c-----------------------------------------------------------------------
 
       integer cnt, cntg
  
-      common /SCRUZ/  ur1(lxo*lxo*lxo*lelt)
+      common /scruz_prepost/  ur1(lxo*lxo*lxo*lelt)
      &              , ur2(lxo*lxo*lxo*lelt)
      &              , ur3(lxo*lxo*lxo*lelt)
 
@@ -1799,7 +1799,7 @@ c-----------------------------------------------------------------------
 
       real u(mx*my*mz,1)
 
-      common /SCRNS/ u4(2+lxo*lxo*lxo*2*lelt)
+      common /scrns_prepost/ u4(2+lxo*lxo*lxo*2*lelt)
       real*4         u4
       real*8         u8(1+lxo*lxo*lxo*1*lelt)
       equivalence    (u4,u8)
@@ -1910,7 +1910,7 @@ c-----------------------------------------------------------------------
 
       real u(mx*my*mz,1),v(mx*my*mz,1),w(mx*my*mz,1)
 
-      common /SCRNS/ u4(2+lxo*lxo*lxo*6*lelt)
+      common /scrns_prepost/ u4(2+lxo*lxo*lxo*6*lelt)
       real*4         u4
       real*8         u8(1+lxo*lxo*lxo*3*lelt)
       equivalence    (u4,u8)
@@ -2049,7 +2049,7 @@ c-----------------------------------------------------------------------
       character*4 chrefcuts
 
       real*4 test_pattern
-      common /ctmp0/ lglist(0:lelt)
+      common /ctmp0_prepost/ lglist(0:lelt)
 
       character*132 hdr
       integer*8 ioff

--- a/core/reader_re2.f
+++ b/core/reader_re2.f
@@ -78,10 +78,10 @@ c-----------------------------------------------------------------------
       parameter(li    = 2*lrs+2)
 
       integer         bufr(li-2,nrmax)
-      common /scrns/  bufr
+      common /scrns_reader_re2/  bufr
 
       integer         vi  (li  ,nrmax)
-      common /ctmp1/  vi
+      common /ctmp1_reader_re2/  vi
 
       integer*8       lre2off_b,dtmp8
       integer*8       nrg
@@ -171,10 +171,10 @@ c-----------------------------------------------------------------------
       parameter(li    = 2*lrs+1)
 
       integer         bufr(li-1,nrmax)
-      common /scrns/  bufr
+      common /scrns_reader_re2/  bufr
 
       integer         vi  (li  ,nrmax)
-      common /ctmp1/  vi
+      common /ctmp1_reader_re2/  vi
 
       integer*8       lre2off_b,dtmp8
       integer*8       nrg,nr
@@ -300,10 +300,10 @@ c-----------------------------------------------------------------------
       parameter(li    = 2*lrs+1)
 
       integer         bufr(li-1,nrmax)
-      common /scrns/  bufr
+      common /scrns_reader_re2/  bufr
 
       integer         vi  (li  ,nrmax)
-      common /ctmp1/  vi
+      common /ctmp1_reader_re2/  vi
 
       integer*8       lre2off_b,dtmp8,nbcs
       integer*8       nrg, nr

--- a/core/ssolv.f
+++ b/core/ssolv.f
@@ -493,18 +493,18 @@ C--------------------------------------------------------------------
       COMMON /CPRINT/ IFPRINT
       LOGICAL         IFPRINT
 C
-      COMMON /SCRSS2/ DV1 (LX1,LY1,LZ1,LELV)
+      COMMON /scrss2_ssolv/ DV1 (LX1,LY1,LZ1,LELV)
      $ ,              DV2 (LX1,LY1,LZ1,LELV)
      $ ,              DV3 (LX1,LY1,LZ1,LELV)
-      COMMON /SCRUZ/  W1  (LX1,LY1,LZ1,LELV)
+      COMMON /scruz_ssolv/  W1  (LX1,LY1,LZ1,LELV)
      $ ,              W2  (LX1,LY1,LZ1,LELV)
      $ ,              W3  (LX1,LY1,LZ1,LELV)
      $ ,              BDIVV(LX2,LY2,LZ2,LELV)
-      COMMON /SCRMG/  T1  (LX1,LY1,LZ1,LELV)
+      COMMON /scrmg_ssolv/  T1  (LX1,LY1,LZ1,LELV)
      $ ,              T2  (LX1,LY1,LZ1,LELV)
      $ ,              T3  (LX1,LY1,LZ1,LELV)
      $ ,              DIVV(LX2,LY2,LZ2,LELV)
-      COMMON /SCRVH/  H1  (LX1,LY1,LZ1,LELV)
+      COMMON /scrvh_ssolv/  H1  (LX1,LY1,LZ1,LELV)
      $ ,              H2  (LX1,LY1,LZ1,LELV)
 C
       CALL OPSUB3 (DV1,DV2,DV3,VX,VY,VZ,VXLAG,VYLAG,VZLAG)
@@ -577,10 +577,10 @@ C----------------------------------------------------------------------
       INCLUDE 'MASS'
       INCLUDE 'TSTEP'
       INCLUDE 'STEADY'
-      COMMON /SCRUZ/  DELTAT (LX1,LY1,LZ1,LELT)
+      COMMON /scruz_ssolv/  DELTAT (LX1,LY1,LZ1,LELT)
      $ ,              WA     (LX1,LY1,LZ1,LELT)
      $ ,              WB     (LX1,LY1,LZ1,LELT)
-      COMMON /SCRVH/  H1     (LX1,LY1,LZ1,LELT)
+      COMMON /scrvh_ssolv/  H1     (LX1,LY1,LZ1,LELT)
      $ ,              H2     (LX1,LY1,LZ1,LELT)
       COMMON /CPRINT/ IFPRINT
       LOGICAL         IFPRINT
@@ -725,7 +725,7 @@ C
       INCLUDE 'SOLN'
       INCLUDE 'MASS'
       INCLUDE 'TSTEP'
-      COMMON /SCRMG/ DIVFLD (LX2,LY2,LZ2,LELV)
+      COMMON /scrmg_ssolv/ DIVFLD (LX2,LY2,LZ2,LELV)
      $ ,             WORK   (LX2,LY2,LZ2,LELV)
       NTOT2 = lx2*ly2*lz2*NELV
       CALL OPDIV   (DIVFLD,VX,VY,VZ)
@@ -782,14 +782,14 @@ C
 C--------------------------------------------------------------------
       INCLUDE 'SIZE'
       INCLUDE 'TOTAL'
-      COMMON /SCRNS/ W1    (LX1,LY1,LZ1,LELV)
+      COMMON /scrns_ssolv/ W1    (LX1,LY1,LZ1,LELV)
      $ ,             W2    (LX1,LY1,LZ1,LELV)
      $ ,             W3    (LX1,LY1,LZ1,LELV)
      $ ,             DV1   (LX1,LY1,LZ1,LELV)
      $ ,             DV2   (LX1,LY1,LZ1,LELV)
      $ ,             DV3   (LX1,LY1,LZ1,LELV)
      $ ,             RESPR (LX2,LY2,LZ2,LELV)
-      COMMON /SCRVH/ H1    (LX1,LY1,LZ1,LELV)
+      COMMON /scrvh_ssolv/ H1    (LX1,LY1,LZ1,LELV)
      $ ,             H2    (LX1,LY1,LZ1,LELV)
 C
       IF (NIO.EQ.0) WRITE(6,5)

--- a/core/subs1.f
+++ b/core/subs1.f
@@ -10,14 +10,14 @@ C     Helmholtz equations
       include 'DOMAIN'
       include 'FDMH1'
 
-      common /screv/  dpc(lx1*ly1*lz1*lelt)
+      common /screv_subs1/  dpc(lx1*ly1*lz1*lelt)
      $     ,          p1 (lx1*ly1*lz1*lelt)
-      common /scrch/  p2 (lx1*ly1*lz1*lelt)
+      common /scrch_subs1/  p2 (lx1*ly1*lz1*lelt)
      $     ,          p3 (lx1*ly1*lz1*lelt)
-      common /scrsl/  qq1(lx1*ly1*lz1*lelt)
+      common /scrsl_subs1/  qq1(lx1*ly1*lz1*lelt)
      $     ,          qq2(lx1*ly1*lz1*lelt)
      $     ,          qq3(lx1*ly1*lz1*lelt)
-      common /scrmg/  pp1(lx1*ly1*lz1*lelt)
+      common /scrmg_subs1/  pp1(lx1*ly1*lz1*lelt)
      $     ,          pp2(lx1*ly1*lz1*lelt)
      $     ,          pp3(lx1*ly1*lz1*lelt)
      $     ,          wa (lx1*ly1*lz1*lelt)
@@ -186,7 +186,7 @@ c
       include 'TSTEP'
       include 'PARALLEL'
 
-      common /scruz/ cx(lx1*ly1*lz1*lelt)
+      common /scruz_subs1/ cx(lx1*ly1*lz1*lelt)
      $ ,             cy(lx1,ly1,lz1,lelt)
      $ ,             cz(lx1,ly1,lz1,lelt)
 
@@ -473,14 +473,14 @@ C--------------------------------------------------------------
       include 'SOLN'
       include 'TSTEP'
 C
-      common /ctmp1/ u(lx1,ly1,lz1,lelv)
+      common /ctmp1_subs1/ u(lx1,ly1,lz1,lelv)
      $ ,             v(lx1,ly1,lz1,lelv)
      $ ,             w(lx1,ly1,lz1,lelv)
-      common /ctmp0/ x(lx1,ly1,lz1,lelv)
+      common /ctmp0_subs1/ x(lx1,ly1,lz1,lelv)
      $ ,             r(lx1,ly1,lz1,lelv)
       common /udxmax/ umax
 
-      common /scruz/ cx(lx1*ly1*lz1*lelv)
+      common /scruz_subs1/ cx(lx1*ly1*lz1*lelv)
      $ ,             cy(lx1,ly1,lz1,lelv)
      $ ,             cz(lx1,ly1,lz1,lelv)
 C
@@ -683,7 +683,8 @@ C
       include 'SOLN'
       include 'GEOM'
       include 'TSTEP'
-      common /ctmp0/  stc(lx1,ly1,lz1),sigst(lx1,ly1),dtst(lx1,ly1)
+      common /ctmp0_subs1/  stc(lx1,ly1,lz1),sigst(lx1,ly1),dtst(lx1,
+     $ ly1)
       character cb*3,cb2*2
 C
 C     Applicable?
@@ -753,7 +754,7 @@ C
       include 'GEOM'
       include 'DXYZ'
       common /delrst/ drst(lx1),drsti(lx1)
-      common /ctmp0/  xfm1(lx1),yfm1(lx1),t1xf(lx1),t1yf(lx1)
+      common /ctmp0_subs1/  xfm1(lx1),yfm1(lx1),t1xf(lx1),t1yf(lx1)
       DIMENSION DTST(LX1,1)
       LOGICAL IFAXIS
 C
@@ -799,10 +800,10 @@ C
       include 'GEOM'
       include 'DXYZ'
       common /delrst/ drst(lx1),drsti(lx1)
-      common /ctmp0/  xfm1(lx1,ly1),yfm1(lx1,ly1),zfm1(lx1,ly1)
-      common /ctmp1/  drm1(lx1,lx1),drtm1(lx1,ly1)
+      common /ctmp0_subs1/  xfm1(lx1,ly1),yfm1(lx1,ly1),zfm1(lx1,ly1)
+      common /ctmp1_subs1/  drm1(lx1,lx1),drtm1(lx1,ly1)
      $             ,  dsm1(lx1,lx1),dstm1(lx1,ly1)
-      common /scrmg/  xrm1(lx1,ly1),yrm1(lx1,ly1),zrm1(lx1,ly1)
+      common /scrmg_subs1/  xrm1(lx1,ly1),yrm1(lx1,ly1),zrm1(lx1,ly1)
      $             ,  xsm1(lx1,ly1),ysm1(lx1,ly1),zsm1(lx1,ly1)
       dimension dtst(lx1,ly1)
 C
@@ -1170,7 +1171,7 @@ C-------------------------------------------------------------------
       include 'EIGEN'
       common /cprint/ ifprint
       logical         ifprint
-      common /ctmp0/ wa (lx1,ly1,lz1,lelt)
+      common /ctmp0_subs1/ wa (lx1,ly1,lz1,lelt)
 C
       dimension r1    (lx1,ly1,lz1,1)
      $        , r2    (lx1,ly1,lz1,1)
@@ -1326,9 +1327,9 @@ C
       include 'GEOM'
       include 'TSTEP'
 
-      common /ctmp0/ exz(lx1*ly1*lz1*lelt)
+      common /ctmp0_subs1/ exz(lx1*ly1*lz1*lelt)
      $             , eyz(lx1*ly1*lz1*lelt)
-      common /ctmp1/ exx(lx1*ly1*lz1*lelt)
+      common /ctmp1_subs1/ exx(lx1*ly1*lz1*lelt)
      $             , exy(lx1*ly1*lz1*lelt)
      $             , eyy(lx1*ly1*lz1*lelt)
      $             , ezz(lx1*ly1*lz1*lelt)
@@ -1369,13 +1370,13 @@ C
 C     CAUTION : Stresses and strainrates share the same scratch commons
 C
       include 'SIZE'
-      common /ctmp1/ txx(lx1,ly1,lz1,lelt)
+      common /ctmp1_subs1/ txx(lx1,ly1,lz1,lelt)
      $             , txy(lx1,ly1,lz1,lelt)
      $             , tyy(lx1,ly1,lz1,lelt)
      $             , tzz(lx1,ly1,lz1,lelt)
-      common /ctmp0/ txz(lx1,ly1,lz1,lelt)
+      common /ctmp0_subs1/ txz(lx1,ly1,lz1,lelt)
      $             , tyz(lx1,ly1,lz1,lelt)
-      common /scrsf/ t11(lx1,ly1,lz1,lelt)
+      common /scrsf_subs1/ t11(lx1,ly1,lz1,lelt)
      $             , t22(lx1,ly1,lz1,lelt)
      $             , t33(lx1,ly1,lz1,lelt)
      $             , hii(lx1,ly1,lz1,lelt)
@@ -1434,11 +1435,11 @@ c-----------------------------------------------------------------------
       subroutine aijuj (au1,au2,au3,nel,ifaxis)
 C
       include 'SIZE'
-      common /ctmp1/ txx(lx1,ly1,lz1,lelt)
+      common /ctmp1_subs1/ txx(lx1,ly1,lz1,lelt)
      $             , txy(lx1,ly1,lz1,lelt)
      $             , tyy(lx1,ly1,lz1,lelt)
      $             , tzz(lx1,ly1,lz1,lelt)
-      common /ctmp0/ txz(lx1,ly1,lz1,lelt)
+      common /ctmp0_subs1/ txz(lx1,ly1,lz1,lelt)
      $             , tyz(lx1,ly1,lz1,lelt)
 C
       DIMENSION AU1(LX1,LY1,LZ1,1)
@@ -1458,7 +1459,7 @@ c-----------------------------------------------------------------------
 C
       include 'SIZE'
       include 'GEOM'
-      common /scrsf/ ur(lx1,ly1,lz1,lelt)
+      common /scrsf_subs1/ ur(lx1,ly1,lz1,lelt)
      $             , us(lx1,ly1,lz1,lelt)
      $             , ut(lx1,ly1,lz1,lelt)
 c
@@ -1643,7 +1644,7 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
 c
-      common /ctmp0/ w(lx1,ly1,lz1)
+      common /ctmp0_subs1/ w(lx1,ly1,lz1)
 c
       include 'FDMH1'
 c
@@ -1730,7 +1731,7 @@ c     a new array of global pointers for an nx^ldim set of elements.
       integer*8 vertex(1)
       logical ifcenter
 
-      common /ctmp0/ gnum(lx1*ly1*lz1*lelt)
+      common /ctmp0_subs1/ gnum(lx1*ly1*lz1*lelt)
       integer*8 gnum
 
       call set_vert(gnum,ngv,nx,nel,vertex,ifcenter)
@@ -1827,9 +1828,9 @@ c     Galerkin projection
       real    a(ldim,ncl,ldim,ncl,1),h1(1),h2(1)
 c     real    a(ncl,ldim,ncl,ldim,1),h1(1),h2(1)
 
-      common /scrcr2/ a1(lx1*ly1*lz1,lelt),w1(lx1*ly1*lz1,lelt)
+      common /scrcr2_subs1/ a1(lx1*ly1*lz1,lelt),w1(lx1*ly1*lz1,lelt)
      $              , a2(lx1*ly1*lz1,lelt),w2(lx1*ly1*lz1,lelt)
-      common /scrcr3/ a3(lx1*ly1*lz1,lelt),w3(lx1*ly1*lz1,lelt)
+      common /scrcr3_subs1/ a3(lx1*ly1*lz1,lelt),w3(lx1*ly1*lz1,lelt)
      $              , b (lx1*ly1*lz1,8)
 
       integer e
@@ -1885,8 +1886,8 @@ c     Given an input vector v, this generates the H1 coarse-grid solution
 
       real u1(1),u2(1),u3(1),v1(1),v2(1),v3(1)
 
-      common /scrpr3/ uc1(lcr*lelt),uc2(lcr*lelt),uc3(lcr*lelt)
-      common /scrpr2/ vc1(lcr*lelt),vc2(lcr*lelt),vc3(lcr*lelt)
+      common /scrpr3_subs1/ uc1(lcr*lelt),uc2(lcr*lelt),uc3(lcr*lelt)
+      common /scrpr2_subs1/ vc1(lcr*lelt),vc2(lcr*lelt),vc3(lcr*lelt)
 
       integer icalld1
       save    icalld1
@@ -1965,11 +1966,11 @@ c-----------------------------------------------------------------------
       integer null_space,e
 
       character*3 cb
-      common /scrxxti/ ia(ldim*ldim*lcr*lcr*lelv)
+      common /scrxxti_subs1/ ia(ldim*ldim*lcr*lcr*lelv)
      $               , ja(ldim*ldim*lcr*lcr*lelv)
 
       parameter (lcc=2**ldim)
-      common /scrcr1/ a(ldim*ldim*lcc*lcc*lelt)
+      common /scrcr1_subs1/ a(ldim*ldim*lcc*lcc*lelt)
       real mask(ldim,lcr,lelv)
       equivalence (mask,a)
 
@@ -2216,7 +2217,7 @@ C
      $        , TZ(LX1,LY1,LZ1,1)
      $        , FF(LX1*LY1*LZ1,1)
 
-      common /scrsf/ fr(lx1*ly1*lz1,lelt)
+      common /scrsf_subs1/ fr(lx1*ly1*lz1,lelt)
      $             , fs(lx1*ly1*lz1,lelt)
      $             , ft(lx1*ly1*lz1,lelt)
       real           wa(lx1,ly1,lz1,lelt)
@@ -2312,7 +2313,7 @@ C
       include 'DXYZ'
       include 'GEOM'
       include 'WZ'
-      common /ctmp0/ phi(lx1,ly1)
+      common /ctmp0_subs1/ phi(lx1,ly1)
 C
       DIMENSION VFY(LX1,LY1,LZ1,1)
      $        , TZZ(LX1,LY1,LZ1,1)
@@ -2383,7 +2384,7 @@ c     Assumes if uservp is true and thus reorthogonalizes every step
       include 'CTIMER'
 
       real b1(1),b2(1),b3(1),h1(1),h2(1),wt(1)
-      common /ctmp1/ w(lx1*ly1*lz1*lelt,ldim)
+      common /ctmp1_subs1/ w(lx1*ly1*lz1*lelt,ldim)
       real l2a,l2b
 
       kmax = napproxstrs(1)
@@ -2627,7 +2628,7 @@ C
 C     Caution: 2nd and 3rd strainrate invariants residing in scratch
 C              common /SCREV/ are used in STNRINV and NEKASGN
 C
-      common /screv/ sii (lx1,ly1,lz1,lelt),siii(lx1,ly1,lz1,lelt)
+      common /screv_subs1/ sii (lx1,ly1,lz1,lelt),siii(lx1,ly1,lz1,lelt)
 
       if (nio.eq.0.and.loglevel.gt.2)
      $   write(6,*) 'setprop'

--- a/core/subs2.f
+++ b/core/subs2.f
@@ -36,13 +36,13 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'SOLN'
       INCLUDE 'TSTEP'
-      common /screv/ ei2(lx1,ly1,lz1,lelt)
+      common /screv_subs2/ ei2(lx1,ly1,lz1,lelt)
      $             , ei3(lx1,ly1,lz1,lelt)
-      common /ctmp1/ exx(lx1,ly1,lz1,lelt)
+      common /ctmp1_subs2/ exx(lx1,ly1,lz1,lelt)
      $             , exy(lx1,ly1,lz1,lelt)
      $             , eyy(lx1,ly1,lz1,lelt)
      $             , ezz(lx1,ly1,lz1,lelt)
-      common /ctmp0/ exz(lx1,ly1,lz1,lelt)
+      common /ctmp0_subs2/ exz(lx1,ly1,lz1,lelt)
      $             , eyz(lx1,ly1,lz1,lelt)
 c
       NTOT1  = lx1*ly1*lz1*NELV
@@ -266,10 +266,10 @@ C-----------------------------------------------------------------------
       INCLUDE 'SOLN'
       INCLUDE 'TSTEP'
       INCLUDE 'WZ'
-      common /scrmg/ ae1(lx1,ly1,lz1,lelv)
+      common /scrmg_subs2/ ae1(lx1,ly1,lz1,lelv)
      $             , ae2(lx1,ly1,lz1,lelv)
      $             , ae3(lx1,ly1,lz1,lelv)
-      common /scruz/ e1(lx1,ly1,lz1,lelv)
+      common /scruz_subs2/ e1(lx1,ly1,lz1,lelv)
      $             , e2(lx1,ly1,lz1,lelv)
      $             , e3(lx1,ly1,lz1,lelv)
 C
@@ -445,10 +445,10 @@ C------------------------------------------------------------------
       INCLUDE 'SIZE'
       INCLUDE 'MASS'
       INCLUDE 'SOLN'
-      common /scrmg/ ae1(lx1,ly1,lz1,lelv)
+      common /scrmg_subs2/ ae1(lx1,ly1,lz1,lelv)
      $             , ae2(lx1,ly1,lz1,lelv)
      $             , ae3(lx1,ly1,lz1,lelv)
-      common /scruz/ e1(lx1,ly1,lz1,lelv)
+      common /scruz_subs2/ e1(lx1,ly1,lz1,lelv)
      $             , e2(lx1,ly1,lz1,lelv)
      $             , e3(lx1,ly1,lz1,lelv)
 C
@@ -678,7 +678,7 @@ C
       INCLUDE 'GEOM'
       INCLUDE 'TSTEP'
       include 'INPUT'
-      common /screv/ hfmask(lx1,lz1,6,lelt)
+      common /screv_subs2/ hfmask(lx1,lz1,6,lelt)
      $             , hvmask(lx1,ly1,lz1,lelt)
 C
       DIMENSION C1MASK(LX1,LY1,LZ1,1)
@@ -713,7 +713,7 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'GEOM'
       INCLUDE 'TSTEP'
-      common /screv/ hfmask(lx1,lz1,6,lelt)
+      common /screv_subs2/ hfmask(lx1,lz1,6,lelt)
      $             , hvmask(lx1,ly1,lz1,lelt)
 C
       IF (.NOT.IFLMSF(IFLD)) RETURN
@@ -1105,7 +1105,7 @@ C-----------------------------------------------------------------------
 C
       INCLUDE 'SIZE'
       INCLUDE 'GEOM'
-      common /scrcg/  vnmag(lx1,ly1,lz1,lelt)
+      common /scrcg_subs2/  vnmag(lx1,ly1,lz1,lelt)
       common /indxfc/ mcrfc(4,6)
      $              , MFCCR(3,8)
      $              , MEGCR(3,8)
@@ -1760,10 +1760,10 @@ C
       INCLUDE 'INPUT'
       INCLUDE 'SOLN'
       INCLUDE 'TSTEP'
-      common /scrsf/ a1mask(lx1,ly1,lz1,lelt)
+      common /scrsf_subs2/ a1mask(lx1,ly1,lz1,lelt)
      $             , a2mask(lx1,ly1,lz1,lelt)
      $             , a3mask(lx1,ly1,lz1,lelt)
-      common /ctmp0/ wa(lx1,ly1,lz1,lelt)
+      common /ctmp0_subs2/ wa(lx1,ly1,lz1,lelt)
 C
       DIMENSION VB1(LX1,LY1,LZ1,1)
      $        , VB2(LX1,LY1,LZ1,1)
@@ -1837,7 +1837,7 @@ C
       INCLUDE 'SIZE'
       INCLUDE 'GEOM'
       INCLUDE 'TSTEP'
-      common /ctmp1/ s1(lx1,ly1,lz1,lelt)
+      common /ctmp1_subs2/ s1(lx1,ly1,lz1,lelt)
      $             , s2(lx1,ly1,lz1,lelt)
      $             , s3(lx1,ly1,lz1,lelt)
 C
@@ -2171,7 +2171,7 @@ c     fixes masks for A/SYM face corners
      $      ,c2mask(lx1,ly1,lz1,1)
      $      ,c3mask(lx1,ly1,lz1,1)
 
-      common /ctmp0/ im1(lx1,ly1,lz1),im2(lx1,ly1,lz1)
+      common /ctmp0_subs2/ im1(lx1,ly1,lz1),im2(lx1,ly1,lz1)
       integer e,f,val,im1,im2
 
       character*3 cb


### PR DESCRIPTION
`/CTMP[01]/` and `/SCR??/` are declared with different shapes in different `core/*.f` files. The standard says a named COMMON must have the same total size everywhere it appears. GNU ld silently picks the max; Apple ld64 since Xcode CLT 15 doesn't, and writes through the larger view overflow into the next COMMON.

Reproducer and full diagnosis: #897. Related: #828.

Each `/CTMPx/` and `/SCRxx/` use in `core/*.f` is local scratch, so the renames give them per-file names. The 5 blocks genuinely shared via `core/SCRCT` (`/CTMP1/`, `/SCRMG/`, `/SCREV/`, `/SCRVH/`, `/SCRCH/`) are kept unchanged in the 4 files that include `SCRCT`.

On macOS arm64 (Xcode CLT 15+, Homebrew gfortran 15, OpenMPI 5, `FFLAGS=-ffp-contract=off`), 24 of the 26 CI matrix cases pass with this patch. The two that don't: `IO_Test` is skipped because its build adds `-mcmodel=medium`, which is x86-only; `FsHydro::test_PnPn2_Parallel` fails the AMP check (+4.9e-5 vs target -5.3e-5, tolerance 1e-4), the value oscillates around zero across timesteps and looks platform-sensitive.

Without `-ffp-contract=off`, several tests fail at machine epsilon because gfortran 15 emits FMA on arm64 by default.

The change is all mechanical renames; no logic changes.