### PR TITLE
Enlarge payload size to read larger checkpoint file

### DIFF
--- a/core/ic.f
+++ b/core/ic.f
@@ -2140,7 +2140,7 @@ c-----------------------------------------------------------------------
 
       real*4 wk(2*lwk) ! message buffer
       real*4 wkg(2*lwk) ! storage buffer
-      parameter(lrbs_loc=20*lx1*ly1*lz1)
+      parameter(lrbs_loc=20*ldim*lx1*ly1*lz1)
       parameter(lrbs=lrbs_loc*lelt)
       common /vrthov/ w2(lrbs) ! read buffer
       real*4 w2


### PR DESCRIPTION
A lx1=6 simulation reads FP64 checkpoint file with lxr=10 and ifcrrs=T will trigger lim_chk "mfi_getv c" error because the elementwise data size (`nxyzr = 6000`) exceeds the CR payload size `lrbs_loc=20*lx1*ly1*lz1 = 4320`.

This fix simply uses larger size to get rid of the ldim ratio in mfi_getv. The table below shows the increased capability.

Table: Read M-th order fp64 file into N-th order simulation using ifcrrs=T
```
Before:
 N\M   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
----------------------------------------------------------------
   1  ok  no  no  no  no  no  no  no  no  no  no  no  no  no  no
   2      ok  ok  no  no  no  no  no  no  no  no  no  no  no  no
   3          ok  ok  no  no  no  no  no  no  no  no  no  no  no
   4              ok  ok  ok  no  no  no  no  no  no  no  no  no
   5                  ok  ok  ok  no  no  no  no  no  no  no  no
   6                      ok  ok  ok  ok  no  no  no  no  no  no
   7                          ok  ok  ok  ok  no  no  no  no  no
   8                              ok  ok  ok  ok  ok  no  no  no
   9                                  ok  ok  ok  ok  ok  no  no
  10                                      ok  ok  ok  ok  ok  ok
  11                                          ok  ok  ok  ok  ok
  12                                              ok  ok  ok  ok
  13                                                  ok  ok  ok
  14                                                      ok  ok
  15                                                          ok

After:
 N\M   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
----------------------------------------------------------------
   1  ok  ok  ok  no  no  no  no  no  no  no  no  no  no  no  no
   2      ok  ok  ok  ok  no  no  no  no  no  no  no  no  no  no
   3          ok  ok  ok  ok  ok  no  no  no  no  no  no  no  no
   4              ok  ok  ok  ok  ok  ok  no  no  no  no  no  no
   5                  ok  ok  ok  ok  ok  ok  ok  no  no  no  no
   6                      ok  ok  ok  ok  ok  ok  ok  ok  ok  no
   7                          ok  ok  ok  ok  ok  ok  ok  ok  ok
   8                              ok  ok  ok  ok  ok  ok  ok  ok
   9                                  ok  ok  ok  ok  ok  ok  ok
  10                                      ok  ok  ok  ok  ok  ok
  11                                          ok  ok  ok  ok  ok
  12                                              ok  ok  ok  ok
  13                                                  ok  ok  ok
  14                                                      ok  ok
  15                                                          ok

```