### PR TITLE
Remap h-refine restart indices during unpacking

### DIFF
--- a/core/RESTART
+++ b/core/RESTART
@@ -48,5 +48,5 @@ c
       real*8 rst_etime(4)
       common /rst_tmr/ rst_etime
 
-      integer nhrefrs, hrefcutsrs(lhref)
-      common /hrefinersi/ nhrefrs, hrefcutsrs
+      integer nhrefrs, hrefcutsrs(lhref), nelt_hr0
+      common /hrefinersi/ nhrefrs, hrefcutsrs, nelt_hr0

--- a/core/RESTART
+++ b/core/RESTART
@@ -48,5 +48,5 @@ c
       real*8 rst_etime(4)
       common /rst_tmr/ rst_etime
 
-      integer nhrefrs, hrefcutsrs(lhref), nelt_hr0
-      common /hrefinersi/ nhrefrs, hrefcutsrs, nelt_hr0
+      integer nhrefrs, hrefcutsrs(lhref), nhrefblkrs
+      common /hrefinersi/ nhrefrs, hrefcutsrs, nhrefblkrs

--- a/core/hrefine.f
+++ b/core/hrefine.f
@@ -460,27 +460,6 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
 c     h refine + restart
 c-----------------------------------------------------------------------
-      subroutine h_refine_copy(u,nel,ncut)
-      include 'SIZE'
-      real u(lx1,ly1,lz1,*)
-      real ubak(lx1,ly1,lz1,lelt)
-      integer ncut, nblk
-
-      nblk = ncut**ldim
-      nxyz = lx1*ly1*lz1
-
-      call rzero(ubak,nxyz*lelt)
-      call copy(ubak,u,nxyz*nel*nblk)
-      call rzero(u,nxyz*nel*nblk)
-
-      do ie=1,nel
-        ien = ie_map_o2r(ie,nblk)
-        call copy(u(1,1,1,ie),ubak(1,1,1,ien),nxyz)
-      enddo
-
-      return
-      end
-c-----------------------------------------------------------------------
       subroutine h_refine_fld(u,nel,ncut)
 c     apply one round of refinement to a field
       include 'SIZE'
@@ -589,37 +568,6 @@ c     restart, refine fields after readfld
 
       if (ifaxis) then
          call exitti('h-refine does not support ifaxis=T$',ncut)
-      endif
-
-      if (np.gt.1) then
-        nelt0 = nelt
-        do iref=refineSize,1,-1 ! reverse copy
-          ncut = refine(iref)
-          nblk = ncut**ldim
-          nelt0 = nelt0 / nblk
-
-          if (ifgetxr.AND.ifgetx) then
-            call h_refine_copy(xm1_,nelt0,ncut)
-            call h_refine_copy(ym1_,nelt0,ncut)
-            call h_refine_copy(zm1_,nelt0,ncut)
-          endif
-          if (ifgetur.AND.ifgetu) then
-            call h_refine_copy(vx_,nelt0,ncut)
-            call h_refine_copy(vy_,nelt0,ncut)
-            call h_refine_copy(vz_,nelt0,ncut)
-          endif
-          if (ifgetpr.AND.ifgetp) then
-            call h_refine_copy(pm1_,nelt0,ncut)
-          endif
-          if (ifgettr.AND.ifgett) then
-            call h_refine_copy(t_,nelt0,ncut)
-          endif
-          do k=1,npsr
-            if (ifgtpsr(k).AND.ifgtps(k))then
-              call h_refine_copy(ps_(1,1,1,1,k),nelt0,ncut)
-            endif
-          enddo
-        enddo
       endif
 
       nelt0 = nelt / nblk_total
@@ -887,7 +835,7 @@ c
       integer nblk, nblk_rs, ncut, ncut_rs, i, j, ierr
       integer nelgr0, nelgt0
 
-      nelt_hr0 = nelt
+      nhrefblkrs = 1
       if (nhref.eq.0) return
 
       if (nio.eq.0) then
@@ -945,8 +893,7 @@ c
       do i=1,nhrefrs
          ncut = ncut * hrefcutsrs(i)
       enddo
-      nblk_dif = ncut**ldim
-      nelt_hr0 = nelt / nblk_dif
+      nhrefblkrs = ncut**ldim
 
       return
 

--- a/core/hrefine.f
+++ b/core/hrefine.f
@@ -887,6 +887,7 @@ c
       integer nblk, nblk_rs, ncut, ncut_rs, i, j, ierr
       integer nelgr0, nelgt0
 
+      nelt_hr0 = nelt
       if (nhref.eq.0) return
 
       if (nio.eq.0) then
@@ -939,6 +940,13 @@ c
       if (nio.eq.0) then
          write(*,*)'href schdule, dif: ', (hrefcutsrs(i),i=1,nhrefrs)
       endif
+
+      ncut = 1
+      do i=1,nhrefrs
+         ncut = ncut * hrefcutsrs(i)
+      enddo
+      nblk_dif = ncut**ldim
+      nelt_hr0 = nelt / nblk_dif
 
       return
 

--- a/core/ic.f
+++ b/core/ic.f
@@ -2142,7 +2142,7 @@ c-----------------------------------------------------------------------
 
       real*4 wk(2*lwk) ! message buffer
       real*4 wkg(2*lwk) ! storage buffer
-      parameter(lrbs_loc=20*lx1*ly1*lz1*ldim)
+      parameter(lrbs_loc=20*lx1*ly1*lz1)
       parameter(lrbs=lrbs_loc*lelt)
       common /vrthov/ w2(lrbs) ! read buffer
       real*4 w2

--- a/core/ic.f
+++ b/core/ic.f
@@ -1944,6 +1944,8 @@ c-----------------------------------------------------------------------
       dnxyzr = nxyzr 
       if (wdsizr.eq.8) nxyzr = 2*nxyzr
 
+      nelt_hr0 = nelt / nhrefblkrs
+
       ! check message buffer wk
       num_recv  = nxyzr*nelt_hr0
       num_avail = size(wk)
@@ -2001,7 +2003,7 @@ c-----------------------------------------------------------------------
                 l = 1
                 iloc = 1
                 do e = k+1,k+nelrr
-                  jeln = gllel(er(e))
+                  jeln = ie_map_r2o(gllel(er(e)),nhrefblkrs)
                   if (jeln.ge.jeln1.AND.jeln.le.jeln2) then
                     vi(1,iloc) = gllnid(er(e))
                     vi(2,iloc) = er(e)
@@ -2030,7 +2032,7 @@ c-----------------------------------------------------------------------
                   goto 100
                 endif
                 do iloc = 1,n
-                  iel = gllel(vi(2,iloc))
+                  iel = ie_map_r2o(gllel(vi(2,iloc)),nhrefblkrs)
                   l = (iel-1) * nxyzr + 1
                   call icopy (wkg(l),vi(3,iloc),nxyzr)
                 enddo
@@ -2044,7 +2046,7 @@ c-----------------------------------------------------------------------
                 call MPI_Win_lock_all(0,rsH,ierr)
                 do e = k+1,k+nelrr
                   jnid = gllnid(er(e))                ! where is er(e) now?
-                  jeln = gllel(er(e))
+                  jeln = ie_map_r2o(gllel(er(e)),nhrefblkrs)
 
                   if (jeln.ge.jeln1.AND.jeln.le.jeln2) then
                     disp = (jeln-jeln1) * int(nxyzr,8)
@@ -2156,6 +2158,8 @@ c-----------------------------------------------------------------------
       nxyzr  = ldim*nxr*nyr*nzr
       if (wdsizr.eq.8) nxyzr = 2*nxyzr
 
+      nelt_hr0 = nelt / nhrefblkrs
+
       ! check message buffer wk
       num_recv  = nxyzr*nelt_hr0
       num_avail = size(wk)
@@ -2211,7 +2215,7 @@ c-----------------------------------------------------------------------
                 l = 1
                 iloc = 1
                 do e = k+1,k+nelrr
-                  jeln = gllel(er(e))
+                  jeln = ie_map_r2o(gllel(er(e)),nhrefblkrs)
                   if (jeln.ge.jeln1.AND.jeln.le.jeln2) then
                     vi(1,iloc) = gllnid(er(e))
                     vi(2,iloc) = er(e)
@@ -2240,9 +2244,10 @@ c-----------------------------------------------------------------------
                   goto 100
                 endif
                 do iloc = 1,n
-                  iel = gllel(vi(2,iloc))
+                  iel = ie_map_r2o(gllel(vi(2,iloc)),nhrefblkrs)
                   l = (iel-1) * nxyzr + 1
                   call icopy (wkg(l),vi(3,iloc),nxyzr)
+                  write(*,*)'dbg2',nid,n,nrmax,iloc,vi(2,iloc),iel
                 enddo
                 call nekgsync()
                 rst_etime(4) = rst_etime(4) + dnekclock_sync() - etime0
@@ -2254,8 +2259,7 @@ c-----------------------------------------------------------------------
                 call MPI_Win_lock_all(0,rsH,ierr)
                 do e = k+1,k+nelrr
                   jnid = gllnid(er(e))                ! where is er(e) now?
-                  jeln = gllel(er(e))
-
+                  jeln = ie_map_r2o(gllel(er(e)),nhrefblkrs)
                   if (jeln.ge.jeln1.AND.jeln.le.jeln2) then
                     disp = (jeln-jeln1) * int(nxyzr,8)
                     call MPI_Put(w2(l),nxyzr,MPI_REAL4,jnid,
@@ -2308,7 +2312,7 @@ c-----------------------------------------------------------------------
          if (np.gt.1) then
             ei = e
          else if(np.eq.1) then
-            ei = er(e) 
+            ei = ie_map_r2o(er(e),nhrefblkrs)
          endif
 
          if (if_byte_sw) then

--- a/core/ic.f
+++ b/core/ic.f
@@ -2247,7 +2247,6 @@ c-----------------------------------------------------------------------
                   iel = ie_map_r2o(gllel(vi(2,iloc)),nhrefblkrs)
                   l = (iel-1) * nxyzr + 1
                   call icopy (wkg(l),vi(3,iloc),nxyzr)
-                  write(*,*)'dbg2',nid,n,nrmax,iloc,vi(2,iloc),iel
                 enddo
                 call nekgsync()
                 rst_etime(4) = rst_etime(4) + dnekclock_sync() - etime0

--- a/core/ic.f
+++ b/core/ic.f
@@ -1945,7 +1945,7 @@ c-----------------------------------------------------------------------
       if (wdsizr.eq.8) nxyzr = 2*nxyzr
 
       ! check message buffer wk
-      num_recv  = nxyzr*nelt
+      num_recv  = nxyzr*nelt_hr0
       num_avail = size(wk)
       call lim_chk(num_recv,num_avail,'     ','     ','mfi_gets a')
 
@@ -1985,7 +1985,7 @@ c-----------------------------------------------------------------------
             endif
 
 #ifdef MPI
-            nbatch = (nelt - 1) / lbrst + 1
+            nbatch = (nelt_hr0 - 1) / lbrst + 1
             nbatch = iglmax(nbatch, 1)
 
             do ibatch = 1,nbatch
@@ -2094,7 +2094,7 @@ c-----------------------------------------------------------------------
       if (wdsizr.eq.8) nxyzw = 2*nxyzw
 
       l = 1
-      do e=1,nelt
+      do e=1,nelt_hr0
          if (np.gt.1) then
             ei = e
          elseif(np.eq.1) then
@@ -2140,7 +2140,7 @@ c-----------------------------------------------------------------------
 
       real*4 wk(2*lwk) ! message buffer
       real*4 wkg(2*lwk) ! storage buffer
-      parameter(lrbs_loc=20*lx1*ly1*lz1)
+      parameter(lrbs_loc=20*lx1*ly1*lz1*ldim)
       parameter(lrbs=lrbs_loc*lelt)
       common /vrthov/ w2(lrbs) ! read buffer
       real*4 w2
@@ -2157,7 +2157,7 @@ c-----------------------------------------------------------------------
       if (wdsizr.eq.8) nxyzr = 2*nxyzr
 
       ! check message buffer wk
-      num_recv  = nxyzr*nelt 
+      num_recv  = nxyzr*nelt_hr0
       num_avail = size(wk)
       call lim_chk(num_recv,num_avail,'     ','     ','mfi_getv a')
 
@@ -2196,7 +2196,7 @@ c-----------------------------------------------------------------------
             endif
 
 #ifdef MPI
-            nbatch = (nelt - 1) / lbrst + 1
+            nbatch = (nelt_hr0 - 1) / lbrst + 1
             nbatch = iglmax(nbatch, 1)
 
             do ibatch = 1,nbatch
@@ -2304,7 +2304,7 @@ c-----------------------------------------------------------------------
       if (wdsizr.eq.8) nxyzw = 2*nxyzw
 
       l = 1
-      do e=1,nelt
+      do e=1,nelt_hr0
          if (np.gt.1) then
             ei = e
          else if(np.eq.1) then
@@ -2565,9 +2565,8 @@ c
 
 #ifdef MPI
       lbrst = min(lbrst, lelt)
-      if (lbrst.lt.nelt) then
-        if(nio.eq.0) write(*,*)'Batched restart with lbrst',lbrst,nelt
-      endif
+      if (lbrst.lt.nelt_hr0.AND.nio.eq.0)
+     $  write(*,*)'Batched restart with lbrst',lbrst,nelt_hr0
 
       call rzero(rst_etime,4) ! mpiio / pack / transfer / unpack
 
@@ -2576,7 +2575,7 @@ c
       else
         disp_unit = 4
         win_size = int(disp_unit,8)*size(wk)
-        if (lbrst.lt.nelt) then
+        if (lbrst.lt.nelt_hr0) then
           win_size = int(disp_unit,8)*(7*lx1*ly1*lz1*lbrst)*(wdsize/4)
         endif
 


### PR DESCRIPTION
When h-refine restarts from an unrefined checkpoint, it first reads the coarse field file, remaps global element IDs so the data is sent to the correct MPI rank, and then refines the fields after the read.

Previously, unpacking placed the coarse data using `gllel` indices from the refined layout. The code then called `h_refine_copy` to compact the data back into a contiguous array before refinement.

This PR avoids that extra copy by directly mapping the `gllel` local index during unpacking.

This reduces the temporary buffer size required for h-refine restart and avoid the `lim_chk mfi_getv a` error seen when restarting from higher-order checkpoint files.


## Code changes
- A new var `nhrefblkrs` (default: 1, set in `hrefcuts_chkdiff`) is added to store the nblk for checkpoint h-ref
- In mfi_get[v,s], reduce loop size nelt -> nelt_hr0 when h-ref is needed
- `gllel` uses `ie_map_r2o` to map from refined-index to original one with nblk size `nhrefblkrs`.
- `h_refine_copy` is removed