### PR TITLE
(CI) add macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
 
-#  pull_request:
-#    branches:
-#      - master
-#  push:
-#    branches:
-#      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
 
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+#  pull_request:
+#    branches:
+#      - master
+#  push:
+#    branches:
+#      - master
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       CC: "${{ matrix.mpi == 'no' && 'gcc' || 'mpicc' }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: apt dependencies
         shell: bash

--- a/.github/workflows/ci_llvm.yml
+++ b/.github/workflows/ci_llvm.yml
@@ -4,12 +4,12 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
 
-#  pull_request:
-#    branches:
-#      - master
-#  push:
-#    branches:
-#      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_llvm.yml
+++ b/.github/workflows/ci_llvm.yml
@@ -4,12 +4,12 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
 
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+#  pull_request:
+#    branches:
+#      - master
+#  push:
+#    branches:
+#      - master
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_llvm.yml
+++ b/.github/workflows/ci_llvm.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Upload artifacts (fallback for same-run cache miss) # 1m16s (if miss)
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: toolchain-${{ steps.key.outputs.cache_key }}
           path: |
@@ -146,7 +146,7 @@ jobs:
 
       - name: Save cache (only if miss) # 21s
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             llvm.tar.zst
@@ -179,7 +179,7 @@ jobs:
       MPICH_FC: flang
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: apt dependencies
         shell: bash
@@ -196,7 +196,7 @@ jobs:
 
       - name: Restore cache (preferred) # 15-20s
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             llvm.tar.zst
@@ -205,7 +205,7 @@ jobs:
 
       - name: Download artifacts (fallback when cache miss)
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: toolchain-${{ needs.prepare-llvm.outputs.cache_key }}
           path: .

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -45,8 +45,8 @@ jobs:
         shell: bash
         run: |
           brew install gcc mpich
-          pip3 install --upgrade pip
-          pip3 install pytest
+          python -m pip install --upgrade pip
+          python -m pip install pytest
 
       - name: Check compilers
         shell: bash

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        test_case: [
+        test_case: [ 
             "Tools",
             "Ethier::test_PnPn2_Parallel",
             "Ethier::test_PnPn_Parallel"
@@ -39,7 +39,7 @@ jobs:
       CC: "${{ matrix.mpi == 'no' && 'gcc' || 'mpicc' }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: brew dependencies
         shell: bash

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -45,8 +45,8 @@ jobs:
         shell: bash
         run: |
           brew install gcc mpich cmake pytest
-#          python -m pip install --upgrade pip
-#          python -m pip install pytest
+          #python -m pip install --upgrade pip
+          #python -m pip install pytest
 
           mkdir -p "$RUNNER_TEMP/bin"
 

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -1,0 +1,51 @@
+name: CI (maxOS)
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  main:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        test_case: [ 
+            "Tools",
+            "Ethier::test_PnPn2_Parallel",
+            "Ethier::test_PnPn_Parallel"
+        include:
+          - test_case: "Tools"
+            mpi: no
+      fail-fast: false
+
+    name: "${{ matrix.test_case }}"
+
+    env:
+      TEST_CASE: ${{ matrix.test_case }}
+      MPI: "${{ matrix.mpi == 'no' && '0' || '1' }}"
+      FC: "${{ matrix.mpi == 'no' && 'gfortran' || 'mpif77' }}"
+      CC: "${{ matrix.mpi == 'no' && 'gcc' || 'mpicc' }}"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: apt dependencies
+        shell: bash
+        run: |
+          sudo apt -y update
+          sudo apt install -y gfortran mpich libmpich-dev python3-pytest
+
+      - name: test
+        shell: bash
+        run: |
+          pytest-3 -s -v short_tests/NekTests.py::$TEST_CASE

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -13,7 +13,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 jobs:
   main:
@@ -35,6 +34,7 @@ jobs:
 
     env:
       TEST_CASE: ${{ matrix.test_case }}
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
       MPI: "${{ matrix.mpi == 'no' && '0' || '1' }}"
       FC: "${{ matrix.mpi == 'no' && 'gfortran' || 'mpif77' }}"
       CC: "${{ matrix.mpi == 'no' && 'gcc' || 'mpicc' }}"

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -1,4 +1,4 @@
-name: CI (maxOS)
+name: CI (macOS)
 
 on:
   # allows us to run workflows manually
@@ -17,6 +17,7 @@ env:
 jobs:
   main:
     runs-on: macos-latest
+
     strategy:
       matrix:
         test_case: [ 
@@ -39,13 +40,29 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: apt dependencies
+      - name: brew dependencies
         shell: bash
         run: |
-          sudo apt -y update
-          sudo apt install -y gfortran mpich libmpich-dev python3-pytest
+          brew install gcc mpich
+          pip3 install --upgrade pip
+          pip3 install pytest
+
+      - name: Check compilers
+        shell: bash
+        run: |
+          which gcc || true
+          which gfortran || true
+          which mpicc || true
+          which mpif77 || true
+          gcc --version || true
+          gfortran --version || true
+          mpicc --version || true
+          mpif77 --version || true
+
+          which pytest
+          pytest --version
 
       - name: test
         shell: bash
         run: |
-          pytest-3 -s -v short_tests/NekTests.py::$TEST_CASE
+          pytest -s -v short_tests/NekTests.py::$TEST_CASE

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -34,7 +34,6 @@ jobs:
 
     env:
       TEST_CASE: ${{ matrix.test_case }}
-      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
       MPI: "${{ matrix.mpi == 'no' && '0' || '1' }}"
       FC: "${{ matrix.mpi == 'no' && 'gfortran' || 'mpif77' }}"
       CC: "${{ matrix.mpi == 'no' && 'gcc' || 'mpicc' }}"

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -39,7 +39,7 @@ jobs:
       CC: "${{ matrix.mpi == 'no' && 'gcc' || 'mpicc' }}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       - name: brew dependencies
         shell: bash

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -24,6 +24,7 @@ jobs:
             "Tools",
             "Ethier::test_PnPn2_Parallel",
             "Ethier::test_PnPn_Parallel"
+        ]
         include:
           - test_case: "Tools"
             mpi: no

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -48,6 +48,16 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest
 
+          mkdir -p "$RUNNER_TEMP/bin"
+
+          GFORTRAN_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gfortran-*' | sort -V | tail -n 1)"
+          GCC_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gcc-*' | sort -V | tail -n 1)"
+
+          ln -sf "$GFORTRAN_BIN" "$RUNNER_TEMP/bin/gfortran"
+          ln -sf "$GCC_BIN" "$RUNNER_TEMP/bin/gcc"
+
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
       - name: Check compilers
         shell: bash
         run: |

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -37,6 +37,7 @@ jobs:
       MPI: "${{ matrix.mpi == 'no' && '0' || '1' }}"
       FC: "${{ matrix.mpi == 'no' && 'gfortran' || 'mpif77' }}"
       CC: "${{ matrix.mpi == 'no' && 'gcc' || 'mpicc' }}"
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -37,7 +37,7 @@ jobs:
       MPI: "${{ matrix.mpi == 'no' && '0' || '1' }}"
       FC: "${{ matrix.mpi == 'no' && 'gfortran' || 'mpif77' }}"
       CC: "${{ matrix.mpi == 'no' && 'gcc' || 'mpicc' }}"
-      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5" # HYPRE dep #873
 
     steps:
       - uses: actions/checkout@v4
@@ -46,22 +46,14 @@ jobs:
         shell: bash
         run: |
           brew install gcc mpich cmake pytest
-          #python -m pip install --upgrade pip
-          #python -m pip install pytest
+
+          # create gfortran soft link rather than gfortran-15
+          GFORTRAN_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gfortran-[0-9]*' | sort -V | tail -n 1)"
+          echo $GFORTRAN_BIN
 
           mkdir -p "$RUNNER_TEMP/bin"
-
-          # create soft link of gfortran rather than gfortran-15
-          GFORTRAN_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gfortran-*' | sort -V | tail -n 1)"
-          GCC_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gcc-[0-9]*' ! -name 'gcc-ar-*' ! -name 'gcc-nm-*' ! -name 'gcc-ranlib-*' | sort -V | tail -n 1)"
-
           ln -sf "$GFORTRAN_BIN" "$RUNNER_TEMP/bin/gfortran"
-          ln -sf "$GCC_BIN" "$RUNNER_TEMP/bin/gcc"
-
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
-
-          echo $GCC_BIN
-          echo $GFORTRAN_BIN
 
       - name: Check compilers
         shell: bash
@@ -71,12 +63,12 @@ jobs:
           which gfortran || true
           which mpicc || true
           which mpif77 || true
+          which cmake || true
+
           gcc --version || true
           gfortran --version || true
           mpicc --version || true
           mpif77 --version || true
-
-          which cmake || true
           cmake --version || true
 
           which pytest

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 jobs:
   main:
@@ -39,17 +40,18 @@ jobs:
       CC: "${{ matrix.mpi == 'no' && 'gcc' || 'mpicc' }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: brew dependencies
         shell: bash
         run: |
-          brew install gcc mpich
-          python -m pip install --upgrade pip
-          python -m pip install pytest
+          brew install gcc mpich cmake pytest
+#          python -m pip install --upgrade pip
+#          python -m pip install pytest
 
           mkdir -p "$RUNNER_TEMP/bin"
 
+          # create soft link of gfortran rather than gfortran-15
           GFORTRAN_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gfortran-*' | sort -V | tail -n 1)"
           GCC_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gcc-[0-9]*' ! -name 'gcc-ar-*' ! -name 'gcc-nm-*' ! -name 'gcc-ranlib-*' | sort -V | tail -n 1)"
 
@@ -73,6 +75,9 @@ jobs:
           gfortran --version || true
           mpicc --version || true
           mpif77 --version || true
+
+          which cmake || true
+          cmake --version || true
 
           which pytest
           pytest --version

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -51,16 +51,20 @@ jobs:
           mkdir -p "$RUNNER_TEMP/bin"
 
           GFORTRAN_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gfortran-*' | sort -V | tail -n 1)"
-          GCC_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gcc-*' | sort -V | tail -n 1)"
+          GCC_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gcc-[0-9]*' ! -name 'gcc-ar-*' ! -name 'gcc-nm-*' ! -name 'gcc-ranlib-*' | sort -V | tail -n 1)"
 
           ln -sf "$GFORTRAN_BIN" "$RUNNER_TEMP/bin/gfortran"
           ln -sf "$GCC_BIN" "$RUNNER_TEMP/bin/gcc"
 
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
+          echo $GCC_BIN
+          echo $GFORTRAN_BIN
+
       - name: Check compilers
         shell: bash
         run: |
+          set -x
           which gcc || true
           which gfortran || true
           which mpicc || true

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        test_case: [ 
+        test_case: [
             "Tools",
             "Ethier::test_PnPn2_Parallel",
             "Ethier::test_PnPn_Parallel"

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -40,12 +40,15 @@ jobs:
       CMAKE_POLICY_VERSION_MINIMUM: "3.5" # HYPRE dep #873
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: brew dependencies
         shell: bash
         run: |
-          brew install gcc mpich cmake pytest
+          # silence already install warnings
+          for pkg in gcc mpich cmake pytest; do
+            brew list "$pkg" >/dev/null 2>&1 || brew install "$pkg"
+          done
 
           # create gfortran soft link rather than gfortran-15
           GFORTRAN_BIN="$(find "$(brew --prefix gcc)/bin" -name 'gfortran-[0-9]*' | sort -V | tail -n 1)"

--- a/tools/maketools.inc
+++ b/tools/maketools.inc
@@ -210,13 +210,13 @@ if ! which make >/dev/null; then
 fi
 function chk_cmake() {
    if ! which cmake >/dev/null; then
-     echo "FATEL ERROR: Cannot find cmake, which is required by "$1
+     echo "FATAL ERROR: Cannot find cmake, which is required by "$1
      exit 11
    fi
 }
 function chk_x11() {
    if ! which X >/dev/null; then
-     echo "FATEL ERROR: Cannot find X11, which is required by "$1
+     echo "FATAL ERROR: Cannot find X11, which is required by "$1
      exit 11
    fi
 }


### PR DESCRIPTION
This PR confirms that https://github.com/Nek5000/Nek5000/commit/a0f032640023b57e711e96bfc003ba6041d8d9d6 fixes `ld` issues on macOS. However, `ld_classic` might not be supported in the future Xcode. Therefore, this CI test would be a good indicator when that happens.
```
ld: warning: ld_classic is deprecated and will be removed in a future release
```

Because of https://github.com/Nek5000/Nek5000/issues/873, a temporary CMake policy change is applied via env: `CMAKE_POLICY_VERSION_MINIMUM="3.5"`

- Fixes typos in `maketools.inc`
- Upgrade actions to Node 25

Close https://github.com/Nek5000/Nek5000/issues/897
Close https://github.com/Nek5000/Nek5000/pull/898
