### PR TITLE
Avoid reserved Fortran I/O unit 101

### DIFF
--- a/core/prepost.f
+++ b/core/prepost.f
@@ -1223,11 +1223,11 @@ c-----------------------------------------------------------------------
 
       if(nid.eq.0) then
         call chcopy(nam1(kk),'.nek5000',8)
-        open(unit=101,file=name)
-        write(101,*) "filetemplate: ", trim(fname), "%01d.f%05d"
-        write(101,*) "firsttimestep: 1"
-        write(101,*) "numtimesteps: ", nfld
-        close(101) 
+        open(unit=89,file=name)
+        write(89,*) "filetemplate: ", trim(fname), "%01d.f%05d"
+        write(89,*) "firsttimestep: 1"
+        write(89,*) "numtimesteps: ", nfld
+        close(89) 
       endif
 
       call chcopy(fnam1(k),six,ndigit)                  !  Add file-id holder


### PR DESCRIPTION
Per the HPE/Cray Fortran documentation [here](https://cpe.ext.hpe.com/docs/24.11/getting_started/CPE-CCE-Fortran.html#file-unit-numbers), Cray Fortran 20 reserves Fortran units `100`, `101`, and `102` for `stdin`, `stdout`, and `stderr`, respectively, through `ISO_FORTRAN_ENV`.

Nek5000 currently uses `unit=101` when generating the `.nek5000` file. On ALCF/Polaris and ALCF/Crux (using PrgEnv-Cray), it will show the error:
```text
lib-4013 : UNRECOVERABLE library error
  The unit number (101) in the OPEN statement must be nonnegative and outside
  the range of 100 through 102.

Encountered during an OPEN of unit 101
Fortran unit 101 is connected to a sequential formatted text file
  (standard output).
```

This PR simply avoid it with a different unused number.

Found by Ramesh.
