### PR TITLE
Fix hRefine + restart np=1 bug

### DIFF
--- a/core/ic.f
+++ b/core/ic.f
@@ -2311,7 +2311,7 @@ c-----------------------------------------------------------------------
          if (np.gt.1) then
             ei = e
          else if(np.eq.1) then
-            ei = ie_map_r2o(er(e),nhrefblkrs)
+            ei = er(e)
          endif
 
          if (if_byte_sw) then


### PR DESCRIPTION
close https://github.com/Nek5000/Nek5000/issues/907

Pass the test with `PARALLEL_PROCS=1 pytest NekTests.py::IO_Test`
